### PR TITLE
test: covenant HTLC claim without receiver signature

### DIFF
--- a/docs/plans/2026-03-07-covenant-htlc-design.md
+++ b/docs/plans/2026-03-07-covenant-htlc-design.md
@@ -1,0 +1,98 @@
+# Covenant HTLC Design
+
+## Overview
+
+Implement a covenant HTLC variant that allows claiming **without the receiver's signature**, inspired by [Boltz covenant claims](https://api.docs.boltz.exchange/claim-covenants.html) and [fulmine's VHTLC](https://github.com/arklabshq/fulmine). Instead of requiring a signature, the claim path uses Arkade script introspection opcodes to verify the transaction outputs directly — ensuring funds go to the correct address with the correct amount.
+
+## Motivation
+
+Standard HTLCs (like fulmine's VHTLC) require the receiver to be online to sign claim transactions. This creates UX friction for non-interactive scenarios like:
+- Lightning reverse swaps where a service claims on behalf of the receiver
+- Automated payment flows where the receiver delegates claiming
+- Any scenario where the receiver wants to pre-commit a destination and let anyone with the preimage construct the claim
+
+## Architecture
+
+### Tap Tree Structure (6 leaves)
+
+Mirrors fulmine's VHTLC structure, but with covenant variants for the collaborative paths:
+
+| # | Leaf | Closure Type | Signers / Conditions | Purpose |
+|---|------|-------------|----------------------|---------|
+| 1 | Covenant Claim | Arkade script + `MultisigClosure(server, introspector)` | preimage + output introspection | Non-interactive claim — no receiver sig |
+| 2 | Traditional Claim | `ConditionMultisigClosure(receiver, server)` | preimage + receiver_sig + server_sig | Standard interactive claim |
+| 3 | Covenant Refund | Arkade script + `MultisigClosure(server, introspector)` | CLTV + output introspection | Non-interactive refund — no sender sig |
+| 4 | Traditional Refund | `MultisigClosure(sender, receiver, server)` | sender_sig + receiver_sig + server_sig | Collaborative refund |
+| 5 | Refund Without Receiver | `CLTVMultisigClosure(sender, server)` | CLTV + sender_sig + server_sig | Refund when receiver offline |
+| 6 | Unilateral Claim | `ConditionCSVMultisigClosure(receiver)` | preimage + receiver_sig + CSV delay | Receiver's exit path |
+
+### Covenant Claim Script (Leaf 1)
+
+The Arkade script enforces output constraints without requiring the receiver's key:
+
+```
+# Witness stack (bottom→top): <output_index> <preimage>
+
+OP_HASH160 <preimage_hash> OP_EQUALVERIFY     # verify preimage (pops preimage)
+OP_DUP                                         # duplicate output_index for reuse
+OP_INSPECTOUTPUTSCRIPTPUBKEY                   # check destination (pops first copy)
+OP_1 OP_EQUALVERIFY                            # segwit v1
+<receiver_witness_program> OP_EQUALVERIFY      # correct address
+OP_INSPECTOUTPUTVALUE                          # check amount (pops second copy)
+<expected_amount_le> OP_EQUAL                  # correct amount
+```
+
+The receiver's address and amount are hardcoded at script creation time. The witness provides the output index, allowing flexibility in transaction construction (the claim output can be at any position). `OP_DUP` is needed because both `OP_INSPECTOUTPUTSCRIPTPUBKEY` and `OP_INSPECTOUTPUTVALUE` pop the index from the stack.
+
+### Covenant Refund Script (Leaf 3)
+
+Same pattern but gated by a timelock:
+
+```
+# Witness stack (bottom→top): <output_index>
+
+<locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP
+OP_DUP
+OP_INSPECTOUTPUTSCRIPTPUBKEY
+OP_1 OP_EQUALVERIFY
+<sender_witness_program> OP_EQUALVERIFY
+OP_INSPECTOUTPUTVALUE
+<expected_amount_le> OP_EQUAL
+```
+
+### How Covenant Paths Work
+
+1. **Script creation**: Receiver's address and claim amount are baked into the Arkade script at VTXO creation time.
+2. **Tweaked key**: The introspector's pubkey is tweaked with the Arkade script hash via `ComputeArkadeScriptPublicKey(introspectorPubKey, ArkadeScriptHash(script))`.
+3. **Claim**: Anyone with the preimage constructs a transaction with the correct output. The Arkade script verifies the output. The introspector validates and signs (replacing the receiver's signature). The server co-signs.
+4. **No receiver interaction needed**: The receiver only needs to provide their address upfront when the HTLC is created.
+
+## Test Plan
+
+### Unit Tests (`pkg/arkade/engine_test.go`)
+
+Exercise the Arkade script engine directly:
+
+- **Covenant claim — valid**: correct preimage + correct output → script succeeds
+- **Covenant claim — wrong preimage**: bad preimage → script fails at HASH160 check
+- **Covenant claim — wrong output address**: correct preimage but wrong output script → script fails
+- **Covenant claim — wrong output amount**: correct preimage but wrong amount → script fails
+- **Covenant claim — flexible output index**: preimage valid, output at index 1 instead of 0 → succeeds
+- **Covenant refund — valid**: after timelock, correct refund output → succeeds
+- **Covenant refund — before timelock**: correct output but locktime not met → fails
+
+### Integration Tests (`test/covenant_htlc_test.go`)
+
+End-to-end with running introspector + arkd stack:
+
+1. Fund a VTXO with the full covenant HTLC tap tree
+2. **Covenant claim path**: claim using only the preimage (no receiver wallet signing), verify introspector signs
+3. **Invalid covenant claim**: wrong output address → introspector rejects
+4. **Covenant refund path** (if time permits): refund after timelock without sender signature
+
+## References
+
+- [Boltz Claim Covenants](https://api.docs.boltz.exchange/claim-covenants.html)
+- [BoltzExchange/covclaim](https://github.com/BoltzExchange/covclaim)
+- [ArkLabsHQ/fulmine VHTLC](https://github.com/arklabshq/fulmine) — `pkg/vhtlc/`
+- Existing test pattern: `test/pay_2_out_test.go`

--- a/docs/plans/2026-03-07-covenant-htlc-impl.md
+++ b/docs/plans/2026-03-07-covenant-htlc-impl.md
@@ -1,0 +1,651 @@
+# Covenant HTLC Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add unit and integration tests demonstrating a covenant HTLC that allows claiming without the receiver's signature, using Arkade introspection opcodes.
+
+**Architecture:** The covenant HTLC uses two Arkade scripts (claim + refund) that enforce output constraints via `OP_INSPECTOUTPUTSCRIPTPUBKEY` and `OP_INSPECTOUTPUTVALUE`, replacing signature requirements with transaction introspection. These scripts are combined with traditional closure leaves in a tap tree mirroring fulmine's VHTLC structure.
+
+**Tech Stack:** Go, `btcsuite/btcd/txscript`, `arkade-os/arkd/pkg/ark-lib/script`, Arkade script engine
+
+---
+
+### Task 1: Create new branch
+
+**Step 1: Create branch from feat/introspect-introspector-packet**
+
+```bash
+cd /c/Git/introspector
+git checkout feat/introspect-introspector-packet
+git checkout -b feat/covenant-htlc
+```
+
+---
+
+### Task 2: Write covenant claim unit tests (engine-level)
+
+**Files:**
+- Modify: `pkg/arkade/engine_test.go` (append new test function)
+
+**Step 1: Write the test**
+
+Append `TestCovenantHTLC` to `pkg/arkade/engine_test.go`. This test exercises the Arkade script engine directly — no gRPC, no running services.
+
+The test builds a covenant claim Arkade script that:
+1. Pops preimage from witness, verifies `OP_HASH160 <hash> OP_EQUALVERIFY`
+2. Pops output index from witness, inspects output scriptPubKey and value
+3. Leaves `OP_TRUE` on stack if all checks pass
+
+```go
+func TestCovenantHTLC(t *testing.T) {
+	t.Parallel()
+
+	// --- Setup: known preimage and its HASH160 ---
+	preimage := bytes.Repeat([]byte{0x42}, 32) // 32-byte preimage
+	sha := sha256.Sum256(preimage)
+	preimageHash := calcHash(sha[:], ripemd160.New()) // RIPEMD160(SHA256(preimage))
+
+	wrongPreimage := bytes.Repeat([]byte{0x43}, 32)
+
+	// --- Setup: receiver taproot output script ---
+	receiverWitnessProgram := bytes.Repeat([]byte{0xaa}, 32)
+	receiverPkScript := append([]byte{OP_1, OP_DATA_32}, receiverWitnessProgram...)
+
+	wrongWitnessProgram := bytes.Repeat([]byte{0xbb}, 32)
+	wrongPkScript := append([]byte{OP_1, OP_DATA_32}, wrongWitnessProgram...)
+
+	// --- Setup: claim amount ---
+	const claimAmount int64 = 50000
+	claimAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(claimAmountLE, uint64(claimAmount))
+
+	const wrongAmount int64 = 49999
+	wrongAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(wrongAmountLE, uint64(wrongAmount))
+
+	// --- Setup: sender taproot output script (for refund) ---
+	senderWitnessProgram := bytes.Repeat([]byte{0xcc}, 32)
+	senderPkScript := append([]byte{OP_1, OP_DATA_32}, senderWitnessProgram...)
+
+	// --- Build covenant claim script ---
+	// Witness stack (bottom to top): <output_index> <preimage>
+	// Script: OP_HASH160 <hash> OP_EQUALVERIFY
+	//         <idx> OP_INSPECTOUTPUTSCRIPTPUBKEY OP_1 OP_EQUALVERIFY <wp> OP_EQUALVERIFY
+	//         <idx> OP_INSPECTOUTPUTVALUE <amount_le> OP_EQUAL
+	covenantClaimScript, err := txscript.NewScriptBuilder().
+		AddOp(OP_HASH160).
+		AddData(preimageHash).
+		AddOp(OP_EQUALVERIFY).
+		AddOp(OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(OP_1).
+		AddOp(OP_EQUALVERIFY).
+		AddData(receiverWitnessProgram).
+		AddOp(OP_EQUALVERIFY).
+		AddOp(OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(OP_EQUAL).
+		Script()
+	if err != nil {
+		t.Fatalf("failed to build covenant claim script: %v", err)
+	}
+
+	// --- Build covenant refund script ---
+	// Witness stack (bottom to top): <output_index>
+	// Script: <locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP
+	//         <idx> OP_INSPECTOUTPUTSCRIPTPUBKEY OP_1 OP_EQUALVERIFY <wp> OP_EQUALVERIFY
+	//         <idx> OP_INSPECTOUTPUTVALUE <amount_le> OP_EQUAL
+	const refundLocktime int64 = 500000
+	covenantRefundScript, err := txscript.NewScriptBuilder().
+		AddInt64(refundLocktime).
+		AddOp(OP_CHECKLOCKTIMEVERIFY).
+		AddOp(OP_DROP).
+		AddOp(OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(OP_1).
+		AddOp(OP_EQUALVERIFY).
+		AddData(senderWitnessProgram).
+		AddOp(OP_EQUALVERIFY).
+		AddOp(OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(OP_EQUAL).
+		Script()
+	if err != nil {
+		t.Fatalf("failed to build covenant refund script: %v", err)
+	}
+
+	// --- Shared prevout fetcher ---
+	prevoutFetcher := txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+		{Hash: chainhash.Hash{}, Index: 0}: {Value: 100000, PkScript: []byte{
+			OP_1, OP_DATA_32,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}},
+	})
+
+	// --- Helper: build a tx with given outputs, locktime, and sequence ---
+	makeTx := func(outputs []*wire.TxOut, locktime uint32, sequence uint32) *wire.MsgTx {
+		return &wire.MsgTx{
+			Version:  1,
+			LockTime: locktime,
+			TxIn: []*wire.TxIn{
+				{
+					PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0},
+					Sequence:         sequence,
+				},
+			},
+			TxOut: outputs,
+		}
+	}
+
+	// --- Helper: run engine ---
+	runEngine := func(t *testing.T, script []byte, tx *wire.MsgTx, stack [][]byte) error {
+		t.Helper()
+		engine, err := NewEngine(
+			script, tx, 0,
+			txscript.NewSigCache(100),
+			txscript.NewTxSigHashes(tx, prevoutFetcher),
+			100000, prevoutFetcher,
+		)
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		if len(stack) > 0 {
+			engine.SetStack(stack)
+		}
+		return engine.Execute()
+	}
+
+	// ===== COVENANT CLAIM TESTS =====
+
+	t.Run("covenant_claim_valid", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		// Stack (bottom to top): output_index=0, preimage
+		stack := [][]byte{{0x00}, preimage}
+		err := runEngine(t, covenantClaimScript, tx, stack)
+		if err != nil {
+			t.Errorf("expected success, got: %v", err)
+		}
+	})
+
+	t.Run("covenant_claim_wrong_preimage", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		stack := [][]byte{{0x00}, wrongPreimage}
+		err := runEngine(t, covenantClaimScript, tx, stack)
+		if err == nil {
+			t.Error("expected failure for wrong preimage")
+		}
+	})
+
+	t.Run("covenant_claim_wrong_address", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: wrongPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		stack := [][]byte{{0x00}, preimage}
+		err := runEngine(t, covenantClaimScript, tx, stack)
+		if err == nil {
+			t.Error("expected failure for wrong address")
+		}
+	})
+
+	t.Run("covenant_claim_wrong_amount", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: wrongAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		stack := [][]byte{{0x00}, preimage}
+		err := runEngine(t, covenantClaimScript, tx, stack)
+		if err == nil {
+			t.Error("expected failure for wrong amount")
+		}
+	})
+
+	t.Run("covenant_claim_flexible_output_index", func(t *testing.T) {
+		t.Parallel()
+		// Claim output is at index 1, not 0
+		tx := makeTx([]*wire.TxOut{
+			{Value: 10000, PkScript: wrongPkScript}, // index 0: some other output
+			{Value: claimAmount, PkScript: receiverPkScript}, // index 1: claim output
+		}, 0, wire.MaxTxInSequenceNum)
+		stack := [][]byte{{0x01}, preimage} // output_index=1
+		err := runEngine(t, covenantClaimScript, tx, stack)
+		if err != nil {
+			t.Errorf("expected success with output at index 1, got: %v", err)
+		}
+	})
+
+	// ===== COVENANT REFUND TESTS =====
+
+	t.Run("covenant_refund_valid", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1) // sequence < max to enable CLTV
+		stack := [][]byte{{0x00}} // output_index=0
+		err := runEngine(t, covenantRefundScript, tx, stack)
+		if err != nil {
+			t.Errorf("expected success, got: %v", err)
+		}
+	})
+
+	t.Run("covenant_refund_before_timelock", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime-1), wire.MaxTxInSequenceNum-1) // locktime too early
+		stack := [][]byte{{0x00}}
+		err := runEngine(t, covenantRefundScript, tx, stack)
+		if err == nil {
+			t.Error("expected failure before timelock")
+		}
+	})
+
+	t.Run("covenant_refund_wrong_address", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: wrongPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1)
+		stack := [][]byte{{0x00}}
+		err := runEngine(t, covenantRefundScript, tx, stack)
+		if err == nil {
+			t.Error("expected failure for wrong refund address")
+		}
+	})
+
+	t.Run("covenant_refund_wrong_amount", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: wrongAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1)
+		stack := [][]byte{{0x00}}
+		err := runEngine(t, covenantRefundScript, tx, stack)
+		if err == nil {
+			t.Error("expected failure for wrong refund amount")
+		}
+	})
+}
+```
+
+**Important notes for the implementer:**
+- The `calcHash` function already exists in `pkg/arkade/opcode.go` (used by `opcodeHash160`). It's unexported but accessible from `engine_test.go` since it's in the same package.
+- The `sha256` and `ripemd160` imports are already used in the package. Add `"crypto/sha256"`, `"encoding/binary"`, and `"golang.org/x/crypto/ripemd160"` to the test imports.
+- The witness stack is set via `engine.SetStack()`. The stack is bottom-to-top, so `[][]byte{{0x00}, preimage}` means output_index is at position 0 (bottom) and preimage is at position 1 (top). The script pops from top first, so it processes preimage first (for `OP_HASH160`), then output_index (for `OP_INSPECTOUTPUTSCRIPTPUBKEY`).
+
+**Step 2: Run tests to verify they pass**
+
+```bash
+cd /c/Git/introspector
+go test ./pkg/arkade/ -run TestCovenantHTLC -v -count=1
+```
+
+Expected: All 8 subtests pass.
+
+**Step 3: Commit**
+
+```bash
+git add pkg/arkade/engine_test.go
+git commit -m "test: add covenant HTLC unit tests for claim and refund scripts"
+```
+
+---
+
+### Task 3: Write integration test for covenant claim
+
+**Files:**
+- Create: `test/covenant_htlc_test.go`
+
+**Step 1: Write the integration test**
+
+This test follows the exact pattern from `test/pay_2_out_test.go`. It:
+1. Sets up Alice (funder) and Bob (receiver — but Bob does NOT sign the claim)
+2. Builds a covenant HTLC Arkade script with hardcoded receiver address + amount
+3. Creates a VTXO with the arkade closure (server + introspector multisig, tweaked with arkade script hash)
+4. Alice sends funds to the covenant HTLC VTXO
+5. Claims using only the preimage — no Bob wallet signing needed
+6. Tests invalid case: wrong output → introspector rejects
+
+```go
+package test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"context"
+
+	"github.com/ArkLabsHQ/introspector/pkg/arkade"
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ripemd160"
+)
+
+// hash160 computes RIPEMD160(SHA256(data)).
+func hash160(data []byte) []byte {
+	sha := sha256.Sum256(data)
+	r := ripemd160.New()
+	r.Write(sha[:])
+	return r.Sum(nil)
+}
+
+// TestCovenantHTLCClaim tests the covenant HTLC claim path where the receiver
+// does NOT sign — only the preimage is needed. The Arkade script enforces that
+// the output goes to the receiver's address with the correct amount.
+func TestCovenantHTLCClaim(t *testing.T) {
+	ctx := context.Background()
+	alice, grpcAlice := setupArkSDK(t)
+	defer grpcAlice.Close()
+
+	// --- Generate receiver key (Bob) but we will NOT use it for signing the claim ---
+	bobPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	bobPubKey := bobPrivKey.PubKey()
+	bobPkScript, err := txscript.PayToTaprootScript(bobPubKey)
+	require.NoError(t, err)
+	bobWitnessProgram := bobPkScript[2:] // strip version + push bytes
+
+	// --- Fund Alice ---
+	aliceAddr := fundAndSettleAlice(t, ctx, alice, 100_000)
+
+	// --- Preimage setup ---
+	preimage := bytes.Repeat([]byte{0x42}, 32)
+	preimageHash := hash160(preimage)
+
+	// --- Constants ---
+	const sendAmount = 10000
+	const claimAmount = 10000
+
+	claimAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(claimAmountLE, uint64(claimAmount))
+
+	// --- Build covenant claim Arkade script ---
+	// Witness stack: <output_index> <preimage>
+	arkadeScript, err := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_HASH160).
+		AddData(preimageHash).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddData(bobWitnessProgram).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(arkade.OP_EQUAL).
+		Script()
+	require.NoError(t, err)
+
+	// --- Introspector client ---
+	introspectorClient, publicKey, connIntrospector := setupIntrospectorClient(t, ctx)
+	defer connIntrospector.Close()
+
+	// --- VTXO with Arkade closure ---
+	// The multisig closure contains: Bob (receiver), Alice (sender's signer), and
+	// the introspector key tweaked with the arkade script hash.
+	vtxoScript := createVtxoScriptWithArkadeScript(
+		bobPubKey, aliceAddr.Signer, publicKey,
+		arkade.ArkadeScriptHash(arkadeScript),
+	)
+
+	vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+
+	closure := vtxoScript.ForfeitClosures()[0]
+
+	htlcAddr := arklib.Address{
+		HRP:        "tark",
+		VtxoTapKey: vtxoTapKey,
+		Signer:     aliceAddr.Signer,
+	}
+
+	arkadeTapscript, err := closure.Script()
+	require.NoError(t, err)
+
+	merkleProof, err := vtxoTapTree.GetTaprootMerkleProof(
+		txscript.NewBaseTapLeaf(arkadeTapscript).TapHash(),
+	)
+	require.NoError(t, err)
+
+	ctrlBlock, err := txscript.ParseControlBlock(merkleProof.ControlBlock)
+	require.NoError(t, err)
+
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock:   ctrlBlock,
+		RevealedScript: merkleProof.Script,
+	}
+
+	htlcAddrStr, err := htlcAddr.EncodeV0()
+	require.NoError(t, err)
+
+	// --- Alice sends to covenant HTLC ---
+	txid, err := alice.SendOffChain(
+		ctx, []types.Receiver{{To: htlcAddrStr, Amount: sendAmount}},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, txid)
+
+	// --- Find HTLC output in funding tx ---
+	indexerSvc := setupIndexer(t)
+
+	fundingTx, err := indexerSvc.GetVirtualTxs(ctx, []string{txid})
+	require.NoError(t, err)
+	require.NotEmpty(t, fundingTx)
+	require.Len(t, fundingTx.Txs, 1)
+
+	redeemPtx, err := psbt.NewFromRawBytes(strings.NewReader(fundingTx.Txs[0]), true)
+	require.NoError(t, err)
+
+	var htlcOutput *wire.TxOut
+	var htlcOutputIndex uint32
+	for i, out := range redeemPtx.UnsignedTx.TxOut {
+		if bytes.Equal(out.PkScript[2:], schnorr.SerializePubKey(htlcAddr.VtxoTapKey)) {
+			htlcOutput = out
+			htlcOutputIndex = uint32(i)
+			break
+		}
+	}
+	require.NotNil(t, htlcOutput)
+
+	infos, err := grpcAlice.GetInfo(ctx)
+	require.NoError(t, err)
+
+	checkpointScriptBytes, err := hex.DecodeString(infos.CheckpointTapscript)
+	require.NoError(t, err)
+
+	vtxoInput := offchain.VtxoInput{
+		Outpoint: &wire.OutPoint{
+			Hash:  redeemPtx.UnsignedTx.TxHash(),
+			Index: htlcOutputIndex,
+		},
+		Tapscript:          tapscript,
+		Amount:             htlcOutput.Value,
+		RevealedTapscripts: []string{hex.EncodeToString(arkadeTapscript)},
+	}
+
+	// ========================================
+	// CASE 1: Invalid — wrong output address
+	// ========================================
+	invalidAddrTx, invalidAddrCheckpoints, err := offchain.BuildTxs(
+		[]offchain.VtxoInput{vtxoInput},
+		[]*wire.TxOut{
+			{Value: claimAmount, PkScript: []byte{0x6a}}, // OP_RETURN, wrong address
+		},
+		checkpointScriptBytes,
+	)
+	require.NoError(t, err)
+
+	addIntrospectorPacket(t, invalidAddrTx, []arkade.IntrospectorEntry{
+		{Vin: 0, Script: arkadeScript, Witness: append([]byte{0x00}, preimage...)},
+	})
+
+	encodedInvalidAddrTx, err := invalidAddrTx.B64Encode()
+	require.NoError(t, err)
+
+	encodedInvalidAddrCheckpoints := make([]string, 0, len(invalidAddrCheckpoints))
+	for _, cp := range invalidAddrCheckpoints {
+		encoded, err := cp.B64Encode()
+		require.NoError(t, err)
+		encodedInvalidAddrCheckpoints = append(encodedInvalidAddrCheckpoints, encoded)
+	}
+
+	// NOTE: No Bob wallet signing! Only submit to introspector.
+	_, _, err = introspectorClient.SubmitTx(ctx, encodedInvalidAddrTx, encodedInvalidAddrCheckpoints)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to process transaction")
+
+	// ========================================
+	// CASE 2: Valid — covenant claim with correct output
+	// ========================================
+	validTx, validCheckpoints, err := offchain.BuildTxs(
+		[]offchain.VtxoInput{vtxoInput},
+		[]*wire.TxOut{
+			{Value: claimAmount, PkScript: bobPkScript},
+		},
+		checkpointScriptBytes,
+	)
+	require.NoError(t, err)
+
+	addIntrospectorPacket(t, validTx, []arkade.IntrospectorEntry{
+		{Vin: 0, Script: arkadeScript, Witness: append([]byte{0x00}, preimage...)},
+	})
+
+	encodedValidTx, err := validTx.B64Encode()
+	require.NoError(t, err)
+
+	encodedValidCheckpoints := make([]string, 0, len(validCheckpoints))
+	for _, cp := range validCheckpoints {
+		encoded, err := cp.B64Encode()
+		require.NoError(t, err)
+		encodedValidCheckpoints = append(encodedValidCheckpoints, encoded)
+	}
+
+	// Submit to introspector — no Bob signing needed!
+	signedTx, signedByIntrospectorCheckpoints, err := introspectorClient.SubmitTx(
+		ctx, encodedValidTx, encodedValidCheckpoints,
+	)
+	require.NoError(t, err)
+
+	// Submit to server
+	txid, _, signedByServerCheckpoints, err := grpcAlice.SubmitTx(ctx, signedTx, encodedValidCheckpoints)
+	require.NoError(t, err)
+
+	finalCheckpoints := make([]string, 0, len(signedByServerCheckpoints))
+	for i, checkpoint := range signedByServerCheckpoints {
+		byInterceptorCheckpointPtx, err := psbt.NewFromRawBytes(
+			strings.NewReader(signedByIntrospectorCheckpoints[i]), true,
+		)
+		require.NoError(t, err)
+
+		checkpointPtx, err := psbt.NewFromRawBytes(strings.NewReader(checkpoint), true)
+		require.NoError(t, err)
+
+		checkpointPtx.Inputs[0].TaprootScriptSpendSig = append(
+			checkpointPtx.Inputs[0].TaprootScriptSpendSig,
+			byInterceptorCheckpointPtx.Inputs[0].TaprootScriptSpendSig...,
+		)
+
+		finalCheckpoint, err := checkpointPtx.B64Encode()
+		require.NoError(t, err)
+
+		finalCheckpoints = append(finalCheckpoints, finalCheckpoint)
+	}
+
+	err = grpcAlice.FinalizeTx(ctx, txid, finalCheckpoints)
+	require.NoError(t, err)
+}
+```
+
+**Important notes for the implementer:**
+- This file uses helpers from `test/utils_test.go`: `setupArkSDK`, `setupIndexer`, `fundAndSettleAlice`, `setupIntrospectorClient`, `createVtxoScriptWithArkadeScript`, `addIntrospectorPacket`
+- You'll need to import `"github.com/arkade-os/go-sdk/types"` for `types.Receiver`
+- The `Witness` field in `IntrospectorEntry` provides the witness data for the Arkade script. The witness bytes are: `output_index || preimage` (concatenated, not stack-encoded). Check how `VerifyEntry` deserializes witness bytes — it may need the witness to be the raw stack elements or serialized differently. **Read `pkg/arkade/introspector_packet.go:VerifyEntry` to confirm the witness format before finalizing.**
+- The integration test requires a running nigiri + arkd + introspector stack
+- The `time` import is only needed if you add `time.Sleep` calls between operations
+
+**Step 2: Run test (requires running stack)**
+
+```bash
+cd /c/Git/introspector
+go test ./test/ -run TestCovenantHTLCClaim -v -count=1 -timeout 120s
+```
+
+Expected: Both cases pass — invalid case errors, valid case succeeds.
+
+**Step 3: Commit**
+
+```bash
+git add test/covenant_htlc_test.go
+git commit -m "test: add integration test for covenant HTLC claim without receiver signature"
+```
+
+---
+
+### Task 4: Verify witness format for IntrospectorEntry
+
+**Files:**
+- Read: `pkg/arkade/introspector_packet.go` (VerifyEntry function)
+
+**Step 1: Read VerifyEntry to understand how witness bytes are deserialized**
+
+The `Witness` field in `IntrospectorEntry` is passed to the Arkade engine as the initial stack. Check whether it's:
+- Raw concatenated bytes (need to split into stack elements)
+- Already stack-encoded (serialized witness)
+- Passed as-is to `SetStack`
+
+**Step 2: Adjust integration test witness format if needed**
+
+If `VerifyEntry` passes `entry.Witness` as a single byte array to the stack, the witness format in the integration test (`append([]byte{0x00}, preimage...)`) would put everything as one stack element. You may need to encode it differently.
+
+If it uses some form of stack serialization (length-prefixed elements), adjust accordingly.
+
+**Step 3: Re-run tests after any adjustments**
+
+---
+
+### Task 5: Push and create PR
+
+**Step 1: Push branch**
+
+```bash
+cd /c/Git/introspector
+git push -u origin feat/covenant-htlc
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create \
+  --base feat/introspect-introspector-packet \
+  --title "test: covenant HTLC claim without receiver signature" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds unit tests exercising the Arkade script engine with covenant HTLC scripts (claim + refund)
+- Adds integration test demonstrating non-interactive HTLC claim using introspection opcodes
+- Covenant claim verifies output address + amount via OP_INSPECTOUTPUTSCRIPTPUBKEY and OP_INSPECTOUTPUTVALUE, replacing the receiver's signature
+- Inspired by Boltz covenant claims and fulmine's VHTLC structure
+
+## Test plan
+- [ ] Unit tests pass: `go test ./pkg/arkade/ -run TestCovenantHTLC -v`
+- [ ] Integration tests pass with running stack: `go test ./test/ -run TestCovenantHTLCClaim -v`
+EOF
+)"
+```

--- a/internal/application/intent.go
+++ b/internal/application/intent.go
@@ -53,7 +53,7 @@ func (s *service) SubmitIntent(ctx context.Context, intent Intent) (*psbt.Packet
 			continue
 		}
 
-		if err := script.execute(ptx.UnsignedTx, prevoutFetcher, inputIndex); err != nil {
+		if err := script.execute(ptx.UnsignedTx, prevoutFetcher, inputIndex, packet); err != nil {
 			log.WithError(err).WithField("input_index", inputIndex).Error("arkade script execution failed")
 			return nil, fmt.Errorf("failed to execute arkade script at input %d: %w", inputIndex, err)
 		}

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -51,7 +51,7 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 		}
 
 		log.Debugf("executing arkade script: %x", script.script)
-		if err := script.execute(arkPtx.UnsignedTx, prevoutFetcher, inputIndex); err != nil {
+		if err := script.execute(arkPtx.UnsignedTx, prevoutFetcher, inputIndex, packet); err != nil {
 			return nil, fmt.Errorf("failed to execute arkade script: %w", err)
 		}
 		log.Debugf("execution of %x succeeded", script.script)

--- a/internal/application/utils.go
+++ b/internal/application/utils.go
@@ -87,7 +87,7 @@ func readArkadeScript(ptx *psbt.Packet, inputIndex int, signerPublicKey *btcec.P
 	}, nil
 }
 
-func (s arkadeScript) execute(spendingTx *wire.MsgTx, prevoutFetcher txscript.PrevOutputFetcher, inputIndex int) error {
+func (s arkadeScript) execute(spendingTx *wire.MsgTx, prevoutFetcher txscript.PrevOutputFetcher, inputIndex int, packet *arkade.IntrospectorPacket) error {
 	prevOut := prevoutFetcher.FetchPrevOutput(spendingTx.TxIn[inputIndex].PreviousOutPoint)
 	inputAmount := int64(0)
 	if prevOut != nil {
@@ -115,6 +115,10 @@ func (s arkadeScript) execute(spendingTx *wire.MsgTx, prevoutFetcher txscript.Pr
 		}
 	}
 	// If error, extension is not present - this is okay, just don't set it
+
+	if packet != nil {
+		engine.SetIntrospectorPacket(packet)
+	}
 
 	if len(s.witness) > 0 {
 		engine.SetStack(s.witness)

--- a/pkg/arkade/engine_test.go
+++ b/pkg/arkade/engine_test.go
@@ -7,6 +7,8 @@ package arkade
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"golang.org/x/crypto/ripemd160"
 )
 
 func TestNewOpcodes(t *testing.T) {
@@ -2154,4 +2157,305 @@ func TestIntrospectorPacketOpcodes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCovenantHTLC exercises Arkade scripts that enforce HTLC-like spending
+// conditions using introspection opcodes instead of signatures.
+//
+// Covenant claim script:
+//
+//	Witness stack (bottom→top): <output_index> <preimage>
+//	OP_HASH160 <preimage_hash> OP_EQUALVERIFY
+//	OP_INSPECTOUTPUTSCRIPTPUBKEY OP_1 OP_EQUALVERIFY <wp> OP_EQUALVERIFY
+//	OP_INSPECTOUTPUTVALUE <amount_le> OP_EQUAL
+//
+// Covenant refund script:
+//
+//	Witness stack (bottom→top): <output_index>
+//	<locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP
+//	OP_INSPECTOUTPUTSCRIPTPUBKEY OP_1 OP_EQUALVERIFY <wp> OP_EQUALVERIFY
+//	OP_INSPECTOUTPUTVALUE <amount_le> OP_EQUAL
+func TestCovenantHTLC(t *testing.T) {
+	t.Parallel()
+
+	// --- Preimage & HASH160 ---
+	preimage := bytes.Repeat([]byte{0x42}, 32)
+	sha := sha256.Sum256(preimage)
+	preimageHash := calcHash(sha[:], ripemd160.New())
+
+	wrongPreimage := bytes.Repeat([]byte{0x43}, 32)
+
+	// --- Receiver taproot output ---
+	receiverWP := bytes.Repeat([]byte{0xaa}, 32)
+	receiverPkScript := append([]byte{OP_1, OP_DATA_32}, receiverWP...)
+
+	wrongWP := bytes.Repeat([]byte{0xbb}, 32)
+	wrongPkScript := append([]byte{OP_1, OP_DATA_32}, wrongWP...)
+
+	// --- Sender taproot output (for refund) ---
+	senderWP := bytes.Repeat([]byte{0xcc}, 32)
+	senderPkScript := append([]byte{OP_1, OP_DATA_32}, senderWP...)
+
+	// --- Amounts ---
+	const claimAmount int64 = 50000
+	claimAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(claimAmountLE, uint64(claimAmount))
+
+	const wrongAmount int64 = 49999
+	wrongAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(wrongAmountLE, uint64(wrongAmount))
+	_ = wrongAmountLE // used indirectly via wrongAmount in TxOut
+
+	// --- Build covenant claim script ---
+	// Witness stack (bottom→top): <output_index> <preimage>
+	// OP_HASH160 <hash> OP_EQUALVERIFY   — verify preimage
+	// OP_DUP                              — duplicate output_index for reuse
+	// OP_INSPECTOUTPUTSCRIPTPUBKEY ...    — verify destination
+	// OP_INSPECTOUTPUTVALUE ...           — verify amount
+	covenantClaimScript, err := txscript.NewScriptBuilder().
+		AddOp(OP_HASH160).
+		AddData(preimageHash).
+		AddOp(OP_EQUALVERIFY).
+		AddOp(OP_DUP).
+		AddOp(OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(OP_1).
+		AddOp(OP_EQUALVERIFY).
+		AddData(receiverWP).
+		AddOp(OP_EQUALVERIFY).
+		AddOp(OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(OP_EQUAL).
+		Script()
+	if err != nil {
+		t.Fatalf("failed to build covenant claim script: %v", err)
+	}
+
+	// --- Build covenant refund script ---
+	// Witness stack (bottom→top): <output_index>
+	// <locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP
+	// OP_DUP
+	// OP_INSPECTOUTPUTSCRIPTPUBKEY ...    — verify destination
+	// OP_INSPECTOUTPUTVALUE ...           — verify amount
+	const refundLocktime int64 = 500000
+	covenantRefundScript, err := txscript.NewScriptBuilder().
+		AddInt64(refundLocktime).
+		AddOp(OP_CHECKLOCKTIMEVERIFY).
+		AddOp(OP_DROP).
+		AddOp(OP_DUP).
+		AddOp(OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(OP_1).
+		AddOp(OP_EQUALVERIFY).
+		AddData(senderWP).
+		AddOp(OP_EQUALVERIFY).
+		AddOp(OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(OP_EQUAL).
+		Script()
+	if err != nil {
+		t.Fatalf("failed to build covenant refund script: %v", err)
+	}
+
+	// --- Shared prevout fetcher ---
+	prevoutFetcher := txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+		{Hash: chainhash.Hash{}, Index: 0}: {Value: 100000, PkScript: []byte{
+			OP_1, OP_DATA_32,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}},
+	})
+
+	makeTx := func(outputs []*wire.TxOut, locktime uint32, sequence uint32) *wire.MsgTx {
+		return &wire.MsgTx{
+			Version:  1,
+			LockTime: locktime,
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0},
+				Sequence:         sequence,
+			}},
+			TxOut: outputs,
+		}
+	}
+
+	runEngine := func(t *testing.T, script []byte, tx *wire.MsgTx, stack [][]byte) error {
+		t.Helper()
+		engine, err := NewEngine(
+			script, tx, 0,
+			txscript.NewSigCache(100),
+			txscript.NewTxSigHashes(tx, prevoutFetcher),
+			100000, prevoutFetcher,
+		)
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		if len(stack) > 0 {
+			engine.SetStack(stack)
+		}
+		return engine.Execute()
+	}
+
+	// ===== COVENANT CLAIM TESTS =====
+
+	t.Run("claim_valid", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		// output_index=0 is encoded as empty []byte{} (minimal encoding for OP_0)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{}, preimage})
+		if err != nil {
+			t.Errorf("expected success, got: %v", err)
+		}
+	})
+
+	t.Run("claim_wrong_preimage", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{}, wrongPreimage})
+		if err == nil {
+			t.Error("expected failure for wrong preimage")
+		}
+	})
+
+	t.Run("claim_wrong_address", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: wrongPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{}, preimage})
+		if err == nil {
+			t.Error("expected failure for wrong address")
+		}
+	})
+
+	t.Run("claim_wrong_amount", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: wrongAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{}, preimage})
+		if err == nil {
+			t.Error("expected failure for wrong amount")
+		}
+	})
+
+	t.Run("claim_flexible_output_index", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: 10000, PkScript: wrongPkScript},          // index 0: unrelated
+			{Value: claimAmount, PkScript: receiverPkScript}, // index 1: claim target
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{0x01}, preimage})
+		if err != nil {
+			t.Errorf("expected success with output at index 1, got: %v", err)
+		}
+	})
+
+	t.Run("claim_output_index_out_of_range", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{0x05}, preimage})
+		if err == nil {
+			t.Error("expected failure for output index out of range")
+		}
+	})
+
+	t.Run("claim_empty_preimage", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: receiverPkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{}, {}})
+		if err == nil {
+			t.Error("expected failure for empty preimage")
+		}
+	})
+
+	t.Run("claim_segwit_v0_rejected", func(t *testing.T) {
+		t.Parallel()
+		// SegWit v0 output (OP_0 + 32-byte program) should fail the OP_1 check
+		v0PkScript := append([]byte{OP_0, OP_DATA_32}, receiverWP...)
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: v0PkScript},
+		}, 0, wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantClaimScript, tx, [][]byte{{}, preimage})
+		if err == nil {
+			t.Error("expected failure for segwit v0 output")
+		}
+	})
+
+	// ===== COVENANT REFUND TESTS =====
+
+	t.Run("refund_valid", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1)
+		err := runEngine(t, covenantRefundScript, tx, [][]byte{{}})
+		if err != nil {
+			t.Errorf("expected success, got: %v", err)
+		}
+	})
+
+	t.Run("refund_before_timelock", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime-1), wire.MaxTxInSequenceNum-1)
+		err := runEngine(t, covenantRefundScript, tx, [][]byte{{}})
+		if err == nil {
+			t.Error("expected failure before timelock")
+		}
+	})
+
+	t.Run("refund_sequence_max_disables_cltv", func(t *testing.T) {
+		t.Parallel()
+		// MaxTxInSequenceNum disables CLTV
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum)
+		err := runEngine(t, covenantRefundScript, tx, [][]byte{{}})
+		if err == nil {
+			t.Error("expected failure when sequence disables CLTV")
+		}
+	})
+
+	t.Run("refund_wrong_address", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: claimAmount, PkScript: wrongPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1)
+		err := runEngine(t, covenantRefundScript, tx, [][]byte{{}})
+		if err == nil {
+			t.Error("expected failure for wrong refund address")
+		}
+	})
+
+	t.Run("refund_wrong_amount", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: wrongAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1)
+		err := runEngine(t, covenantRefundScript, tx, [][]byte{{}})
+		if err == nil {
+			t.Error("expected failure for wrong refund amount")
+		}
+	})
+
+	t.Run("refund_flexible_output_index", func(t *testing.T) {
+		t.Parallel()
+		tx := makeTx([]*wire.TxOut{
+			{Value: 10000, PkScript: wrongPkScript},
+			{Value: claimAmount, PkScript: senderPkScript},
+		}, uint32(refundLocktime), wire.MaxTxInSequenceNum-1)
+		err := runEngine(t, covenantRefundScript, tx, [][]byte{{0x01}})
+		if err != nil {
+			t.Errorf("expected success with output at index 1, got: %v", err)
+		}
+	})
 }

--- a/test/covenant_htlc_test.go
+++ b/test/covenant_htlc_test.go
@@ -1,0 +1,441 @@
+package test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"context"
+
+	"github.com/ArkLabsHQ/introspector/pkg/arkade"
+	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ripemd160"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+)
+
+// serializeWitness serializes stack items using Bitcoin's witness encoding:
+// varint(count) || [varint(len) || data]...
+func serializeWitness(items [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	err := psbt.WriteTxWitness(&buf, items)
+	return buf.Bytes(), err
+}
+
+// TestCovenantHTLCClaim tests the covenant HTLC claim path where the receiver
+// does NOT sign — only the preimage is needed. The Arkade script enforces that
+// the output goes to the receiver's address with the correct amount.
+//
+// This mirrors fulmine's VHTLC TestVHTLC e2e test but uses introspection
+// opcodes instead of receiver signatures for the claim path.
+//
+// Spending paths tested:
+//  1. Covenant claim (invalid — wrong address): introspector rejects
+//  2. Covenant claim (valid — correct output): introspector signs, no receiver sig needed
+func TestCovenantHTLCClaim(t *testing.T) {
+	ctx := context.Background()
+	alice, grpcAlice := setupArkSDK(t)
+	defer grpcAlice.Close()
+
+	// --- Receiver key (Bob) — NOT used for signing the claim ---
+	bobPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	bobPubKey := bobPrivKey.PubKey()
+	bobPkScript, err := txscript.PayToTaprootScript(bobPubKey)
+	require.NoError(t, err)
+	bobWitnessProgram := bobPkScript[2:] // strip OP_1 + OP_DATA_32
+
+	// --- Fund Alice ---
+	aliceAddr := fundAndSettleAlice(t, ctx, alice, 100_000)
+
+	// --- Preimage setup (matches fulmine's random preimage pattern) ---
+	preimage := bytes.Repeat([]byte{0x42}, 32)
+	sha := sha256.Sum256(preimage)
+	r := ripemd160.New()
+	r.Write(sha[:])
+	preimageHash := r.Sum(nil) // RIPEMD160(SHA256(preimage))
+
+	// --- Constants ---
+	const sendAmount = 10000
+	const claimAmount = 10000
+
+	claimAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(claimAmountLE, uint64(claimAmount))
+
+	// --- Build covenant claim Arkade script ---
+	// Witness stack (bottom→top): <output_index> <preimage>
+	// Script pops preimage first (OP_HASH160), then uses output_index twice (OP_DUP)
+	arkadeScript, err := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_HASH160).
+		AddData(preimageHash).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_DUP).
+		AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddData(bobWitnessProgram).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(arkade.OP_EQUAL).
+		Script()
+	require.NoError(t, err)
+
+	// --- Introspector client ---
+	introspectorClient, publicKey, connIntrospector := setupIntrospectorClient(t, ctx)
+	defer connIntrospector.Close()
+
+	// --- VTXO with Arkade closure ---
+	// MultisigClosure contains: Bob, Alice's signer, and introspector tweaked key
+	// This matches fulmine's ClaimClosure pattern but replaces ConditionMultisigClosure
+	// with an Arkade-script-backed MultisigClosure
+	vtxoScript := createVtxoScriptWithArkadeScript(
+		bobPubKey, aliceAddr.Signer, publicKey,
+		arkade.ArkadeScriptHash(arkadeScript),
+	)
+
+	vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+
+	closure := vtxoScript.ForfeitClosures()[0]
+
+	htlcAddr := arklib.Address{
+		HRP:        "tark",
+		VtxoTapKey: vtxoTapKey,
+		Signer:     aliceAddr.Signer,
+	}
+
+	arkadeTapscript, err := closure.Script()
+	require.NoError(t, err)
+
+	merkleProof, err := vtxoTapTree.GetTaprootMerkleProof(
+		txscript.NewBaseTapLeaf(arkadeTapscript).TapHash(),
+	)
+	require.NoError(t, err)
+
+	ctrlBlock, err := txscript.ParseControlBlock(merkleProof.ControlBlock)
+	require.NoError(t, err)
+
+	tapscriptObj := &waddrmgr.Tapscript{
+		ControlBlock:   ctrlBlock,
+		RevealedScript: merkleProof.Script,
+	}
+
+	htlcAddrStr, err := htlcAddr.EncodeV0()
+	require.NoError(t, err)
+
+	// --- Alice sends to covenant HTLC ---
+	txid, err := alice.SendOffChain(
+		ctx, []types.Receiver{{To: htlcAddrStr, Amount: sendAmount}},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, txid)
+
+	// --- Find HTLC output in funding tx ---
+	indexerSvc := setupIndexer(t)
+
+	fundingTx, err := indexerSvc.GetVirtualTxs(ctx, []string{txid})
+	require.NoError(t, err)
+	require.NotEmpty(t, fundingTx)
+	require.Len(t, fundingTx.Txs, 1)
+
+	redeemPtx, err := psbt.NewFromRawBytes(strings.NewReader(fundingTx.Txs[0]), true)
+	require.NoError(t, err)
+
+	var htlcOutput *wire.TxOut
+	var htlcOutputIndex uint32
+	for i, out := range redeemPtx.UnsignedTx.TxOut {
+		if bytes.Equal(out.PkScript[2:], schnorr.SerializePubKey(htlcAddr.VtxoTapKey)) {
+			htlcOutput = out
+			htlcOutputIndex = uint32(i)
+			break
+		}
+	}
+	require.NotNil(t, htlcOutput)
+
+	infos, err := grpcAlice.GetInfo(ctx)
+	require.NoError(t, err)
+
+	checkpointScriptBytes, err := hex.DecodeString(infos.CheckpointTapscript)
+	require.NoError(t, err)
+
+	vtxoInput := offchain.VtxoInput{
+		Outpoint: &wire.OutPoint{
+			Hash:  redeemPtx.UnsignedTx.TxHash(),
+			Index: htlcOutputIndex,
+		},
+		Tapscript:          tapscriptObj,
+		Amount:             htlcOutput.Value,
+		RevealedTapscripts: []string{hex.EncodeToString(arkadeTapscript)},
+	}
+
+	// --- Serialize witness: [output_index=0, preimage] ---
+	witnessBytes, err := serializeWitness([][]byte{{}, preimage})
+	require.NoError(t, err)
+
+	// ========================================
+	// CASE 1: Invalid — wrong output address
+	// ========================================
+	invalidAddrTx, invalidAddrCheckpoints, err := offchain.BuildTxs(
+		[]offchain.VtxoInput{vtxoInput},
+		[]*wire.TxOut{
+			{Value: claimAmount, PkScript: []byte{0x6a}}, // OP_RETURN, wrong address
+		},
+		checkpointScriptBytes,
+	)
+	require.NoError(t, err)
+
+	addIntrospectorPacket(t, invalidAddrTx, []arkade.IntrospectorEntry{
+		{Vin: 0, Script: arkadeScript, Witness: witnessBytes},
+	})
+
+	encodedInvalidAddrTx, err := invalidAddrTx.B64Encode()
+	require.NoError(t, err)
+
+	encodedInvalidAddrCheckpoints := make([]string, 0, len(invalidAddrCheckpoints))
+	for _, cp := range invalidAddrCheckpoints {
+		encoded, err := cp.B64Encode()
+		require.NoError(t, err)
+		encodedInvalidAddrCheckpoints = append(encodedInvalidAddrCheckpoints, encoded)
+	}
+
+	// No Bob wallet signing — submit directly to introspector
+	_, _, err = introspectorClient.SubmitTx(ctx, encodedInvalidAddrTx, encodedInvalidAddrCheckpoints)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to process transaction")
+
+	// ========================================
+	// CASE 2: Valid — covenant claim with correct output
+	// ========================================
+	validTx, validCheckpoints, err := offchain.BuildTxs(
+		[]offchain.VtxoInput{vtxoInput},
+		[]*wire.TxOut{
+			{Value: claimAmount, PkScript: bobPkScript},
+		},
+		checkpointScriptBytes,
+	)
+	require.NoError(t, err)
+
+	addIntrospectorPacket(t, validTx, []arkade.IntrospectorEntry{
+		{Vin: 0, Script: arkadeScript, Witness: witnessBytes},
+	})
+
+	encodedValidTx, err := validTx.B64Encode()
+	require.NoError(t, err)
+
+	encodedValidCheckpoints := make([]string, 0, len(validCheckpoints))
+	for _, cp := range validCheckpoints {
+		encoded, err := cp.B64Encode()
+		require.NoError(t, err)
+		encodedValidCheckpoints = append(encodedValidCheckpoints, encoded)
+	}
+
+	// Submit to introspector — no Bob signing needed!
+	signedTx, signedByIntrospectorCheckpoints, err := introspectorClient.SubmitTx(
+		ctx, encodedValidTx, encodedValidCheckpoints,
+	)
+	require.NoError(t, err)
+
+	// Submit to server
+	txid, _, signedByServerCheckpoints, err := grpcAlice.SubmitTx(ctx, signedTx, encodedValidCheckpoints)
+	require.NoError(t, err)
+
+	finalCheckpoints := make([]string, 0, len(signedByServerCheckpoints))
+	for i, checkpoint := range signedByServerCheckpoints {
+		byInterceptorCheckpointPtx, err := psbt.NewFromRawBytes(
+			strings.NewReader(signedByIntrospectorCheckpoints[i]), true,
+		)
+		require.NoError(t, err)
+
+		checkpointPtx, err := psbt.NewFromRawBytes(strings.NewReader(checkpoint), true)
+		require.NoError(t, err)
+
+		checkpointPtx.Inputs[0].TaprootScriptSpendSig = append(
+			checkpointPtx.Inputs[0].TaprootScriptSpendSig,
+			byInterceptorCheckpointPtx.Inputs[0].TaprootScriptSpendSig...,
+		)
+
+		finalCheckpoint, err := checkpointPtx.B64Encode()
+		require.NoError(t, err)
+
+		finalCheckpoints = append(finalCheckpoints, finalCheckpoint)
+	}
+
+	err = grpcAlice.FinalizeTx(ctx, txid, finalCheckpoints)
+	require.NoError(t, err)
+}
+
+// TestCovenantHTLCFullTapTree tests that a covenant HTLC can be constructed
+// with all 6 spending paths (matching fulmine's VHTLC structure):
+//  1. Covenant Claim — Arkade script (preimage + introspection, no receiver sig)
+//  2. Traditional Claim — ConditionMultisigClosure (preimage + receiver + server)
+//  3. Covenant Refund — Arkade script (timelock + introspection, no sender sig)
+//  4. Traditional Refund — MultisigClosure (sender + receiver + server)
+//  5. Refund Without Receiver — CLTVMultisigClosure (sender + server + CLTV)
+//  6. Unilateral Claim — ConditionCSVMultisigClosure (preimage + receiver + CSV)
+//
+// This test validates the tap tree construction without requiring a running stack.
+func TestCovenantHTLCFullTapTree(t *testing.T) {
+	// --- Key setup ---
+	senderPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	senderPubKey := senderPrivKey.PubKey()
+
+	receiverPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	receiverPubKey := receiverPrivKey.PubKey()
+
+	serverPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPubKey := serverPrivKey.PubKey()
+
+	introspectorPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	introspectorPubKey := introspectorPrivKey.PubKey()
+
+	// --- Preimage ---
+	preimage := bytes.Repeat([]byte{0x42}, 32)
+	sha := sha256.Sum256(preimage)
+	r := ripemd160.New()
+	r.Write(sha[:])
+	preimageHash := r.Sum(nil)
+
+	// --- Receiver output params ---
+	receiverPkScript, err := txscript.PayToTaprootScript(receiverPubKey)
+	require.NoError(t, err)
+
+	senderPkScript, err := txscript.PayToTaprootScript(senderPubKey)
+	require.NoError(t, err)
+
+	const claimAmount = 10000
+	claimAmountLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(claimAmountLE, uint64(claimAmount))
+
+	// --- Preimage condition script (for traditional claim paths) ---
+	preimageConditionScript, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_HASH160).
+		AddData(preimageHash).
+		AddOp(txscript.OP_EQUAL).
+		Script()
+	require.NoError(t, err)
+
+	// --- Leaf 1: Covenant Claim (Arkade script) ---
+	covenantClaimScript, err := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_HASH160).
+		AddData(preimageHash).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_DUP).
+		AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddData(receiverPkScript[2:]).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(arkade.OP_EQUAL).
+		Script()
+	require.NoError(t, err)
+
+	covenantClaimTweakedKey := arkade.ComputeArkadeScriptPublicKey(
+		introspectorPubKey, arkade.ArkadeScriptHash(covenantClaimScript),
+	)
+
+	// --- Leaf 3: Covenant Refund (Arkade script) ---
+	const refundLocktime int64 = 500000
+	covenantRefundScript, err := txscript.NewScriptBuilder().
+		AddInt64(refundLocktime).
+		AddOp(arkade.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(arkade.OP_DROP).
+		AddOp(arkade.OP_DUP).
+		AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddData(senderPkScript[2:]).
+		AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddData(claimAmountLE).
+		AddOp(arkade.OP_EQUAL).
+		Script()
+	require.NoError(t, err)
+
+	covenantRefundTweakedKey := arkade.ComputeArkadeScriptPublicKey(
+		introspectorPubKey, arkade.ArkadeScriptHash(covenantRefundScript),
+	)
+
+	// --- Build full tap tree with all 6 closures ---
+	vtxoScript := script.TapscriptsVtxoScript{
+		Closures: []script.Closure{
+			// Leaf 1: Covenant Claim — server + introspector (tweaked with claim script)
+			&script.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{serverPubKey, covenantClaimTweakedKey},
+			},
+			// Leaf 2: Traditional Claim — receiver + server + preimage condition
+			&script.ConditionMultisigClosure{
+				MultisigClosure: script.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{receiverPubKey, serverPubKey},
+				},
+				Condition: preimageConditionScript,
+			},
+			// Leaf 3: Covenant Refund — server + introspector (tweaked with refund script)
+			&script.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{serverPubKey, covenantRefundTweakedKey},
+			},
+			// Leaf 4: Traditional Refund — sender + receiver + server
+			&script.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{senderPubKey, receiverPubKey, serverPubKey},
+			},
+			// Leaf 5: Refund Without Receiver — sender + server + CLTV
+			&script.CLTVMultisigClosure{
+				MultisigClosure: script.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{senderPubKey, serverPubKey},
+				},
+				Locktime: arklib.AbsoluteLocktime(refundLocktime),
+			},
+			// Leaf 6: Unilateral Claim — receiver + preimage + CSV delay
+			&script.ConditionCSVMultisigClosure{
+				CSVMultisigClosure: script.CSVMultisigClosure{
+					MultisigClosure: script.MultisigClosure{
+						PubKeys: []*btcec.PublicKey{receiverPubKey},
+					},
+					Locktime: arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
+				},
+				Condition: preimageConditionScript,
+			},
+		},
+	}
+
+	// --- Verify tap tree builds successfully ---
+	vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+	require.NotNil(t, vtxoTapKey)
+	require.NotNil(t, vtxoTapTree)
+
+	// --- Verify each closure produces a valid tapscript ---
+	for i, closure := range vtxoScript.Closures {
+		closureScript, err := closure.Script()
+		require.NoError(t, err, "closure %d failed to produce script", i)
+		require.NotEmpty(t, closureScript, "closure %d produced empty script", i)
+
+		// Verify each closure can be found in the tap tree
+		leaf := txscript.NewBaseTapLeaf(closureScript)
+		proof, err := vtxoTapTree.GetTaprootMerkleProof(leaf.TapHash())
+		require.NoError(t, err, "closure %d not found in tap tree", i)
+		require.NotNil(t, proof, "closure %d has nil proof", i)
+	}
+
+	// --- Verify forfeit closures are available ---
+	forfeitClosures := vtxoScript.ForfeitClosures()
+	require.NotEmpty(t, forfeitClosures)
+}


### PR DESCRIPTION
## Summary
- Adds **unit tests** exercising the Arkade script engine with covenant HTLC scripts (claim + refund) — 14 test cases covering valid/invalid preimage, address, amount, output index flexibility, segwit version checks, and timelock enforcement
- Adds **integration test** demonstrating non-interactive HTLC claim using introspection opcodes — no receiver wallet signing needed
- Adds **tap tree construction test** validating all 6 spending paths (mirroring fulmine's VHTLC structure)
- Includes design doc and implementation plan

### Covenant HTLC Script Structure

The covenant claim Arkade script replaces the receiver's signature with transaction introspection:

```
# Witness stack (bottom→top): <output_index> <preimage>
OP_HASH160 <preimage_hash> OP_EQUALVERIFY     # verify preimage
OP_DUP                                         # duplicate index for reuse
OP_INSPECTOUTPUTSCRIPTPUBKEY                   # check destination
OP_1 OP_EQUALVERIFY                            # segwit v1
<receiver_witness_program> OP_EQUALVERIFY      # correct address
OP_INSPECTOUTPUTVALUE                          # check amount
<expected_amount_le> OP_EQUAL                  # correct amount
```

### 6 Tap Leaves (mirroring fulmine VHTLC)

| # | Leaf | Type | Purpose |
|---|------|------|---------|
| 1 | Covenant Claim | Arkade script | Non-interactive claim (no receiver sig) |
| 2 | Traditional Claim | ConditionMultisigClosure | Standard claim (receiver + server + preimage) |
| 3 | Covenant Refund | Arkade script | Non-interactive refund (no sender sig) |
| 4 | Traditional Refund | MultisigClosure | Collaborative refund (sender + receiver + server) |
| 5 | Refund Without Receiver | CLTVMultisigClosure | Refund when receiver offline |
| 6 | Unilateral Claim | ConditionCSVMultisigClosure | Receiver's exit path |

### References
- [Boltz Claim Covenants](https://api.docs.boltz.exchange/claim-covenants.html)
- [BoltzExchange/covclaim](https://github.com/BoltzExchange/covclaim)
- [ArkLabsHQ/fulmine VHTLC](https://github.com/arklabshq/fulmine) — `pkg/vhtlc/`

## Test plan
- [x] Unit tests pass: `cd pkg/arkade && go test -run TestCovenantHTLC -v` (14/14 passing)
- [x] Full arkade test suite passes: `cd pkg/arkade && go test -v` (all passing)
- [x] Integration tests compile: `go vet ./test/`
- [ ] Integration tests pass with running stack: `go test ./test/ -run TestCovenantHTLC -v`