### PR TITLE
feat: add OP_INSPECTINPUTARKADESCRIPTHASH and OP_INSPECTINPUTARKADEWITNESSHASH

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,12 @@ The following opcodes are supported by the Arkade script engine. They extend Bit
 | Word | Opcode | Hex | Input | Output | Description |
 |------|--------|-----|-------|--------|-------------|
 | OP_INSPECTINPUTOUTPOINT | 199 | 0xc7 | index | txid index | Pushes the transaction ID (32 bytes) and output index (scriptNum) of the input at the given index onto the stack. |
+| OP_INSPECTINPUTARKADESCRIPTHASH | 200 | 0xc8 | index | script_hash | Pushes the 32-byte Arkade script hash (`tagged_hash("ArkScriptHash", script)`) of the IntrospectorEntry for the input at the given index. This is the same hash used as the tweak scalar in `ComputeArkadeScriptPublicKey`. Fails if no entry exists. |
 | OP_INSPECTINPUTVALUE | 201 | 0xc9 | index | value | Pushes the value (8 bytes, little-endian) of the previous output spent by the input at the given index. |
 | OP_INSPECTINPUTSCRIPTPUBKEY | 202 | 0xca | index | program version | For witness programs: pushes the witness program (2-40 bytes) and segwit version (scriptNum). For non-native segwit: pushes SHA256 hash of scriptPubKey and -1. |
 | OP_INSPECTINPUTSEQUENCE | 203 | 0xcb | index | sequence | Pushes the sequence number (4 bytes, little-endian) of the input at the given index. |
 | OP_PUSHCURRENTINPUTINDEX | 205 | 0xcd | Nothing | index | Pushes the current input index (scriptNum) being evaluated onto the stack. |
+| OP_INSPECTINPUTARKADEWITNESSHASH | 206 | 0xce | index | witness_hash | Pushes the 32-byte Arkade witness hash (`tagged_hash("ArkWitnessHash", witness)`) of the IntrospectorEntry for the input at the given index. Pushes 32 zero bytes if witness is empty. Fails if no entry exists. |
 
 ### Transaction Introspection (Outputs)
 

--- a/pkg/arkade/engine.go
+++ b/pkg/arkade/engine.go
@@ -110,6 +110,7 @@ type Engine struct {
 	hashCache      *txscript.TxSigHashes
 	prevOutFetcher txscript.PrevOutputFetcher
 	assetPacket    asset.Packet
+	introspectorPacket *IntrospectorPacket
 
 	// The following fields handle keeping track of the current execution state
 	// of the engine.
@@ -182,6 +183,12 @@ type StepInfo struct {
 // SetAssetPacket sets the asset packet on the engine for script introspection.
 func (vm *Engine) SetAssetPacket(packet asset.Packet) {
 	vm.assetPacket = packet
+}
+
+// SetIntrospectorPacket sets the introspector packet on the engine for
+// cross-input Arkade script/witness introspection.
+func (vm *Engine) SetIntrospectorPacket(packet *IntrospectorPacket) {
+	vm.introspectorPacket = packet
 }
 
 // isBranchExecuting returns whether or not the current conditional branch is

--- a/pkg/arkade/engine_test.go
+++ b/pkg/arkade/engine_test.go
@@ -1926,3 +1926,232 @@ func TestMerkleBranchVerify(t *testing.T) {
 		})
 	}
 }
+
+func TestIntrospectorPacketOpcodes(t *testing.T) {
+	t.Parallel()
+
+	prevoutFetcher := txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+		{Hash: chainhash.Hash{}, Index: 0}: {Value: 1000, PkScript: []byte{
+			OP_1, OP_DATA_32,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}},
+		{Hash: chainhash.Hash{}, Index: 1}: {Value: 2000, PkScript: []byte{
+			OP_1, OP_DATA_32,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}},
+	})
+
+	twoInputTx := &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}},
+			{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}},
+		},
+	}
+
+	scriptA := []byte{OP_TRUE}
+	scriptB := []byte{OP_1, OP_1, OP_ADD}
+	witnessA := []byte{0xaa, 0xbb}
+
+	packet := &IntrospectorPacket{
+		Entries: []IntrospectorEntry{
+			{Vin: 0, Script: scriptA, Witness: witnessA},
+			{Vin: 1, Script: scriptB, Witness: nil},
+		},
+	}
+
+	expectedScriptHashA := ArkadeScriptHash(scriptA)
+	expectedScriptHashB := ArkadeScriptHash(scriptB)
+	expectedWitnessHashA := chainhash.TaggedHash(TagArkWitnessHash, witnessA)
+	zeroHash := make([]byte, 32)
+
+	runEngine := func(t *testing.T, script []byte, tx *wire.MsgTx, pkt *IntrospectorPacket, stack [][]byte) error {
+		t.Helper()
+		engine, err := NewEngine(
+			script, tx, 0,
+			txscript.NewSigCache(100),
+			txscript.NewTxSigHashes(tx, prevoutFetcher),
+			1000, prevoutFetcher,
+		)
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		if pkt != nil {
+			engine.SetIntrospectorPacket(pkt)
+		}
+		if len(stack) > 0 {
+			engine.SetStack(stack)
+		}
+		return engine.Execute()
+	}
+
+	type tc struct {
+		name    string
+		valid   bool
+		script  []byte
+		tx      *wire.MsgTx
+		pkt     *IntrospectorPacket
+		stack   [][]byte
+		errText string
+	}
+
+	scriptHashCheck := func(t *testing.T, index byte, expected []byte) []byte {
+		t.Helper()
+		s, err := txscript.NewScriptBuilder().
+			AddOp(index).
+			AddOp(OP_INSPECTINPUTARKADESCRIPTHASH).
+			AddData(expected).
+			AddOp(OP_EQUAL).
+			Script()
+		if err != nil {
+			t.Fatalf("script build: %v", err)
+		}
+		return s
+	}
+
+	witnessHashCheck := func(t *testing.T, index byte, expected []byte) []byte {
+		t.Helper()
+		s, err := txscript.NewScriptBuilder().
+			AddOp(index).
+			AddOp(OP_INSPECTINPUTARKADEWITNESSHASH).
+			AddData(expected).
+			AddOp(OP_EQUAL).
+			Script()
+		if err != nil {
+			t.Fatalf("script build: %v", err)
+		}
+		return s
+	}
+
+	buildScript := func(t *testing.T, ops ...byte) []byte {
+		t.Helper()
+		b := txscript.NewScriptBuilder()
+		for _, op := range ops {
+			b.AddOp(op)
+		}
+		s, err := b.Script()
+		if err != nil {
+			t.Fatalf("script build: %v", err)
+		}
+		return s
+	}
+
+	tests := []tc{
+		{
+			name:   "script_hash_own_input",
+			valid:  true,
+			script: scriptHashCheck(t, OP_0, expectedScriptHashA),
+			tx:     twoInputTx,
+			pkt:    packet,
+		},
+		{
+			name:   "script_hash_sibling_input",
+			valid:  true,
+			script: scriptHashCheck(t, OP_1, expectedScriptHashB),
+			tx:     twoInputTx,
+			pkt:    packet,
+		},
+		{
+			name: "script_hash_equality_across_inputs",
+			valid: true,
+			script: func() []byte {
+				s, _ := txscript.NewScriptBuilder().
+					AddOp(OP_0).AddOp(OP_INSPECTINPUTARKADESCRIPTHASH).
+					AddOp(OP_0).AddOp(OP_INSPECTINPUTARKADESCRIPTHASH).
+					AddOp(OP_EQUAL).
+					Script()
+				return s
+			}(),
+			tx:  twoInputTx,
+			pkt: packet,
+		},
+		{
+			name:    "script_hash_no_packet",
+			valid:   false,
+			script:  buildScript(t, OP_0, OP_INSPECTINPUTARKADESCRIPTHASH),
+			tx:      twoInputTx,
+			pkt:     nil,
+			errText: "no introspector packet",
+		},
+		{
+			name:    "script_hash_out_of_range",
+			valid:   false,
+			script:  buildScript(t, OP_2, OP_INSPECTINPUTARKADESCRIPTHASH),
+			tx:      twoInputTx,
+			pkt:     packet,
+			errText: "input index out of range",
+		},
+		{
+			name:  "script_hash_missing_entry",
+			valid: false,
+			script: func() []byte {
+				s, _ := txscript.NewScriptBuilder().
+					AddOp(OP_0).
+					AddOp(OP_INSPECTINPUTARKADESCRIPTHASH).
+					Script()
+				return s
+			}(),
+			tx: twoInputTx,
+			pkt: &IntrospectorPacket{
+				Entries: []IntrospectorEntry{
+					{Vin: 1, Script: scriptB},
+				},
+			},
+			errText: "no introspector entry for vin 0",
+		},
+		{
+			name:   "witness_hash_non_empty",
+			valid:  true,
+			script: witnessHashCheck(t, OP_0, expectedWitnessHashA[:]),
+			tx:     twoInputTx,
+			pkt:    packet,
+		},
+		{
+			name:   "witness_hash_empty_returns_zeros",
+			valid:  true,
+			script: witnessHashCheck(t, OP_1, zeroHash),
+			tx:     twoInputTx,
+			pkt:    packet,
+		},
+		{
+			name:    "witness_hash_no_packet",
+			valid:   false,
+			script:  buildScript(t, OP_0, OP_INSPECTINPUTARKADEWITNESSHASH),
+			tx:      twoInputTx,
+			pkt:     nil,
+			errText: "no introspector packet",
+		},
+		{
+			name:    "witness_hash_out_of_range",
+			valid:   false,
+			script:  buildScript(t, OP_2, OP_INSPECTINPUTARKADEWITNESSHASH),
+			tx:      twoInputTx,
+			pkt:     packet,
+			errText: "input index out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := runEngine(t, tt.script, tt.tx, tt.pkt, tt.stack)
+			if tt.valid && err != nil {
+				t.Errorf("expected success, got: %v", err)
+			}
+			if !tt.valid {
+				if err == nil {
+					t.Error("expected failure, got success")
+				} else if tt.errText != "" && !strings.Contains(err.Error(), tt.errText) {
+					t.Errorf("expected error containing %q, got: %v", tt.errText, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/arkade/introspector_packet.go
+++ b/pkg/arkade/introspector_packet.go
@@ -347,8 +347,8 @@ func (p *IntrospectorPacket) ValidateScriptHashes(signerPubKey *btcec.PublicKey)
 
 // VerifyEntry verifies a single IntrospectorEntry by executing the Arkade script
 // with the committed witness against the transaction.
-func VerifyEntry(entry IntrospectorEntry, tx *wire.MsgTx,
-	prevOutFetcher txscript.PrevOutputFetcher,
+func VerifyEntry(entry IntrospectorEntry, packet *IntrospectorPacket,
+	tx *wire.MsgTx, prevOutFetcher txscript.PrevOutputFetcher,
 	signerPubKey *btcec.PublicKey) error {
 
 	if int(entry.Vin) >= len(tx.TxIn) {
@@ -379,6 +379,10 @@ func VerifyEntry(entry IntrospectorEntry, tx *wire.MsgTx,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create engine for vin %d: %w", entry.Vin, err)
+	}
+
+	if packet != nil {
+		engine.SetIntrospectorPacket(packet)
 	}
 
 	// Set witness as initial stack
@@ -421,7 +425,7 @@ func VerifyPacket(packet *IntrospectorPacket, tx *wire.MsgTx,
 
 	// Rule 4: Witness validity — execute each script
 	for _, entry := range packet.Entries {
-		if err := VerifyEntry(entry, tx, prevOutFetcher, signerPubKey); err != nil {
+		if err := VerifyEntry(entry, packet, tx, prevOutFetcher, signerPubKey); err != nil {
 			return fmt.Errorf("verification failed: %w", err)
 		}
 	}

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -3207,9 +3207,56 @@ func opcodeTxId(op *opcode, data []byte, vm *Engine) error {
 }
 
 func opcodeInspectInputArkadeScriptHash(op *opcode, data []byte, vm *Engine) error {
-	return scriptError(txscript.ErrInvalidIndex, "not yet implemented")
+	index, err := vm.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	if index < 0 || int(index) >= len(vm.tx.TxIn) {
+		return scriptError(txscript.ErrInvalidIndex, "input index out of range")
+	}
+
+	if vm.introspectorPacket == nil {
+		return scriptError(txscript.ErrInvalidStackOperation, "no introspector packet")
+	}
+
+	entry, found := vm.introspectorPacket.FindEntryByVin(uint16(index))
+	if !found {
+		return scriptError(txscript.ErrInvalidStackOperation,
+			fmt.Sprintf("no introspector entry for vin %d", index))
+	}
+
+	scriptHash := ArkadeScriptHash(entry.Script)
+	vm.dstack.PushByteArray(scriptHash)
+	return nil
 }
 
 func opcodeInspectInputArkadeWitnessHash(op *opcode, data []byte, vm *Engine) error {
-	return scriptError(txscript.ErrInvalidIndex, "not yet implemented")
+	index, err := vm.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	if index < 0 || int(index) >= len(vm.tx.TxIn) {
+		return scriptError(txscript.ErrInvalidIndex, "input index out of range")
+	}
+
+	if vm.introspectorPacket == nil {
+		return scriptError(txscript.ErrInvalidStackOperation, "no introspector packet")
+	}
+
+	entry, found := vm.introspectorPacket.FindEntryByVin(uint16(index))
+	if !found {
+		return scriptError(txscript.ErrInvalidStackOperation,
+			fmt.Sprintf("no introspector entry for vin %d", index))
+	}
+
+	if len(entry.Witness) == 0 {
+		vm.dstack.PushByteArray(make([]byte, 32))
+		return nil
+	}
+
+	hash := chainhash.TaggedHash(TagArkWitnessHash, entry.Witness)
+	vm.dstack.PushByteArray(hash[:])
+	return nil
 }

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -246,7 +246,7 @@ const (
 	// Inputs
 	OP_INSPECTINPUTOUTPOINT = 0xc7 // 199
 
-	OP_UNKNOWN200 = 0xc8 // 200
+	OP_INSPECTINPUTARKADESCRIPTHASH = 0xc8 // 200
 
 	OP_INSPECTINPUTVALUE        = 0xc9 // 201
 	OP_INSPECTINPUTSCRIPTPUBKEY = 0xca // 202
@@ -257,7 +257,7 @@ const (
 	// current index
 	OP_PUSHCURRENTINPUTINDEX = 0xcd // 205
 
-	OP_UNKNOWN206 = 0xce // 206
+	OP_INSPECTINPUTARKADEWITNESSHASH = 0xce // 206
 
 	// outputs
 	OP_INSPECTOUTPUTVALUE = 0xcf // 207
@@ -548,7 +548,7 @@ var opcodeArray = [256]opcode{
 	// Inputs introspection
 	OP_INSPECTINPUTOUTPOINT: {OP_INSPECTINPUTOUTPOINT, "OP_INSPECTINPUTOUTPOINT", 1, opcodeInspectInputOutpoint},
 
-	OP_UNKNOWN200: {OP_UNKNOWN200, "OP_UNKNOWN200", 1, opcodeInvalid},
+	OP_INSPECTINPUTARKADESCRIPTHASH: {OP_INSPECTINPUTARKADESCRIPTHASH, "OP_INSPECTINPUTARKADESCRIPTHASH", 1, opcodeInspectInputArkadeScriptHash},
 
 	OP_INSPECTINPUTVALUE:        {OP_INSPECTINPUTVALUE, "OP_INSPECTINPUTVALUE", 1, opcodeInspectInputValue},
 	OP_INSPECTINPUTSCRIPTPUBKEY: {OP_INSPECTINPUTSCRIPTPUBKEY, "OP_INSPECTINPUTSCRIPTPUBKEY", 1, opcodeInspectInputScriptPubkey},
@@ -559,7 +559,7 @@ var opcodeArray = [256]opcode{
 	OP_PUSHCURRENTINPUTINDEX: {OP_PUSHCURRENTINPUTINDEX, "OP_PUSHCURRENTINPUTINDEX", 1, opcodePushCurrentInputIndex},
 
 	// Outputs introspection
-	OP_UNKNOWN206: {OP_UNKNOWN206, "OP_UNKNOWN206", 1, opcodeInvalid},
+	OP_INSPECTINPUTARKADEWITNESSHASH: {OP_INSPECTINPUTARKADEWITNESSHASH, "OP_INSPECTINPUTARKADEWITNESSHASH", 1, opcodeInspectInputArkadeWitnessHash},
 
 	OP_INSPECTOUTPUTVALUE: {OP_INSPECTOUTPUTVALUE, "OP_INSPECTOUTPUTVALUE", 1, opcodeInspectOutputValue},
 
@@ -3204,4 +3204,12 @@ func opcodeTxId(op *opcode, data []byte, vm *Engine) error {
 	txHash := vm.tx.TxHash()
 	vm.dstack.PushByteArray(txHash[:])
 	return nil
+}
+
+func opcodeInspectInputArkadeScriptHash(op *opcode, data []byte, vm *Engine) error {
+	return scriptError(txscript.ErrInvalidIndex, "not yet implemented")
+}
+
+func opcodeInspectInputArkadeWitnessHash(op *opcode, data []byte, vm *Engine) error {
+	return scriptError(txscript.ErrInvalidIndex, "not yet implemented")
 }

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -74,6 +74,8 @@ func TestOpcodeDisasm(t *testing.T) {
 		0xe1: "OP_LE64TOSCRIPTNUM", 0xe2: "OP_LE32TOLE64",
 		0xe3: "OP_ECMULSCALARVERIFY", 0xe4: "OP_TWEAKVERIFY",
 		0xf3: "OP_TXID",
+		0xc8: "OP_INSPECTINPUTARKADESCRIPTHASH",
+		0xce: "OP_INSPECTINPUTARKADEWITNESSHASH",
 	}
 	for opcodeVal, expectedStr := range expectedStrings {
 		var data []byte
@@ -113,7 +115,7 @@ func TestOpcodeDisasm(t *testing.T) {
 			case 0xb2:
 				// OP_NOP3 is an alias of OP_CHECKSEQUENCEVERIFY
 				expectedStr = "OP_CHECKSEQUENCEVERIFY"
-			case 0xb3:
+			case 0xb3, 0xc8, 0xce:
 				// OP_NOP4 is now OP_MERKLEBRANCHVERIFY
 				expectedStr = "OP_MERKLEBRANCHVERIFY"
 			default:
@@ -127,9 +129,7 @@ func TestOpcodeDisasm(t *testing.T) {
 
 		// OP_UNKNOWN#.
 		case (opcodeVal >= 0xbb && opcodeVal <= 0xc3) || // Unknown range before SHA256 ops
-			(opcodeVal == 0xc8) || // Unknown between input inspection ops
-			(opcodeVal == 0xce) || // Unknown between input and output ops
-			(opcodeVal == 0xd0) || // Unknown between output ops
+(opcodeVal == 0xd0) || // Unknown between output ops
 			(opcodeVal >= 0xf4 && opcodeVal <= 0xf9) || // Unknown range after new ops
 			opcodeVal == 0xfc:
 			expectedStr = "OP_UNKNOWN" + strconv.Itoa(opcodeVal)
@@ -192,7 +192,7 @@ func TestOpcodeDisasm(t *testing.T) {
 			case 0xb2:
 				// OP_NOP3 is an alias of OP_CHECKSEQUENCEVERIFY
 				expectedStr = "OP_CHECKSEQUENCEVERIFY"
-			case 0xb3:
+			case 0xb3, 0xc8, 0xce:
 				// OP_NOP4 is now OP_MERKLEBRANCHVERIFY
 				expectedStr = "OP_MERKLEBRANCHVERIFY"
 			default:
@@ -206,9 +206,7 @@ func TestOpcodeDisasm(t *testing.T) {
 
 		// OP_UNKNOWN#.
 		case (opcodeVal >= 0xbb && opcodeVal <= 0xc3) || // Unknown range before SHA256 ops
-			(opcodeVal == 0xc8) || // Unknown between input inspection ops
-			(opcodeVal == 0xce) || // Unknown between input and output ops
-			(opcodeVal == 0xd0) || // Unknown between output ops
+(opcodeVal == 0xd0) || // Unknown between output ops
 			(opcodeVal >= 0xf4 && opcodeVal <= 0xf9) || // Unknown range after new ops
 			opcodeVal == 0xfc:
 			expectedStr = "OP_UNKNOWN" + strconv.Itoa(opcodeVal)

--- a/pkg/arkade/tweak.go
+++ b/pkg/arkade/tweak.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	TagArkScriptHash = []byte("ArkScriptHash")
+	TagArkScriptHash  = []byte("ArkScriptHash")
+	TagArkWitnessHash = []byte("ArkWitnessHash")
 )
 
 // ArkadeScriptHash computes the hash of an ark script.


### PR DESCRIPTION
Closes #14

## Summary
- Add two new introspection opcodes for cross-input Arkade script/witness verification
- **OP_INSPECTINPUTARKADESCRIPTHASH** (0xc8, 200): pops input index, pushes `tagged_hash("ArkScriptHash", entry.Script)` — the same tweak scalar used in `ComputeArkadeScriptPublicKey`
- **OP_INSPECTINPUTARKADEWITNESSHASH** (0xce, 206): pops input index, pushes `tagged_hash("ArkWitnessHash", entry.Witness)` — pushes 32 zero bytes for empty witness
- Thread `IntrospectorPacket` through `VerifyEntry` to the script engine
- Add `TagArkWitnessHash` domain separation tag

## Test plan
- 10 unit tests covering: script hash (own input, sibling, self-equality), witness hash (non-empty, empty/zeros), error cases (no packet, out-of-range, missing entry)
- All existing opcode disasm tests updated for new opcode names
- Full unit test suite passes