### PR TITLE
Fuzz: tokenizer, opcodes and engine

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/pkg/arkade/engine_fuzz_test.go
+++ b/pkg/arkade/engine_fuzz_test.go
@@ -1,0 +1,280 @@
+package arkade
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+func FuzzNewEngineExecuteArbitraryNoPanic(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fz := fuzz.NewConsumer(data)
+
+		tx, scriptPubKey := fuzzMsgTx(t, fz)
+
+		txIdx := -1
+		if b, err := fz.GetByte(); err == nil {
+			txIdx = int(b)%(len(tx.TxIn)+3) - 1
+		}
+
+		prevoutFetcher, inputAmount := fuzzPrevFetcher(t, fz, &tx, txIdx)
+
+		sigCache := txscript.NewSigCache(32)
+		hashCache := txscript.NewTxSigHashes(&tx, prevoutFetcher)
+
+		vm, err := NewEngine(scriptPubKey, &tx, txIdx, sigCache, hashCache, inputAmount, prevoutFetcher)
+
+		if err == nil {
+			_ = vm.Execute()
+		}
+	})
+}
+
+func FuzzNewEngineExecuteTaprootScriptPathNoPanic(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fz := fuzz.NewConsumer(data)
+
+		tx, scriptPubKey := fuzzMsgTxWithTaprootScriptPath(t, fz)
+		txIdx := 0
+
+		prevoutFetcher, inputAmount := fuzzPrevFetcher(t, fz, &tx, txIdx)
+
+		sigCache := txscript.NewSigCache(32)
+		hashCache := txscript.NewTxSigHashes(&tx, prevoutFetcher)
+
+		vm, err := NewEngine(scriptPubKey, &tx, txIdx, sigCache, hashCache, inputAmount, prevoutFetcher)
+
+		if err == nil {
+			_ = vm.Execute()
+		}
+	})
+}
+
+func FuzzNewEngineExecuteCommittedTaprootScriptPathNoPanic(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fz := fuzz.NewConsumer(data)
+
+		tx, scriptPubKey := fuzzMsgTxWithCommittedTaprootScriptPath(t, fz)
+		txIdx := 0
+
+		prevoutFetcher, inputAmount := fuzzPrevFetcher(t, fz, &tx, txIdx)
+
+		sigCache := txscript.NewSigCache(32)
+		hashCache := txscript.NewTxSigHashes(&tx, prevoutFetcher)
+
+		vm, err := NewEngine(scriptPubKey, &tx, txIdx, sigCache, hashCache, inputAmount, prevoutFetcher)
+
+		if err == nil {
+			_ = vm.Execute()
+		}
+	})
+}
+
+func fuzzMsgTx(t *testing.T, fz *fuzz.ConsumeFuzzer) (wire.MsgTx, []byte) {
+	t.Helper()
+
+	// Step 1: Build a mostly-random transaction shell with at least one input.
+	var tx wire.MsgTx
+	_ = fz.GenerateStruct(&tx.Version)
+	_ = fz.GenerateStruct(&tx.LockTime)
+	inCount := 1
+	if b, err := fz.GetByte(); err == nil {
+		inCount = int(b%8) + 1
+	}
+	outCount := 0
+	if b, err := fz.GetByte(); err == nil {
+		outCount = int(b % 8)
+	}
+
+	// Step 2: Fill the inputs with random outpoints, sequences, and sigscripts.
+	tx.TxIn = make([]*wire.TxIn, inCount)
+	for i := range tx.TxIn {
+		in := &wire.TxIn{}
+		_ = fz.GenerateStruct(&in.PreviousOutPoint)
+		_ = fz.GenerateStruct(&in.Sequence)
+		in.SignatureScript, _ = fz.GetBytes()
+		tx.TxIn[i] = in
+	}
+
+	// Step 3: Fill the outputs with random values and scripts.
+	tx.TxOut = make([]*wire.TxOut, outCount)
+	for i := range tx.TxOut {
+		out := &wire.TxOut{}
+		_ = fz.GenerateStruct(&out.Value)
+		out.PkScript, _ = fz.GetBytes()
+		tx.TxOut[i] = out
+	}
+
+	// Step 4: Return a fully arbitrary scriptPubKey for NewEngine.
+	scriptPubKey, _ := fz.GetBytes()
+
+	return tx, scriptPubKey
+}
+
+func fuzzMsgTxWithTaprootScriptPath(t *testing.T, fz *fuzz.ConsumeFuzzer) (wire.MsgTx, []byte) {
+	t.Helper()
+
+	// Step 1: Build a random transaction shell with at least one input.
+	var tx wire.MsgTx
+	_ = fz.GenerateStruct(&tx.Version)
+	_ = fz.GenerateStruct(&tx.LockTime)
+	inCount := 1
+	if b, err := fz.GetByte(); err == nil {
+		inCount = int(b%4) + 1
+	}
+	outCount := 0
+	if b, err := fz.GetByte(); err == nil {
+		outCount = int(b % 4)
+	}
+
+	// Step 2: Force script-path-shaped witnesses so valid indices land in the
+	// default branch of verifyWitnessProgram instead of the key-spend branch.
+	tx.TxIn = make([]*wire.TxIn, inCount)
+	for i := range tx.TxIn {
+		in := &wire.TxIn{}
+		_ = fz.GenerateStruct(&in.PreviousOutPoint)
+		_ = fz.GenerateStruct(&in.Sequence)
+		in.SignatureScript = nil
+
+		script, _ := fz.GetBytes()
+
+		keySeed, _ := fz.GetBytes()
+		priv, _ := btcec.PrivKeyFromBytes(normalizePrivKeySeed(keySeed))
+
+		controlBlock := make([]byte, 33)
+		controlBlock[0] = byte(txscript.BaseLeafVersion)
+		copy(controlBlock[1:], schnorr.SerializePubKey(priv.PubKey()))
+
+		stackCount := 0
+		if b, err := fz.GetByte(); err == nil {
+			stackCount = int(b % 3)
+		}
+		in.Witness = make(wire.TxWitness, 0, stackCount+2)
+		for range stackCount {
+			elem, _ := fz.GetBytes()
+			in.Witness = append(in.Witness, elem)
+		}
+		in.Witness = append(in.Witness, script, controlBlock)
+		tx.TxIn[i] = in
+	}
+
+	// Step 3: Fill the outputs with random values and scripts.
+	tx.TxOut = make([]*wire.TxOut, outCount)
+	for i := range tx.TxOut {
+		out := &wire.TxOut{}
+		_ = fz.GenerateStruct(&out.Value)
+		out.PkScript, _ = fz.GetBytes()
+		tx.TxOut[i] = out
+	}
+
+	// Step 4: Return a taproot witness program with a random 32-byte program.
+	prog, _ := fz.GetBytes()
+	if len(prog) < 32 {
+		p := make([]byte, 32)
+		copy(p, prog)
+		prog = p
+	}
+	prog = prog[:32]
+	scriptPubKey := append([]byte{OP_1, 0x20}, prog...)
+	return tx, scriptPubKey
+}
+
+func fuzzMsgTxWithCommittedTaprootScriptPath(t *testing.T, fz *fuzz.ConsumeFuzzer) (wire.MsgTx, []byte) {
+	t.Helper()
+
+	// Step 1: Build the smallest transaction shell that can exercise the full
+	// taproot script-path flow.
+	var tx wire.MsgTx
+	_ = fz.GenerateStruct(&tx.Version)
+	_ = fz.GenerateStruct(&tx.LockTime)
+	tx.TxIn = []*wire.TxIn{{}}
+	_ = fz.GenerateStruct(&tx.TxIn[0].PreviousOutPoint)
+	_ = fz.GenerateStruct(&tx.TxIn[0].Sequence)
+	tx.TxIn[0].SignatureScript = nil
+
+	// Step 2: Choose a small parseable tapscript plus any stack items it needs.
+	script := []byte{OP_TRUE}
+	initialStack := wire.TxWitness{}
+	if b, err := fz.GetByte(); err == nil {
+		switch b % 3 {
+		case 1:
+			script = []byte{OP_DUP, OP_DROP, OP_TRUE}
+			initialStack = wire.TxWitness{[]byte{0x01}}
+		case 2:
+			script = []byte{OP_IF, OP_TRUE, OP_ELSE, OP_TRUE, OP_ENDIF}
+			initialStack = wire.TxWitness{[]byte{0x01}}
+		}
+	}
+
+	// Step 3: Build a coherent taproot output key and matching control block so
+	// execution can get past the leaf-commitment checks.
+	keySeed, _ := fz.GetBytes()
+	internalPriv, _ := btcec.PrivKeyFromBytes(normalizePrivKeySeed(keySeed))
+
+	leaf := txscript.NewBaseTapLeaf(script)
+	leafHash := leaf.TapHash()
+	outputKey := txscript.ComputeTaprootOutputKey(internalPriv.PubKey(), leafHash[:])
+
+	controlBlock := &txscript.ControlBlock{
+		InternalKey:     internalPriv.PubKey(),
+		LeafVersion:     txscript.BaseLeafVersion,
+		OutputKeyYIsOdd: outputKey.SerializeCompressed()[0] == 0x03,
+	}
+	controlBytes, _ := controlBlock.ToBytes()
+
+	witness := append(initialStack, script, controlBytes)
+	tx.TxIn[0].Witness = witness
+
+	// Step 4: Return the taproot output script that commits to the witness
+	// script above.
+	scriptPubKey, _ := txscript.PayToTaprootScript(outputKey)
+	return tx, scriptPubKey
+}
+
+func fuzzPrevFetcher(t *testing.T, consumer *fuzz.ConsumeFuzzer, tx *wire.MsgTx, txIdx int) (ArkPrevOutFetcher, int64) {
+	t.Helper()
+
+	// Step 1: Build a random prevout set for every input in the transaction.
+	prevouts := make(map[wire.OutPoint]*wire.TxOut, len(tx.TxIn))
+	for _, txIn := range tx.TxIn {
+		pkScript, _ := consumer.GetBytes()
+		value, _ := consumer.GetInt()
+		prevouts[txIn.PreviousOutPoint] = &wire.TxOut{
+			Value:    int64(value),
+			PkScript: pkScript,
+		}
+	}
+
+	// Step 2: Return both the fetcher and the selected prevout amount when the
+	// index is valid.
+	fetcher := newTestArkPrevOutFetcher(txscript.NewMultiPrevOutFetcher(prevouts), nil, nil)
+	inputAmount := int64(0)
+	if txIdx >= 0 && txIdx < len(tx.TxIn) {
+		if prev := fetcher.FetchPrevOutput(tx.TxIn[txIdx].PreviousOutPoint); prev != nil {
+			inputAmount = prev.Value
+		}
+	}
+	return fetcher, inputAmount
+}
+
+func normalizePrivKeySeed(seed []byte) []byte {
+	key := make([]byte, 32)
+	copy(key, seed)
+
+	allZero := true
+	for _, b := range key {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		key[0] = 1
+	}
+
+	return key
+}

--- a/pkg/arkade/fuzz_utils_test.go
+++ b/pkg/arkade/fuzz_utils_test.go
@@ -1,0 +1,503 @@
+package arkade
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	scriptlib "github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// fuzzWorldParams is decoded from fuzz bytes to drive the shape of a generated
+// transaction world. Fields are named for their semantic role so the struct
+// layout is stable across corpus runs.
+type fuzzWorldParams struct {
+	InputCountSeed       uint8
+	OutputCountSeed      uint8
+	BasePrevOutIndex     uint32
+	BaseSequence         uint32
+	BaseInputValue       int64
+	BaseOutputValue      int64
+	InputScriptTypeSeed  uint8
+	OutputScriptTypeSeed uint8
+	TxVersionSeed        int32
+	LockTimeSeed         uint32
+}
+
+// opcodeFuzzWorld bundles a coherent transaction world together with the PSBT
+// and signer key that are needed to validate arkade script submissions.
+type opcodeFuzzWorld struct {
+	world           *opcodeWorld
+	ptx             *psbt.Packet
+	signerPublicKey *btcec.PublicKey
+}
+
+// buildFuzzWorld derives a transaction, prevout set, introspector packet, and
+// asset packet that are internally consistent enough for most opcodes to run.
+// This intentionally biases toward "valid enough to execute" instead of fully
+// unconstrained randomness so the fuzzer spends more time inside opcode logic.
+func buildFuzzWorld(data []byte) *opcodeFuzzWorld {
+	params := fuzzStructFromBytes[fuzzWorldParams](saltedBytes(data, 0xa0))
+	inputCount := int(params.InputCountSeed%fuzzMaxInOutCount) + 1
+	outputCount := int(params.OutputCountSeed % fuzzMaxInOutCount)
+
+	txIn := make([]*wire.TxIn, inputCount)
+	prevouts := make(map[wire.OutPoint]*wire.TxOut, inputCount)
+	arkTxs := make(map[wire.OutPoint]*wire.MsgTx, inputCount)
+	prevoutIdxs := make(map[wire.OutPoint]uint32, inputCount)
+	scriptByVin := make(map[int][]byte, inputCount)
+	execScriptByVin := make(map[int][]byte, inputCount)
+	witnessByVin := make(map[int]wire.TxWitness, inputCount)
+	entries := make([]IntrospectorEntry, 0, inputCount)
+
+	for i := range inputCount {
+		h := hashWithSalt(data, byte(i))
+		outpoint := wire.OutPoint{Hash: h, Index: params.BasePrevOutIndex + uint32(i)}
+		txIn[i] = &wire.TxIn{
+			PreviousOutPoint: outpoint,
+			Sequence:         params.BaseSequence + uint32(i),
+		}
+
+		pkScript := []byte{OP_1, 0x20}
+		pkScript = append(pkScript, h[:]...)
+
+		prevouts[outpoint] = &wire.TxOut{
+			Value:    params.BaseInputValue + int64(i),
+			PkScript: pkScript,
+		}
+
+		scriptByVin[i] = []byte{OP_TRUE}
+		entryWitness := wire.TxWitness{h[:], h[:16]}
+		entries = append(entries, IntrospectorEntry{
+			Vin:     uint16(i),
+			Script:  cloneBytes(scriptByVin[i]),
+			Witness: cloneWitness(entryWitness),
+		})
+
+		prevPacketType := uint8(2 + h[0]%200)
+		prevPayloadLen := int(h[1]%32) + 1
+		prevTx := makeOpcodeTxWithExtension(extension.UnknownPacket{
+			PacketType: prevPacketType,
+			Data:       cloneBytes(h[:prevPayloadLen]),
+		})
+		prevScript := append([]byte{OP_1, 0x20}, h[:]...)
+		prevTx.TxOut = append([]*wire.TxOut{{
+			Value:    params.BaseInputValue + int64(i),
+			PkScript: prevScript,
+		}}, prevTx.TxOut...)
+		arkTxs[outpoint] = &prevTx
+		prevoutIdxs[outpoint] = 0
+
+		if h[2]&1 == 0 {
+			execScript := []byte{OP_TRUE}
+			execStack := wire.TxWitness{}
+			switch h[3] % 3 {
+			case 1:
+				execScript = []byte{OP_DUP, OP_DROP, OP_TRUE}
+				execStack = wire.TxWitness{[]byte{0x01}}
+			case 2:
+				execScript = []byte{OP_IF, OP_TRUE, OP_ELSE, OP_TRUE, OP_ENDIF}
+				execStack = wire.TxWitness{[]byte{0x01}}
+			}
+
+			internalPriv, _ := btcec.PrivKeyFromBytes(saltedBytes(data, byte(0x40+i)))
+			leaf := txscript.NewBaseTapLeaf(execScript)
+			leafHash := leaf.TapHash()
+			outputKey := txscript.ComputeTaprootOutputKey(internalPriv.PubKey(), leafHash[:])
+			controlBlock := &txscript.ControlBlock{
+				InternalKey:     internalPriv.PubKey(),
+				LeafVersion:     txscript.BaseLeafVersion,
+				OutputKeyYIsOdd: outputKey.SerializeCompressed()[0] == 0x03,
+			}
+			controlBytes, err := controlBlock.ToBytes()
+			if err != nil {
+				return nil
+			}
+			scriptPubKey, err := txscript.PayToTaprootScript(outputKey)
+			if err != nil {
+				return nil
+			}
+
+			execScriptByVin[i] = scriptPubKey
+			witnessByVin[i] = append(cloneWitness(execStack), cloneBytes(execScript), cloneBytes(controlBytes))
+		}
+	}
+
+	packet, err := NewPacket(entries...)
+	if err != nil {
+		return nil
+	}
+	assetPacket := buildFuzzAssetPacket(data, inputCount, outputCount)
+
+	txOut := make([]*wire.TxOut, outputCount)
+	for i := range outputCount {
+		txOut[i] = &wire.TxOut{
+			Value:    params.BaseOutputValue + int64(i),
+			PkScript: []byte{OP_TRUE},
+		}
+	}
+
+	ext := extension.Extension{assetPacket, packet}
+	packetOut, err := ext.TxOut()
+	if err != nil {
+		return nil
+	}
+	txOut = append(txOut, packetOut)
+
+	tx := wire.MsgTx{
+		Version:  params.TxVersionSeed,
+		LockTime: params.LockTimeSeed,
+		TxIn:     txIn,
+		TxOut:    txOut,
+	}
+
+	parsedPacket, err := FindIntrospectorPacket(&tx)
+	if err != nil || len(parsedPacket) == 0 {
+		return nil
+	}
+
+	ptx, err := psbt.NewFromUnsignedTx(&tx)
+	if err != nil {
+		return nil
+	}
+
+	privKey, _ := btcec.PrivKeyFromBytes(saltedBytes(data, 0x44))
+	signerPubKey := privKey.PubKey()
+
+	for _, entry := range parsedPacket {
+		vin := int(entry.Vin)
+		if vin < 0 || vin >= len(ptx.Inputs) {
+			return nil
+		}
+
+		tweakedPubKey := ComputeArkadeScriptPublicKey(signerPubKey, ArkadeScriptHash(entry.Script))
+		closure := &scriptlib.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{tweakedPubKey},
+			Type:    scriptlib.MultisigTypeChecksig,
+		}
+		tapScript, err := closure.Script()
+		if err != nil {
+			return nil
+		}
+
+		ptx.Inputs[vin].TaprootLeafScript = []*psbt.TaprootTapLeafScript{{
+			Script: tapScript,
+		}}
+	}
+
+	return &opcodeFuzzWorld{
+		world: &opcodeWorld{
+			tx:              tx,
+			prevouts:        prevouts,
+			prevFetcher:     newTestArkPrevOutFetcher(txscript.NewMultiPrevOutFetcher(prevouts), arkTxs, prevoutIdxs),
+			assetPacket:     assetPacket,
+			scriptByVin:     scriptByVin,
+			execScriptByVin: execScriptByVin,
+			witnessByVin:    witnessByVin,
+			packet:          parsedPacket,
+		},
+		ptx:             ptx,
+		signerPublicKey: signerPubKey,
+	}
+}
+
+// buildMinimalEngineWorld returns the simplest valid opcodeWorld that
+// NewEngine will accept: one input, one prevout, no asset/introspector
+// packets. It is used by engine fuzzers when buildFuzzWorld returns nil.
+func buildMinimalEngineWorld(data []byte) *opcodeWorld {
+	h := hashWithSalt(data, 0x01)
+	outpoint := wire.OutPoint{Hash: h, Index: 0}
+	tx := wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: outpoint}},
+		TxOut:   []*wire.TxOut{{Value: 1000, PkScript: []byte{OP_TRUE}}},
+	}
+	prevouts := map[wire.OutPoint]*wire.TxOut{
+		outpoint: {Value: 1000, PkScript: []byte{OP_1, 0x20}},
+	}
+	return &opcodeWorld{
+		tx:          tx,
+		prevouts:    prevouts,
+		prevFetcher: newTestArkPrevOutFetcher(txscript.NewMultiPrevOutFetcher(prevouts), nil, nil),
+	}
+}
+
+// setEnginePacketsFromWorld attaches the introspector and asset packets stored
+// in world to an already-constructed Engine.
+func setEnginePacketsFromWorld(vm *Engine, world *opcodeWorld) {
+	vm.SetIntrospectorPacket(world.packet)
+	if world.assetPacket != nil {
+		vm.SetAssetPacket(world.assetPacket)
+		return
+	}
+
+	ext, err := extension.NewExtensionFromTx(&world.tx)
+	if err != nil {
+		return
+	}
+	if packet := ext.GetAssetPacket(); packet != nil {
+		vm.SetAssetPacket(packet)
+	}
+}
+
+// buildFuzzAssetPacket fuzzes asset packet structure while normalizing invalid
+// constructions back to a minimal fallback packet. That keeps asset opcodes in
+// play even when a particular random shape does not satisfy packet invariants.
+func buildFuzzAssetPacket(data []byte, inputCount int, outputCount int) asset.Packet {
+	seed := saltedBytes(data, 0xb0)
+	groupCount := int(seed[0]%fuzzMaxAssetGroupCount) + 1
+	txOutputCount := outputCount + 1
+	if txOutputCount <= 0 {
+		txOutputCount = 1
+	}
+
+	groups := make([]asset.AssetGroup, 0, groupCount)
+	seenAssetIDs := make(map[asset.AssetId]struct{}, groupCount)
+
+	for i := range groupCount {
+		groupSeed := saltedBytes(data, byte(0xb1+i))
+		groups = append(groups, buildFuzzAssetGroup(groupSeed, data, i, groupCount, inputCount, txOutputCount, seenAssetIDs))
+	}
+
+	packet, err := asset.NewPacket(groups)
+	if err == nil {
+		return packet
+	}
+
+	fallback, _ := asset.NewPacket([]asset.AssetGroup{fallbackFuzzAssetGroup()})
+	return fallback
+}
+
+func buildFuzzAssetGroup(
+	seed []byte,
+	data []byte,
+	groupIndex int,
+	groupCount int,
+	inputCount int,
+	txOutputCount int,
+	seenAssetIDs map[asset.AssetId]struct{},
+) asset.AssetGroup {
+	issuance := seed[0]&1 == 0
+
+	var assetID *asset.AssetId
+	if !issuance {
+		candidate := uniqueFuzzAssetID(data, groupIndex, seenAssetIDs)
+		assetID = &candidate
+	}
+
+	var controlAsset *asset.AssetRef
+	if issuance && seed[1]&1 == 1 {
+		if groupCount > 1 && seed[2]&1 == 0 {
+			controlAsset = &asset.AssetRef{
+				Type:       asset.AssetRefByGroup,
+				GroupIndex: uint16(seed[3]) % uint16(groupCount),
+			}
+		} else {
+			controlAsset = &asset.AssetRef{
+				Type: asset.AssetRefByID,
+				AssetId: asset.AssetId{
+					Txid:  nonZeroHashFromSeed(saltedBytes(seed, 0x44)),
+					Index: uint16(seed[4]),
+				},
+			}
+		}
+	}
+
+	outputCount := int(seed[5] % fuzzMaxAssetItemCount)
+	if issuance && outputCount == 0 {
+		outputCount = 1
+	}
+	outputs := make([]asset.AssetOutput, 0, outputCount)
+	for i := range outputCount {
+		itemSeed := saltedBytes(seed, byte(0x50+i))
+		outputs = append(outputs, asset.AssetOutput{
+			Type:   asset.AssetOutputTypeLocal,
+			Vout:   uint16(binary.LittleEndian.Uint16(itemSeed[:2]) % uint16(txOutputCount)),
+			Amount: uint64(binary.LittleEndian.Uint32(itemSeed[2:6])) + 1,
+		})
+	}
+
+	var inputs []asset.AssetInput
+	if !issuance {
+		inputItems := int(seed[6] % fuzzMaxAssetItemCount)
+		if inputItems == 0 && len(outputs) == 0 {
+			inputItems = 1
+		}
+
+		inputs = make([]asset.AssetInput, 0, inputItems)
+		for i := range inputItems {
+			itemSeed := saltedBytes(seed, byte(0x70+i))
+			input := asset.AssetInput{
+				Type:   asset.AssetInputTypeLocal,
+				Vin:    uint16(binary.LittleEndian.Uint16(itemSeed[1:3]) % uint16(inputCount)),
+				Amount: uint64(binary.LittleEndian.Uint32(itemSeed[3:7])) + 1,
+			}
+			if itemSeed[0]&1 == 1 {
+				input.Type = asset.AssetInputTypeIntent
+				input.Txid = nonZeroHashFromSeed(saltedBytes(itemSeed, 0x71))
+			}
+			inputs = append(inputs, input)
+		}
+	}
+
+	metadataCount := int(seed[7] % fuzzMaxMetadataCount)
+	metadata := make([]asset.Metadata, 0, metadataCount)
+	for i := range metadataCount {
+		itemSeed := saltedBytes(seed, byte(0x90+i))
+		metadata = append(metadata, asset.Metadata{
+			Key:   fuzzMetadataField(itemSeed[0], itemSeed[1:16]),
+			Value: fuzzMetadataField(itemSeed[16], itemSeed[17:32]),
+		})
+	}
+
+	return asset.AssetGroup{
+		AssetId:      assetID,
+		ControlAsset: controlAsset,
+		Inputs:       inputs,
+		Outputs:      outputs,
+		Metadata:     metadata,
+	}
+}
+
+func uniqueFuzzAssetID(data []byte, groupIndex int, seen map[asset.AssetId]struct{}) asset.AssetId {
+	for attempt := range 16 {
+		seed := saltedBytes(data, byte(0xc0+groupIndex+attempt))
+		candidate := asset.AssetId{
+			Txid:  nonZeroHashFromSeed(seed),
+			Index: uint16(binary.LittleEndian.Uint16(seed[:2])),
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		return candidate
+	}
+
+	fallback := asset.AssetId{Txid: nonZeroHashFromSeed(saltedBytes(data, byte(0xe0+groupIndex))), Index: uint16(groupIndex)}
+	seen[fallback] = struct{}{}
+	return fallback
+}
+
+func fallbackFuzzAssetGroup() asset.AssetGroup {
+	return asset.AssetGroup{
+		Outputs: []asset.AssetOutput{{
+			Type:   asset.AssetOutputTypeLocal,
+			Vout:   0,
+			Amount: 1,
+		}},
+	}
+}
+
+func nonZeroHashFromSeed(seed []byte) [32]byte {
+	h := hashWithSalt(seed, 0xaa)
+	allZero := true
+	for _, b := range h {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		h[0] = 1
+	}
+	return h
+}
+
+func fuzzMetadataField(sizeSeed byte, pool []byte) []byte {
+	if len(pool) == 0 {
+		return []byte{1}
+	}
+	length := int(sizeSeed%12) + 1
+	out := make([]byte, length)
+	for i := range length {
+		out[i] = pool[i%len(pool)]
+		if out[i] == 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+// saltedBytes deterministically derives 32 bytes from data and a salt byte.
+// Every opcode/engine fuzz case uses a different salt so one raw fuzz input
+// drives many independent but reproducible sub-inputs.
+func saltedBytes(data []byte, salt byte) []byte {
+	b := make([]byte, len(data)+1)
+	copy(b, data)
+	b[len(data)] = salt
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+// fuzzStructFromBytes populates any struct T from fuzz bytes using the
+// go-fuzz-headers consumer, which fills fields in declaration order.
+func fuzzStructFromBytes[T any](data []byte) T {
+	var params T
+	consumer := fuzz.NewConsumer(data)
+	_ = consumer.GenerateStruct(&params)
+	return params
+}
+
+// fuzzStackItems decodes a small number of arbitrary byte slices from fuzz
+// data to use as pre-loaded stack items.
+func fuzzStackItems(data []byte) [][]byte {
+	consumer := fuzz.NewConsumer(data)
+	numItems, _ := consumer.GetInt()
+	if numItems < 0 {
+		numItems = -numItems
+	}
+	numItems %= 10
+
+	items := make([][]byte, 0, numItems)
+	for range numItems {
+		item, _ := consumer.GetBytes()
+		if len(item) > 520 {
+			item = item[:520]
+		}
+		items = append(items, cloneBytes(item))
+	}
+
+	return items
+}
+
+// cloneBytes returns a deep copy of b, or nil if b is nil.
+func cloneBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	clone := make([]byte, len(b))
+	copy(clone, b)
+	return clone
+}
+
+// clone2DBytes returns a deep copy of a slice of byte slices.
+func clone2DBytes(items [][]byte) [][]byte {
+	if items == nil {
+		return nil
+	}
+
+	clone := make([][]byte, len(items))
+	for i := range items {
+		clone[i] = cloneBytes(items[i])
+	}
+	return clone
+}
+
+// cloneWitness returns a deep copy of a transaction witness stack.
+func cloneWitness(w wire.TxWitness) wire.TxWitness {
+	if w == nil {
+		return nil
+	}
+
+	clone := make(wire.TxWitness, len(w))
+	for i := range w {
+		clone[i] = cloneBytes(w[i])
+	}
+	return clone
+}

--- a/pkg/arkade/go.mod
+++ b/pkg/arkade/go.mod
@@ -3,6 +3,7 @@ module github.com/ArkLabsHQ/introspector/pkg/arkade
 go 1.26.2
 
 require (
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5

--- a/pkg/arkade/go.sum
+++ b/pkg/arkade/go.sum
@@ -1,3 +1,5 @@
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70 h1:qLdbRS0rlHYjQuX0FWgJsvb+CE0U/m0q6Amy8WOvocA=
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70/go.mod h1:VpyqrRS8Qk3uAhUTiH417gyC52caAfan/o8aVPDO528=

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -2861,6 +2861,10 @@ func opcodeInspectInputPacket(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidStackOperation, "packet type out of range")
 	}
 
+	if vm.prevOutFetcher == nil {
+		return scriptError(txscript.ErrInvalidIndex, "previous output fetcher not set")
+	}
+
 	outpoint := vm.tx.TxIn[int(index)].PreviousOutPoint
 	prevTx := vm.prevOutFetcher.FetchPrevOutArkTx(outpoint)
 	if prevTx == nil {

--- a/pkg/arkade/opcode_fuzz_test.go
+++ b/pkg/arkade/opcode_fuzz_test.go
@@ -1,0 +1,881 @@
+package arkade
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+const fuzzMaxInOutCount = 200
+
+const (
+	fuzzMaxAssetGroupCount = 16
+	fuzzMaxAssetItemCount  = 16
+	fuzzMaxMetadataCount   = 8
+
+	fuzzSerializedSetupPushLimit = 3
+	fuzzSerializedSetupPushSize  = 32
+)
+
+type fuzzIndexSource struct {
+	IndexSeed uint8
+	IndexMode uint8
+}
+
+type opcodeFuzzCase struct {
+	stackPushes    [][]byte
+	altStackPushes [][]byte
+	condStack      []int
+	txIdx          int
+	opcodeData     []byte
+}
+
+type fuzzExecutionSource struct {
+	TxSeed   uint8
+	AltSeed  uint8
+	CondSeed uint8
+	Mode     uint8
+}
+
+type fuzzCaseBuilder interface {
+	Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase
+}
+
+type defaultCaseBuilder struct{}
+
+func (defaultCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	seed := fuzzStructFromBytes[fuzzExecutionSource](data)
+	c := opcodeFuzzCase{
+		stackPushes: fuzzStackItems(data),
+		txIdx:       0,
+	}
+	if len(world.world.tx.TxIn) > 0 {
+		c.txIdx = int(seed.TxSeed) % len(world.world.tx.TxIn)
+	}
+	if seed.Mode&1 == 0 {
+		c.altStackPushes = fuzzStackItems(saltedBytes(data, seed.AltSeed))
+	}
+	switch seed.CondSeed % 5 {
+	case 1:
+		c.condStack = []int{OpCondTrue}
+	case 2:
+		c.condStack = []int{OpCondFalse}
+	case 3:
+		c.condStack = []int{OpCondSkip}
+	case 4:
+		c.condStack = []int{OpCondTrue, []int{OpCondFalse, OpCondSkip}[seed.Mode%2]}
+	}
+	return c
+}
+
+type indexCaseBuilder struct {
+	isOut bool
+}
+
+func (b indexCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	seed := fuzzStructFromBytes[fuzzIndexSource](data)
+	count := len(world.world.tx.TxIn)
+	if b.isOut {
+		count = len(world.world.tx.TxOut)
+	}
+	idx := deriveIndex(seed.IndexSeed, seed.IndexMode, count)
+	c.stackPushes = [][]byte{scriptNum(idx).Bytes()}
+	return c
+}
+
+type pushDataCaseBuilder struct {
+	opcode byte
+}
+
+func (b pushDataCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	payload := buildPushDataPayload(b.opcode, data)
+	c.opcodeData = payload
+	return c
+}
+
+type packetCaseBuilder struct{}
+
+func (packetCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	packetType := scriptNum(int64(data[0]))
+	if ext, err := extension.NewExtensionFromTx(&world.world.tx); err == nil && len(ext) > 0 {
+		packet := ext[int(data[0])%len(ext)]
+		packetType = scriptNum(packet.Type())
+		if data[1]&1 == 1 {
+			packetType = scriptNum((int64(packet.Type()) + 1) & 0xff)
+		}
+	}
+	c.stackPushes = [][]byte{packetType.Bytes()}
+	return c
+}
+
+type inputPacketCaseBuilder struct{}
+
+func (inputPacketCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	if len(world.world.tx.TxIn) == 0 {
+		c.stackPushes = [][]byte{nil, nil}
+		return c
+	}
+	inputIdx := int(data[0]) % len(world.world.tx.TxIn)
+	packetType := scriptNum(int64(data[1]))
+	prevTx := world.world.prevFetcher.FetchPrevOutArkTx(world.world.tx.TxIn[inputIdx].PreviousOutPoint)
+	if prevTx != nil {
+		if ext, err := extension.NewExtensionFromTx(prevTx); err == nil && len(ext) > 0 {
+			packet := ext[int(data[1])%len(ext)]
+			packetType = scriptNum(packet.Type())
+			if data[2]&1 == 1 {
+				packetType = scriptNum((int64(packet.Type()) + 1) & 0xff)
+			}
+		}
+	}
+	c.stackPushes = [][]byte{packetType.Bytes(), scriptNum(inputIdx).Bytes()}
+	return c
+}
+
+type assetIDLookupCaseBuilder struct{}
+
+func (assetIDLookupCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	var txid []byte
+	groupRef := int64(0)
+	if world.world.assetPacket != nil && len(world.world.assetPacket) > 0 {
+		groupIdx := int(data[0]) % len(world.world.assetPacket)
+		group := world.world.assetPacket[groupIdx]
+		groupRef = int64(groupIdx)
+		if group.AssetId == nil {
+			txHash := world.world.tx.TxHash()
+			txid = cloneBytes(txHash[:])
+		} else {
+			groupRef = int64(group.AssetId.Index)
+			txid = cloneBytes(group.AssetId.Txid[:])
+		}
+		if data[1]&1 == 1 {
+			groupRef += int64(len(world.world.assetPacket))
+		}
+	}
+	if len(txid) == 0 {
+		txid = make([]byte, 32)
+	}
+	if data[2]&1 == 1 {
+		txid[0] ^= 0xff
+	}
+	c.stackPushes = [][]byte{txid, scriptNum(groupRef).Bytes()}
+	return c
+}
+
+type taprootCheckSigCaseBuilder struct{}
+
+func (taprootCheckSigCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	for txIdx := range world.world.execScriptByVin {
+		c.txIdx = txIdx
+		break
+	}
+	c.stackPushes = [][]byte{nil, cloneBytes(saltedBytes(data, 0x91))}
+	return c
+}
+
+type taprootCheckSigAddCaseBuilder struct{}
+
+func (taprootCheckSigAddCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	for txIdx := range world.world.execScriptByVin {
+		c.txIdx = txIdx
+		break
+	}
+	c.stackPushes = [][]byte{nil, scriptNum(int64(data[0] % 4)).Bytes(), cloneBytes(saltedBytes(data, 0x92))}
+	return c
+}
+
+type assetGroupCaseBuilder struct{}
+
+func (assetGroupCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	idx := int64(-1)
+	if world.world.assetPacket != nil && len(world.world.assetPacket) > 0 {
+		idx = int64(data[0] % uint8(len(world.world.assetPacket)))
+		if data[1]&1 == 1 {
+			idx = int64(len(world.world.assetPacket) + int(data[0]%4))
+		}
+	}
+	c.stackPushes = [][]byte{scriptNum(idx).Bytes()}
+	return c
+}
+
+type assetGroupSourceCaseBuilder struct{}
+
+func (assetGroupSourceCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := assetGroupCaseBuilder{}.Build(data, world)
+	source := scriptNum(int64(data[2] % 3))
+	if data[3]&1 == 1 {
+		source = scriptNum(3 + data[2]%3)
+	}
+	c.stackPushes = append(c.stackPushes, source.Bytes())
+	return c
+}
+
+type assetGroupItemSourceCaseBuilder struct{}
+
+func (assetGroupItemSourceCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	groupIdx := 0
+	if world.world.assetPacket != nil && len(world.world.assetPacket) > 0 {
+		groupIdx = int(data[0]) % len(world.world.assetPacket)
+	}
+	source := int64(data[1] % 2)
+	itemIdx := int64(0)
+	if world.world.assetPacket != nil && len(world.world.assetPacket) > 0 {
+		group := world.world.assetPacket[groupIdx]
+		count := len(group.Inputs)
+		if source == 1 {
+			count = len(group.Outputs)
+		}
+		if count > 0 {
+			itemIdx = int64(data[2] % uint8(count))
+		}
+		if data[3]&1 == 1 {
+			itemIdx = int64(count + int(data[2]%4))
+		}
+	}
+	if data[4]&1 == 1 {
+		source = 2
+	}
+	c.stackPushes = [][]byte{scriptNum(groupIdx).Bytes(), scriptNum(itemIdx).Bytes(), scriptNum(source).Bytes()}
+	return c
+}
+
+type assetIndexCaseBuilder struct {
+	isOut bool
+}
+
+func (b assetIndexCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	index := int64(0)
+	count := len(world.world.tx.TxIn)
+	if b.isOut {
+		count = len(world.world.tx.TxOut)
+	}
+	if count > 0 {
+		index = int64(data[0] % uint8(count))
+	}
+	if data[1]&1 == 1 {
+		index = int64(count + int(data[0]%4))
+	}
+	c.stackPushes = [][]byte{scriptNum(index).Bytes()}
+	return c
+}
+
+type assetAtCaseBuilder struct {
+	isOut bool
+}
+
+func (b assetAtCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	index := int64(0)
+	assetIdx := int64(0)
+	count := len(world.world.tx.TxIn)
+	if b.isOut {
+		count = len(world.world.tx.TxOut)
+	}
+	if count > 0 {
+		index = int64(data[0] % uint8(count))
+	}
+	if data[1]&1 == 1 {
+		index = int64(count + int(data[0]%4))
+	}
+	assetIdx = int64(data[2] % 4)
+	c.stackPushes = [][]byte{scriptNum(index).Bytes(), scriptNum(assetIdx).Bytes()}
+	return c
+}
+
+type assetLookupCaseBuilder struct {
+	isOut bool
+}
+
+func (b assetLookupCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	index := int64(0)
+	if b.isOut {
+		if len(world.world.tx.TxOut) > 0 {
+			index = int64(data[0] % uint8(len(world.world.tx.TxOut)))
+		}
+	} else if len(world.world.tx.TxIn) > 0 {
+		index = int64(data[0] % uint8(len(world.world.tx.TxIn)))
+	}
+
+	var txid []byte
+	groupIdx := int64(0)
+	if world.world.assetPacket != nil && len(world.world.assetPacket) > 0 {
+		group := world.world.assetPacket[int(data[1])%len(world.world.assetPacket)]
+		groupIdx = int64(int(data[1]) % len(world.world.assetPacket))
+		if group.AssetId == nil {
+			assetTxid := world.world.tx.TxHash()
+			txid = cloneBytes(assetTxid[:])
+		} else {
+			txid = cloneBytes(group.AssetId.Txid[:])
+		}
+		if data[2]&1 == 1 {
+			groupIdx = int64(len(world.world.assetPacket) + int(data[1]%4))
+		}
+	}
+	if len(txid) == 0 {
+		txid = make([]byte, 32)
+	}
+	if data[3]&1 == 1 {
+		txid[0] ^= 0xff
+	}
+	c.stackPushes = [][]byte{scriptNum(index).Bytes(), txid, scriptNum(groupIdx).Bytes()}
+	return c
+}
+
+var fuzzCaseBuilders = [256]fuzzCaseBuilder{
+	OP_INSPECTINPUTOUTPOINT:          indexCaseBuilder{},
+	OP_INSPECTINPUTSEQUENCE:          indexCaseBuilder{},
+	OP_INSPECTINPUTSCRIPTPUBKEY:      indexCaseBuilder{},
+	OP_INSPECTINPUTVALUE:             indexCaseBuilder{},
+	OP_INSPECTOUTPUTVALUE:            indexCaseBuilder{isOut: true},
+	OP_INSPECTOUTPUTSCRIPTPUBKEY:     indexCaseBuilder{isOut: true},
+	OP_INSPECTINPUTARKADESCRIPTHASH:  indexCaseBuilder{},
+	OP_INSPECTINPUTARKADEWITNESSHASH: indexCaseBuilder{},
+	OP_INSPECTPACKET:                 packetCaseBuilder{},
+	OP_INSPECTINPUTPACKET:            inputPacketCaseBuilder{},
+	OP_CODESEPARATOR:                 defaultCaseBuilder{},
+	OP_CHECKSIG:                      taprootCheckSigCaseBuilder{},
+	OP_CHECKSIGVERIFY:                taprootCheckSigCaseBuilder{},
+	OP_CHECKSIGADD:                   taprootCheckSigAddCaseBuilder{},
+	OP_FINDASSETGROUPBYASSETID:       assetIDLookupCaseBuilder{},
+	OP_INSPECTASSETGROUPASSETID:      assetGroupCaseBuilder{},
+	OP_INSPECTASSETGROUPCTRL:         assetGroupCaseBuilder{},
+	OP_INSPECTASSETGROUPMETADATAHASH: assetGroupCaseBuilder{},
+	OP_INSPECTASSETGROUPNUM:          assetGroupSourceCaseBuilder{},
+	OP_INSPECTASSETGROUP:             assetGroupItemSourceCaseBuilder{},
+	OP_INSPECTASSETGROUPSUM:          assetGroupSourceCaseBuilder{},
+	OP_INSPECTOUTASSETCOUNT:          assetIndexCaseBuilder{isOut: true},
+	OP_INSPECTOUTASSETAT:             assetAtCaseBuilder{isOut: true},
+	OP_INSPECTOUTASSETLOOKUP:         assetLookupCaseBuilder{isOut: true},
+	OP_INSPECTINASSETCOUNT:           assetIndexCaseBuilder{},
+	OP_INSPECTINASSETAT:              assetAtCaseBuilder{},
+	OP_INSPECTINASSETLOOKUP:          assetLookupCaseBuilder{},
+}
+
+// FuzzOpcodes turns one fuzz input into a coherent transaction world, derives a
+// reproducible case for every opcode, and then exercises those cases in three
+// complementary ways: isolated execution, stateful/chained execution, and a
+// serialized script pass that goes through the tokenizer and Step().
+func FuzzOpcodes(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(make([]byte, 32))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) < 10 {
+			return
+		}
+
+		fuzzWorld := buildFuzzWorld(data)
+		if fuzzWorld == nil {
+			return
+		}
+		if !validateSubmitTxPreconditions(fuzzWorld) {
+			return
+		}
+
+		opcodes := shuffledFuzzOpcodes(data)
+		cases := buildOpcodeFuzzCases(data, fuzzWorld)
+
+		runFreshOpcodeCases(t, fuzzWorld.world, opcodes, cases)
+		runChainedOpcodeCases(t, fuzzWorld.world, opcodes, cases)
+		runSerializedOpcodeScriptCases(t, fuzzWorld.world, opcodes, cases)
+	})
+}
+
+// runFreshOpcodeCases executes each opcode against a fresh VM so failures are
+// easy to attribute to a single opcode/case pair.
+func runFreshOpcodeCases(t *testing.T, world *opcodeWorld, opcodes []byte, cases [256]opcodeFuzzCase) {
+	t.Helper()
+
+	for i, opcode := range opcodes {
+		spec := opcodeSpecs[opcode]
+		if spec == nil {
+			continue
+		}
+
+		vm, err := newOpcodeEngine(world, cases[opcode].txIdx)
+		require.NoError(t, err)
+		setEnginePacketsFromWorld(vm, world)
+
+		// err is used in the chained case only
+		_ = executeOpcodeCase(t, vm, spec, cases[opcode], "fresh", i)
+	}
+}
+
+// runChainedOpcodeCases reuses one VM across many opcodes so fuzzing can expose
+// state interaction bugs that do not appear when every opcode starts from a
+// clean engine. The VM is reset after an error so later opcodes still get a run.
+func runChainedOpcodeCases(t *testing.T, world *opcodeWorld, opcodes []byte, cases [256]opcodeFuzzCase) {
+	t.Helper()
+
+	currentTxIdx := 0
+	vm, err := newOpcodeEngine(world, currentTxIdx)
+	require.NoError(t, err)
+	setEnginePacketsFromWorld(vm, world)
+
+	for i, opcode := range opcodes {
+		spec := opcodeSpecs[opcode]
+		if spec == nil {
+			continue
+		}
+		if cases[opcode].txIdx != currentTxIdx {
+			currentTxIdx = cases[opcode].txIdx
+			vm, err = newOpcodeEngine(world, currentTxIdx)
+			require.NoError(t, err)
+			setEnginePacketsFromWorld(vm, world)
+		}
+
+		err := executeOpcodeCase(t, vm, spec, cases[opcode], "chained", i)
+		if err != nil {
+			vm, err = newOpcodeEngine(world, currentTxIdx)
+			require.NoError(t, err)
+			setEnginePacketsFromWorld(vm, world)
+		}
+	}
+}
+
+// executeOpcodeCase applies the fuzz-generated stack setup, snapshots the VM,
+// executes the opcode through engine semantics, and then reuses the opcode spec
+// property checker as the oracle. The skipped-branch fast path exists because a
+// real engine now treats most opcodes as no-ops while a false conditional branch
+// is inactive.
+func executeOpcodeCase(t *testing.T, vm *Engine, spec *opcodeSpec, c opcodeFuzzCase, phase string, index int) error {
+	t.Helper()
+
+	applyOpcodeFuzzCase(vm, c)
+	branchExecuting := vm.isBranchExecuting()
+	before := cloneEngineForExpectedResult(vm)
+	err := invokeOpcodeWithData(spec.opcode, c.opcodeData, vm)
+	if !branchExecuting && !isOpcodeConditional(spec.opcode) && err == nil {
+		require.Equal(t, before.GetStack(), vm.GetStack())
+		require.Equal(t, before.GetAltStack(), vm.GetAltStack())
+		require.Equal(t, before.condStack, vm.condStack)
+		return nil
+	}
+
+	ctx := opcodeCheckContext{
+		before:     before,
+		after:      vm,
+		opcodeData: c.opcodeData,
+		execErr:    err,
+		opcode:     spec.opcode,
+		opcodeName: opcodeArray[spec.opcode].name,
+		phase:      phase,
+		order:      index,
+	}
+	if isAssetOpcode(spec.opcode) {
+		assetOpcodeFuzzChecker(t, ctx)
+	} else {
+		require.NotNil(t, spec.checkProperties)
+		failedBefore := t.Failed()
+		spec.checkProperties(t, ctx)
+		if !failedBefore && t.Failed() {
+			t.Logf(
+				"fuzz opcode failure: opcode=%s (0x%02x) phase=%s order=%d stack_before=%d stack_after=%d alt_before=%d alt_after=%d opcode_data_len=%d exec_err=%v",
+				ctx.opcodeName,
+				ctx.opcode,
+				ctx.phase,
+				ctx.order,
+				len(ctx.before.GetStack()),
+				len(ctx.after.GetStack()),
+				len(ctx.before.GetAltStack()),
+				len(ctx.after.GetAltStack()),
+				len(ctx.opcodeData),
+				ctx.execErr,
+			)
+		}
+	}
+
+	return err
+}
+
+// runSerializedOpcodeScriptCases adds an integration-style fuzz pass that packs
+// many opcode snippets into real scripts and executes them with Step(). Unlike
+// the direct opcode passes above, this exercises tokenizer/dispatch behavior and
+// script-level interactions. Errors are expected; the value is broader coverage
+// and panic/invariant detection rather than per-script success.
+func runSerializedOpcodeScriptCases(t *testing.T, world *opcodeWorld, opcodes []byte, cases [256]opcodeFuzzCase) {
+	t.Helper()
+
+	for _, script := range buildSerializedOpcodeScripts(opcodes, cases) {
+		vm, err := NewEngine(script, &world.tx, 0, nil, nil, 0, world.prevFetcher)
+		require.NoError(t, err)
+		setEnginePacketsFromWorld(vm, world)
+
+		for {
+			done, err := vm.Step()
+			if err != nil || done {
+				break
+			}
+		}
+	}
+}
+
+func isAssetOpcode(op byte) bool {
+	return op >= OP_INSPECTNUMASSETGROUPS && op <= OP_INSPECTINASSETLOOKUP
+}
+
+func assetOpcodeFuzzChecker(t *testing.T, c opcodeCheckContext) {
+	t.Helper()
+	require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+	require.Equal(t, c.before.condStack, c.after.condStack)
+	if c.execErr == nil {
+		return
+	}
+
+	requireScriptErrorCodeIn(t, c.execErr,
+		txscript.ErrInvalidStackOperation,
+		txscript.ErrNumberTooBig,
+		txscript.ErrMinimalData,
+	)
+}
+
+func applyOpcodeFuzzCase(vm *Engine, c opcodeFuzzCase) {
+	if c.condStack == nil {
+		vm.condStack = nil
+	} else {
+		vm.condStack = append(vm.condStack[:0], c.condStack...)
+	}
+	for _, item := range c.altStackPushes {
+		vm.astack.PushByteArray(cloneBytes(item))
+	}
+	for _, item := range c.stackPushes {
+		vm.dstack.PushByteArray(cloneBytes(item))
+	}
+}
+
+// buildSerializedOpcodeScripts concatenates many opcode snippets into scripts
+// that stay under the standard max script size. Splitting large permutations
+// into chunks keeps the serialized pass broad without making every input fail at
+// construction time.
+func buildSerializedOpcodeScripts(opcodes []byte, cases [256]opcodeFuzzCase) [][]byte {
+	scripts := make([][]byte, 0, 1)
+	current := make([]byte, 0, txscript.MaxScriptSize)
+
+	for _, opcode := range opcodes {
+		if opcodeSpecs[opcode] == nil {
+			continue
+		}
+
+		snippet := serializeOpcodeFuzzSnippet(opcode, cases[opcode])
+		if len(snippet) == 0 {
+			continue
+		}
+
+		if len(current) > 0 && len(current)+len(snippet) > txscript.MaxScriptSize {
+			scripts = append(scripts, current)
+			current = make([]byte, 0, txscript.MaxScriptSize)
+		}
+
+		current = append(current, snippet...)
+	}
+
+	if len(current) > 0 {
+		scripts = append(scripts, current)
+	}
+
+	return scripts
+}
+
+// serializeOpcodeFuzzSnippet turns one fuzz case into a small script fragment:
+// a bounded number of setup pushes followed by the target opcode encoding. The
+// bounds keep serialized scripts compact enough that many different opcodes can
+// appear in a single Step()-driven pass.
+func serializeOpcodeFuzzSnippet(opcode byte, c opcodeFuzzCase) []byte {
+	buf := make([]byte, 0, 128)
+	for i, item := range c.stackPushes {
+		if i >= fuzzSerializedSetupPushLimit {
+			break
+		}
+		if len(item) > fuzzSerializedSetupPushSize {
+			item = item[:fuzzSerializedSetupPushSize]
+		}
+		buf = appendSerializedPush(buf, item)
+	}
+	return appendSerializedOpcode(buf, opcode, c.opcodeData)
+}
+
+func appendSerializedPush(dst []byte, data []byte) []byte {
+	switch {
+	case len(data) == 0:
+		return append(dst, OP_0)
+	case len(data) == 1 && data[0] >= 1 && data[0] <= 16:
+		return append(dst, OP_1+data[0]-1)
+	case len(data) == 1 && data[0] == 0x81:
+		return append(dst, OP_1NEGATE)
+	case len(data) <= 75:
+		dst = append(dst, byte(len(data)))
+		return append(dst, data...)
+	case len(data) <= 255:
+		dst = append(dst, OP_PUSHDATA1, byte(len(data)))
+		return append(dst, data...)
+	default:
+		var lenBytes [2]byte
+		binary.LittleEndian.PutUint16(lenBytes[:], uint16(len(data)))
+		dst = append(dst, OP_PUSHDATA2)
+		dst = append(dst, lenBytes[:]...)
+		return append(dst, data...)
+	}
+}
+
+func appendSerializedOpcode(dst []byte, opcode byte, data []byte) []byte {
+	op := &opcodeArray[opcode]
+	if data == nil && op.length > 1 {
+		data = make([]byte, op.length-1)
+	}
+
+	if opcode >= OP_DATA_1 && opcode <= OP_DATA_75 {
+		payload := data
+		wantLen := int(opcode)
+		if len(payload) > wantLen {
+			payload = payload[:wantLen]
+		} else if len(payload) < wantLen {
+			payload = append(cloneBytes(payload), make([]byte, wantLen-len(payload))...)
+		}
+		dst = append(dst, opcode)
+		return append(dst, payload...)
+	}
+
+	switch opcode {
+	case OP_PUSHDATA1:
+		dst = append(dst, opcode, byte(len(data)))
+		return append(dst, data...)
+	case OP_PUSHDATA2:
+		var lenBytes [2]byte
+		binary.LittleEndian.PutUint16(lenBytes[:], uint16(len(data)))
+		dst = append(dst, opcode)
+		dst = append(dst, lenBytes[:]...)
+		return append(dst, data...)
+	case OP_PUSHDATA4:
+		var lenBytes [4]byte
+		binary.LittleEndian.PutUint32(lenBytes[:], uint32(len(data)))
+		dst = append(dst, opcode)
+		dst = append(dst, lenBytes[:]...)
+		return append(dst, data...)
+	default:
+		return append(dst, opcode)
+	}
+}
+
+// validateSubmitTxPreconditions filters out worlds that fail for unrelated
+// transaction/packet setup reasons before any opcode is exercised. That keeps
+// the fuzz signal focused on opcode behavior instead of repeatedly rediscovering
+// invalid arkade submission scaffolding.
+func validateSubmitTxPreconditions(fuzzWorld *opcodeFuzzWorld) bool {
+	if fuzzWorld == nil || fuzzWorld.world == nil {
+		return false
+	}
+	if fuzzWorld.ptx == nil || fuzzWorld.signerPublicKey == nil {
+		return false
+	}
+	if len(fuzzWorld.world.packet) == 0 {
+		return false
+	}
+
+	for _, entry := range fuzzWorld.world.packet {
+		script, err := ReadArkadeScript(fuzzWorld.ptx, fuzzWorld.signerPublicKey, entry)
+		if err != nil {
+			return false
+		}
+
+		vin := int(entry.Vin)
+		if vin < 0 || vin >= len(fuzzWorld.world.tx.TxIn) {
+			return false
+		}
+
+		inputAmount := int64(0)
+		if fuzzWorld.world.prevFetcher != nil {
+			prevOut := fuzzWorld.world.prevFetcher.FetchPrevOutput(fuzzWorld.world.tx.TxIn[vin].PreviousOutPoint)
+			if prevOut != nil {
+				inputAmount = prevOut.Value
+			}
+		}
+
+		_, err = NewEngine(
+			script.Script(),
+			&fuzzWorld.world.tx,
+			vin,
+			nil,
+			nil,
+			inputAmount,
+			fuzzWorld.world.prevFetcher,
+		)
+		if err != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+// buildOpcodeFuzzCases deterministically derives one case per opcode from the
+// same top-level fuzz input by salting the bytes with the opcode value. This
+// gives broad per-input coverage while keeping failures reproducible.
+func buildOpcodeFuzzCases(data []byte, world *opcodeFuzzWorld) [256]opcodeFuzzCase {
+	var cases [256]opcodeFuzzCase
+
+	for opcode := range 256 {
+		if opcodeSpecs[opcode] == nil {
+			continue
+		}
+
+		opcodeVal := byte(opcode)
+		builder := fuzzCaseBuilders[opcode]
+		if builder == nil {
+			if isPushDataOpcode(opcodeVal) {
+				builder = pushDataCaseBuilder{opcode: opcodeVal}
+			} else {
+				builder = defaultCaseBuilder{}
+			}
+		}
+
+		cases[opcode] = builder.Build(saltedBytes(data, opcodeVal), world)
+	}
+
+	return cases
+}
+
+// shuffledFuzzOpcodes permutes the opcode order deterministically for a given
+// input so chained/script passes explore different interaction orders while
+// still being reproducible when a crash or assertion fires.
+func shuffledFuzzOpcodes(data []byte) []byte {
+	opcodes := make([]byte, 0, 256)
+	for i := range 256 {
+		if opcodeSpecs[i] != nil {
+			opcodes = append(opcodes, byte(i))
+		}
+	}
+
+	seedBytes := saltedBytes(data, 0xfe)
+	seed := int64(binary.LittleEndian.Uint64(seedBytes[:8]))
+	rng := rand.New(rand.NewSource(seed))
+	rng.Shuffle(len(opcodes), func(i, j int) {
+		opcodes[i], opcodes[j] = opcodes[j], opcodes[i]
+	})
+
+	return opcodes
+}
+
+func deriveIndex(indexSeed uint8, indexMode uint8, count int) int64 {
+	switch indexMode % 4 {
+	case 0:
+		if count == 0 {
+			return 0
+		}
+		return int64(indexSeed % uint8(count))
+	case 1:
+		return -1 - int64(indexSeed%32)
+	case 2:
+		return int64(count) + int64(indexSeed%32)
+	default:
+		return 1<<31 - int64(indexSeed)
+	}
+}
+
+func isPushDataOpcode(opcode byte) bool {
+	if opcode >= OP_DATA_1 && opcode <= OP_DATA_75 {
+		return true
+	}
+
+	switch opcode {
+	case OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildPushDataPayload(opcode byte, seed []byte) []byte {
+	length := pushDataPayloadLength(opcode, seed)
+	if length == 0 {
+		return nil
+	}
+
+	payload := make([]byte, length)
+	for i := range length {
+		payload[i] = seed[(i+1)%len(seed)] ^ byte(i)
+	}
+	return payload
+}
+
+func pushDataPayloadLength(opcode byte, seed []byte) int {
+	if opcode >= OP_DATA_1 && opcode <= OP_DATA_75 {
+		return int(opcode)
+	}
+
+	switch opcode {
+	case OP_PUSHDATA1:
+		return int(seed[0] % 76)
+	case OP_PUSHDATA2:
+		return int(binary.LittleEndian.Uint16(seed[:2]) % 128)
+	case OP_PUSHDATA4:
+		return int(binary.LittleEndian.Uint32(seed[:4]) % 196)
+	default:
+		return 0
+	}
+}
+
+func cloneEngineForExpectedResult(vm *Engine) *Engine {
+	clone := *vm
+
+	txCopy := vm.tx.Copy()
+	if txCopy != nil {
+		clone.tx = *txCopy
+	}
+
+	clone.scripts = clone2DBytes(vm.scripts)
+	if vm.condStack == nil {
+		clone.condStack = nil
+	} else {
+		clone.condStack = make([]int, len(vm.condStack))
+		copy(clone.condStack, vm.condStack)
+	}
+	clone.witnessProgram = cloneBytes(vm.witnessProgram)
+	clone.dstack = cloneStack(vm.dstack)
+	clone.astack = cloneStack(vm.astack)
+	clone.introspectorPacket = cloneIntrospectorPacket(vm.introspectorPacket)
+
+	if vm.taprootCtx != nil {
+		taprootCtx := *vm.taprootCtx
+		taprootCtx.annex = cloneBytes(vm.taprootCtx.annex)
+		clone.taprootCtx = &taprootCtx
+	}
+
+	return &clone
+}
+
+func cloneStack(s stack) stack {
+	clone := s
+	clone.stk = clone2DBytes(s.stk)
+	return clone
+}
+
+func cloneIntrospectorPacket(packet IntrospectorPacket) IntrospectorPacket {
+	if packet == nil {
+		return nil
+	}
+
+	clone := make(IntrospectorPacket, len(packet))
+	for i, entry := range packet {
+		clone[i] = IntrospectorEntry{
+			Vin:     entry.Vin,
+			Script:  cloneBytes(entry.Script),
+			Witness: cloneWitness(entry.Witness),
+		}
+	}
+
+	return clone
+}

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -1,456 +1,4819 @@
-// Copyright (c) 2013-2017 The btcsuite developers
-// Use of this source code is governed by an ISC
-// license that can be found in the LICENSE file.
-
 package arkade
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"math"
+	"math/big"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
 )
 
-// TestOpcodeDisasm tests the print function for all opcodes in both the oneline
-// and full modes to ensure it provides the expected disassembly.
+type opcodeSpec struct {
+	opcode          byte
+	validVectors    []opcodeVector
+	invalidVectors  []opcodeVector
+	disasm          *opcodeDisasm
+	checkProperties opcodePropertyChecker
+}
+
+type opcodeCheckContext struct {
+	before     *Engine
+	after      *Engine
+	opcodeData []byte
+	execErr    error
+	opcode     byte
+	opcodeName string
+	phase      string
+	order      int
+}
+
+type opcodePropertyChecker func(t *testing.T, c opcodeCheckContext)
+
+type opcodeDisasm struct {
+	data    []byte
+	compact string
+	full    string
+}
+
+type opcodeVector struct {
+	name             string
+	inputStack       [][]byte
+	inputAltStack    [][]byte
+	opcodeData       []byte
+	expectedStack    [][]byte
+	expectedAltStack [][]byte
+	expectedError    txscript.ErrorCode
+	expectedExecErr  error
+	setupWorld       func(*opcodeWorld)
+	setupVM          func(*Engine)
+}
+
+type opcodeWorld struct {
+	tx              wire.MsgTx
+	prevouts        map[wire.OutPoint]*wire.TxOut
+	prevFetcher     ArkPrevOutFetcher
+	assetPacket     asset.Packet
+	scriptByVin     map[int][]byte
+	execScriptByVin map[int][]byte
+	witnessByVin    map[int]wire.TxWitness
+	packet          IntrospectorPacket
+}
+
+var opcodeSpecs = [256]*opcodeSpec{
+	OP_0:                  constantSpec(OP_0, 0),
+	OP_1NEGATE:            constantSpec(OP_1NEGATE, -1),
+	OP_1:                  constantSpec(OP_1, 1),
+	OP_2:                  constantSpec(OP_2, 2),
+	OP_3:                  constantSpec(OP_3, 3),
+	OP_4:                  constantSpec(OP_4, 4),
+	OP_5:                  constantSpec(OP_5, 5),
+	OP_6:                  constantSpec(OP_6, 6),
+	OP_7:                  constantSpec(OP_7, 7),
+	OP_8:                  constantSpec(OP_8, 8),
+	OP_9:                  constantSpec(OP_9, 9),
+	OP_10:                 constantSpec(OP_10, 10),
+	OP_11:                 constantSpec(OP_11, 11),
+	OP_12:                 constantSpec(OP_12, 12),
+	OP_13:                 constantSpec(OP_13, 13),
+	OP_14:                 constantSpec(OP_14, 14),
+	OP_15:                 constantSpec(OP_15, 15),
+	OP_16:                 constantSpec(OP_16, 16),
+	OP_DATA_1:             dataPushSpec(OP_DATA_1),
+	OP_DATA_2:             dataPushSpec(OP_DATA_2),
+	OP_DATA_3:             dataPushSpec(OP_DATA_3),
+	OP_DATA_4:             dataPushSpec(OP_DATA_4),
+	OP_DATA_5:             dataPushSpec(OP_DATA_5),
+	OP_DATA_6:             dataPushSpec(OP_DATA_6),
+	OP_DATA_7:             dataPushSpec(OP_DATA_7),
+	OP_DATA_8:             dataPushSpec(OP_DATA_8),
+	OP_DATA_9:             dataPushSpec(OP_DATA_9),
+	OP_DATA_10:            dataPushSpec(OP_DATA_10),
+	OP_DATA_11:            dataPushSpec(OP_DATA_11),
+	OP_DATA_12:            dataPushSpec(OP_DATA_12),
+	OP_DATA_13:            dataPushSpec(OP_DATA_13),
+	OP_DATA_14:            dataPushSpec(OP_DATA_14),
+	OP_DATA_15:            dataPushSpec(OP_DATA_15),
+	OP_DATA_16:            dataPushSpec(OP_DATA_16),
+	OP_DATA_17:            dataPushSpec(OP_DATA_17),
+	OP_DATA_18:            dataPushSpec(OP_DATA_18),
+	OP_DATA_19:            dataPushSpec(OP_DATA_19),
+	OP_DATA_20:            dataPushSpec(OP_DATA_20),
+	OP_DATA_21:            dataPushSpec(OP_DATA_21),
+	OP_DATA_22:            dataPushSpec(OP_DATA_22),
+	OP_DATA_23:            dataPushSpec(OP_DATA_23),
+	OP_DATA_24:            dataPushSpec(OP_DATA_24),
+	OP_DATA_25:            dataPushSpec(OP_DATA_25),
+	OP_DATA_26:            dataPushSpec(OP_DATA_26),
+	OP_DATA_27:            dataPushSpec(OP_DATA_27),
+	OP_DATA_28:            dataPushSpec(OP_DATA_28),
+	OP_DATA_29:            dataPushSpec(OP_DATA_29),
+	OP_DATA_30:            dataPushSpec(OP_DATA_30),
+	OP_DATA_31:            dataPushSpec(OP_DATA_31),
+	OP_DATA_32:            dataPushSpec(OP_DATA_32),
+	OP_DATA_33:            dataPushSpec(OP_DATA_33),
+	OP_DATA_34:            dataPushSpec(OP_DATA_34),
+	OP_DATA_35:            dataPushSpec(OP_DATA_35),
+	OP_DATA_36:            dataPushSpec(OP_DATA_36),
+	OP_DATA_37:            dataPushSpec(OP_DATA_37),
+	OP_DATA_38:            dataPushSpec(OP_DATA_38),
+	OP_DATA_39:            dataPushSpec(OP_DATA_39),
+	OP_DATA_40:            dataPushSpec(OP_DATA_40),
+	OP_DATA_41:            dataPushSpec(OP_DATA_41),
+	OP_DATA_42:            dataPushSpec(OP_DATA_42),
+	OP_DATA_43:            dataPushSpec(OP_DATA_43),
+	OP_DATA_44:            dataPushSpec(OP_DATA_44),
+	OP_DATA_45:            dataPushSpec(OP_DATA_45),
+	OP_DATA_46:            dataPushSpec(OP_DATA_46),
+	OP_DATA_47:            dataPushSpec(OP_DATA_47),
+	OP_DATA_48:            dataPushSpec(OP_DATA_48),
+	OP_DATA_49:            dataPushSpec(OP_DATA_49),
+	OP_DATA_50:            dataPushSpec(OP_DATA_50),
+	OP_DATA_51:            dataPushSpec(OP_DATA_51),
+	OP_DATA_52:            dataPushSpec(OP_DATA_52),
+	OP_DATA_53:            dataPushSpec(OP_DATA_53),
+	OP_DATA_54:            dataPushSpec(OP_DATA_54),
+	OP_DATA_55:            dataPushSpec(OP_DATA_55),
+	OP_DATA_56:            dataPushSpec(OP_DATA_56),
+	OP_DATA_57:            dataPushSpec(OP_DATA_57),
+	OP_DATA_58:            dataPushSpec(OP_DATA_58),
+	OP_DATA_59:            dataPushSpec(OP_DATA_59),
+	OP_DATA_60:            dataPushSpec(OP_DATA_60),
+	OP_DATA_61:            dataPushSpec(OP_DATA_61),
+	OP_DATA_62:            dataPushSpec(OP_DATA_62),
+	OP_DATA_63:            dataPushSpec(OP_DATA_63),
+	OP_DATA_64:            dataPushSpec(OP_DATA_64),
+	OP_DATA_65:            dataPushSpec(OP_DATA_65),
+	OP_DATA_66:            dataPushSpec(OP_DATA_66),
+	OP_DATA_67:            dataPushSpec(OP_DATA_67),
+	OP_DATA_68:            dataPushSpec(OP_DATA_68),
+	OP_DATA_69:            dataPushSpec(OP_DATA_69),
+	OP_DATA_70:            dataPushSpec(OP_DATA_70),
+	OP_DATA_71:            dataPushSpec(OP_DATA_71),
+	OP_DATA_72:            dataPushSpec(OP_DATA_72),
+	OP_DATA_73:            dataPushSpec(OP_DATA_73),
+	OP_DATA_74:            dataPushSpec(OP_DATA_74),
+	OP_DATA_75:            dataPushSpec(OP_DATA_75),
+	OP_PUSHDATA1:          pushDataNSpec(OP_PUSHDATA1, 1),
+	OP_PUSHDATA2:          pushDataNSpec(OP_PUSHDATA2, 2),
+	OP_PUSHDATA4:          pushDataNSpec(OP_PUSHDATA4, 4),
+	OP_NOP:                nopSpec(OP_NOP),
+	OP_NOP1:               nopSpec(OP_NOP1),
+	OP_NOP5:               nopSpec(OP_NOP5),
+	OP_NOP6:               nopSpec(OP_NOP6),
+	OP_NOP7:               nopSpec(OP_NOP7),
+	OP_NOP8:               nopSpec(OP_NOP8),
+	OP_NOP9:               nopSpec(OP_NOP9),
+	OP_NOP10:              nopSpec(OP_NOP10),
+	OP_IF:                 ifSpec(OP_IF),
+	OP_NOTIF:              ifSpec(OP_NOTIF),
+	OP_ELSE:               elseSpec(),
+	OP_ENDIF:              endifSpec(),
+	OP_VERIFY:             verifySpec(),
+	OP_RETURN:             returnSpec(),
+	OP_TOALTSTACK:         toAltStackSpec(),
+	OP_FROMALTSTACK:       fromAltStackSpec(),
+	OP_2DROP:              stackOpSpec(OP_2DROP),
+	OP_2DUP:               stackOpSpec(OP_2DUP),
+	OP_3DUP:               stackOpSpec(OP_3DUP),
+	OP_2OVER:              stackOpSpec(OP_2OVER),
+	OP_2ROT:               stackOpSpec(OP_2ROT),
+	OP_2SWAP:              stackOpSpec(OP_2SWAP),
+	OP_IFDUP:              ifDupSpec(),
+	OP_DEPTH:              depthSpec(),
+	OP_DROP:               stackOpSpec(OP_DROP),
+	OP_DUP:                stackOpSpec(OP_DUP),
+	OP_NIP:                stackOpSpec(OP_NIP),
+	OP_OVER:               stackOpSpec(OP_OVER),
+	OP_PICK:               pickSpec(),
+	OP_ROLL:               rollSpec(),
+	OP_ROT:                stackOpSpec(OP_ROT),
+	OP_SWAP:               stackOpSpec(OP_SWAP),
+	OP_TUCK:               stackOpSpec(OP_TUCK),
+	OP_CAT:                catSpec(),
+	OP_SUBSTR:             substrSpec(),
+	OP_LEFT:               leftSpec(),
+	OP_RIGHT:              rightSpec(),
+	OP_SIZE:               sizeSpec(),
+	OP_INVERT:             invertSpec(),
+	OP_AND:                bitwiseSpec(OP_AND),
+	OP_OR:                 bitwiseSpec(OP_OR),
+	OP_XOR:                bitwiseSpec(OP_XOR),
+	OP_EQUAL:              equalSpec(),
+	OP_EQUALVERIFY:        equalVerifySpec(),
+	OP_1ADD:               oneAddSpec(),
+	OP_1SUB:               oneSubSpec(),
+	OP_2MUL:               twoMulSpec(),
+	OP_2DIV:               twoDivSpec(),
+	OP_NEGATE:             negateSpec(),
+	OP_ABS:                absSpec(),
+	OP_NOT:                notSpec(),
+	OP_0NOTEQUAL:          zeroNotEqualSpec(),
+	OP_ADD:                addSpec(),
+	OP_SUB:                subSpec(),
+	OP_MUL:                mulSpec(),
+	OP_DIV:                divSpec(),
+	OP_MOD:                modSpec(),
+	OP_LSHIFT:             shiftSpec(OP_LSHIFT),
+	OP_RSHIFT:             shiftSpec(OP_RSHIFT),
+	OP_BOOLAND:            boolAndSpec(),
+	OP_BOOLOR:             boolOrSpec(),
+	OP_NUMEQUAL:           numEqualSpec(),
+	OP_NUMEQUALVERIFY:     numEqualVerifySpec(),
+	OP_NUMNOTEQUAL:        numNotEqualSpec(),
+	OP_LESSTHAN:           lessThanSpec(),
+	OP_GREATERTHAN:        greaterThanSpec(),
+	OP_LESSTHANOREQUAL:    lessThanOrEqualSpec(),
+	OP_GREATERTHANOREQUAL: greaterThanOrEqualSpec(),
+	OP_MIN:                minSpec(),
+	OP_MAX:                maxSpec(),
+	OP_WITHIN:             withinSpec(),
+	OP_RIPEMD160: hashSpec(
+		OP_RIPEMD160,
+		"0102",
+		"189f7c8b1a386ffe8eed91b3830c7a7bcd1e778c",
+		20,
+	),
+	OP_SHA1: hashSpec(
+		OP_SHA1,
+		"0102",
+		"0ca623e2855f2c75c842ad302fe820e41b4d197d",
+		20,
+	),
+	OP_SHA256: hashSpec(
+		OP_SHA256,
+		"0102",
+		"a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222",
+		32,
+	),
+	OP_HASH160: hashSpec(
+		OP_HASH160,
+		"0102",
+		"15cc49e191cbc520d91944600a5cb77af6aa3291",
+		20,
+	),
+	OP_HASH256: hashSpec(
+		OP_HASH256,
+		"0102",
+		"76a56aced915d2513dcd84c2c378b2e8aa5cd632b5b71ca2f2ac5b0e3a649bdb",
+		32,
+	),
+	OP_CODESEPARATOR:  noContextReservedSpec(OP_CODESEPARATOR, nil),
+	OP_CHECKSIG:       noContextReservedSpec(OP_CHECKSIG, [][]byte{nil, nil}),
+	OP_CHECKSIGVERIFY: noContextReservedSpec(OP_CHECKSIGVERIFY, [][]byte{nil, nil}),
+	OP_CHECKSIGADD: noContextReservedSpec(
+		OP_CHECKSIGADD,
+		[][]byte{nil, {0x01}, nil},
+	),
+	OP_CHECKMULTISIG:                 tapscriptDisabledSpec(OP_CHECKMULTISIG),
+	OP_CHECKMULTISIGVERIFY:           tapscriptDisabledSpec(OP_CHECKMULTISIGVERIFY),
+	OP_CHECKLOCKTIMEVERIFY:           checkLockTimeVerifySpec(),
+	OP_CHECKSEQUENCEVERIFY:           checkSequenceVerifySpec(),
+	OP_MERKLEBRANCHVERIFY:            merkleBranchVerifySpec(),
+	OP_SHA256INITIALIZE:              sha256InitializeSpec(),
+	OP_SHA256UPDATE:                  sha256UpdateSpec(),
+	OP_SHA256FINALIZE:                sha256FinalizeSpec(),
+	OP_INSPECTINPUTOUTPOINT:          inspectInputOutpointSpec(),
+	OP_INSPECTINPUTARKADESCRIPTHASH:  inspectInputArkadeScriptHashSpec(),
+	OP_INSPECTINPUTVALUE:             inspectInputValueSpec(),
+	OP_INSPECTINPUTSCRIPTPUBKEY:      inspectInputScriptPubkeySpec(),
+	OP_INSPECTINPUTSEQUENCE:          inspectInputSequenceSpec(),
+	OP_CHECKSIGFROMSTACK:             checksigFromStackSpec(),
+	OP_PUSHCURRENTINPUTINDEX:         pushCurrentInputIndexSpec(),
+	OP_INSPECTINPUTARKADEWITNESSHASH: inspectInputArkadeWitnessHashSpec(),
+	OP_INSPECTOUTPUTVALUE:            inspectOutputValueSpec(),
+	OP_INSPECTOUTPUTSCRIPTPUBKEY:     inspectOutputScriptPubkeySpec(),
+	OP_INSPECTVERSION:                inspectVersionSpec(),
+	OP_INSPECTLOCKTIME:               inspectLocktimeSpec(),
+	OP_INSPECTNUMINPUTS:              inspectNumInputsSpec(),
+	OP_INSPECTNUMOUTPUTS:             inspectNumOutputsSpec(),
+	OP_TXWEIGHT:                      txWeightSpec(),
+	OP_NUM2BIN:                       num2BinSpec(),
+	OP_BIN2NUM:                       bin2NumSpec(),
+	OP_UNKNOWN217:                    invalidSpec(OP_UNKNOWN217),
+	OP_UNKNOWN218:                    invalidSpec(OP_UNKNOWN218),
+	OP_UNKNOWN219:                    invalidSpec(OP_UNKNOWN219),
+	OP_UNKNOWN220:                    invalidSpec(OP_UNKNOWN220),
+	OP_UNKNOWN221:                    invalidSpec(OP_UNKNOWN221),
+	OP_UNKNOWN222:                    invalidSpec(OP_UNKNOWN222),
+	OP_UNKNOWN223:                    invalidSpec(OP_UNKNOWN223),
+	OP_UNKNOWN224:                    invalidSpec(OP_UNKNOWN224),
+	OP_UNKNOWN225:                    invalidSpec(OP_UNKNOWN225),
+	OP_UNKNOWN226:                    invalidSpec(OP_UNKNOWN226),
+	OP_ECMULSCALARVERIFY:             ecmulScalarVerifySpec(),
+	OP_TWEAKVERIFY:                   tweakVerifySpec(),
+	OP_INSPECTNUMASSETGROUPS:         assetSpec(OP_INSPECTNUMASSETGROUPS),
+	OP_INSPECTASSETGROUPASSETID:      assetSpec(OP_INSPECTASSETGROUPASSETID),
+	OP_INSPECTASSETGROUPCTRL:         assetSpec(OP_INSPECTASSETGROUPCTRL),
+	OP_FINDASSETGROUPBYASSETID:       assetSpec(OP_FINDASSETGROUPBYASSETID),
+	OP_INSPECTASSETGROUPMETADATAHASH: assetSpec(OP_INSPECTASSETGROUPMETADATAHASH),
+	OP_INSPECTASSETGROUPNUM:          assetSpec(OP_INSPECTASSETGROUPNUM),
+	OP_INSPECTASSETGROUP:             assetSpec(OP_INSPECTASSETGROUP),
+	OP_INSPECTASSETGROUPSUM:          assetSpec(OP_INSPECTASSETGROUPSUM),
+	OP_INSPECTOUTASSETCOUNT:          assetSpec(OP_INSPECTOUTASSETCOUNT),
+	OP_INSPECTOUTASSETAT:             assetSpec(OP_INSPECTOUTASSETAT),
+	OP_INSPECTOUTASSETLOOKUP:         assetSpec(OP_INSPECTOUTASSETLOOKUP),
+	OP_INSPECTINASSETCOUNT:           assetSpec(OP_INSPECTINASSETCOUNT),
+	OP_INSPECTINASSETAT:              assetSpec(OP_INSPECTINASSETAT),
+	OP_INSPECTINASSETLOOKUP:          assetSpec(OP_INSPECTINASSETLOOKUP),
+	OP_TXID:                          txIDSpec(),
+	OP_RESERVED:                      reservedSpec(OP_RESERVED),
+	OP_VER:                           reservedSpec(OP_VER),
+	OP_VERIF:                         reservedSpec(OP_VERIF),
+	OP_VERNOTIF:                      reservedSpec(OP_VERNOTIF),
+	OP_RESERVED1:                     reservedSpec(OP_RESERVED1),
+	OP_RESERVED2:                     reservedSpec(OP_RESERVED2),
+	OP_UNKNOWN187:                    invalidSpec(OP_UNKNOWN187),
+	OP_UNKNOWN188:                    invalidSpec(OP_UNKNOWN188),
+	OP_UNKNOWN189:                    invalidSpec(OP_UNKNOWN189),
+	OP_UNKNOWN190:                    invalidSpec(OP_UNKNOWN190),
+	OP_UNKNOWN191:                    invalidSpec(OP_UNKNOWN191),
+	OP_UNKNOWN192:                    invalidSpec(OP_UNKNOWN192),
+	OP_UNKNOWN193:                    invalidSpec(OP_UNKNOWN193),
+	OP_UNKNOWN194:                    invalidSpec(OP_UNKNOWN194),
+	OP_UNKNOWN195:                    invalidSpec(OP_UNKNOWN195),
+	OP_UNKNOWN208:                    invalidSpec(OP_UNKNOWN208),
+	OP_INSPECTPACKET:                 inspectPacketSpec(),
+	OP_INSPECTINPUTPACKET:            inspectInputPacketSpec(),
+	OP_UNKNOWN246:                    invalidSpec(OP_UNKNOWN246),
+	OP_UNKNOWN247:                    invalidSpec(OP_UNKNOWN247),
+	OP_UNKNOWN248:                    invalidSpec(OP_UNKNOWN248),
+	OP_UNKNOWN249:                    invalidSpec(OP_UNKNOWN249),
+	OP_SMALLINTEGER:                  invalidSpec(OP_SMALLINTEGER),
+	OP_PUBKEYS:                       invalidSpec(OP_PUBKEYS),
+	OP_UNKNOWN252:                    invalidSpec(OP_UNKNOWN252),
+	OP_PUBKEYHASH:                    invalidSpec(OP_PUBKEYHASH),
+	OP_PUBKEY:                        invalidSpec(OP_PUBKEY),
+	OP_INVALIDOPCODE:                 invalidSpec(OP_INVALIDOPCODE),
+}
+
+func TestOpcodeVectors(t *testing.T) {
+	t.Parallel()
+
+	for opcode, spec := range opcodeSpecs {
+		if spec == nil {
+			continue
+		}
+
+		opcode := byte(opcode)
+		t.Run(opcodeArray[opcode].name, func(t *testing.T) {
+			t.Parallel()
+
+			runVector := func(t *testing.T, v opcodeVector) {
+				t.Helper()
+				world := buildOpcodeWorld()
+				if v.setupWorld != nil {
+					v.setupWorld(world)
+				}
+				vm, err := newOpcodeEngine(world, 0)
+				require.NoError(t, err)
+				if v.setupWorld != nil {
+					vm.introspectorPacket = world.packet
+				}
+				vm.SetStack(v.inputStack)
+				vm.SetAltStack(v.inputAltStack)
+				if v.setupVM != nil {
+					v.setupVM(vm)
+				}
+				opcodeData := append([]byte(nil), v.opcodeData...)
+				before := cloneEngineForExpectedResult(vm)
+
+				require.NotNil(t, spec.checkProperties)
+				err = invokeOpcodeWithData(spec.opcode, opcodeData, vm)
+				spec.checkProperties(
+					t,
+					opcodeCheckContext{
+						before:     before,
+						after:      vm,
+						opcodeData: opcodeData,
+						execErr:    err,
+					},
+				)
+
+				if v.expectedError != 0 {
+					requireScriptErrorCode(t, err, v.expectedError)
+					return
+				}
+				if v.expectedExecErr != nil {
+					require.ErrorIs(t, err, v.expectedExecErr)
+					return
+				}
+				require.NoError(t, err)
+
+				if v.expectedStack != nil {
+					require.Equal(t, v.expectedStack, vm.GetStack())
+				}
+				if v.expectedAltStack != nil {
+					require.Equal(t, v.expectedAltStack, vm.GetAltStack())
+				}
+			}
+
+			t.Run("valid", func(t *testing.T) {
+				t.Parallel()
+				for _, v := range spec.validVectors {
+					t.Run(v.name, func(t *testing.T) {
+						t.Parallel()
+						runVector(t, v)
+					})
+				}
+			})
+			t.Run("invalid", func(t *testing.T) {
+				t.Parallel()
+				for _, v := range spec.invalidVectors {
+					t.Run(v.name, func(t *testing.T) {
+						t.Parallel()
+						runVector(t, v)
+					})
+				}
+			})
+		})
+	}
+}
+
 func TestOpcodeDisasm(t *testing.T) {
 	t.Parallel()
 
-	// First, test the oneline disassembly.
-
-	// The expected strings for the data push opcodes are replaced in the
-	// test loops below since they involve repeating bytes.  Also, the
-	// OP_NOP# and OP_UNKNOWN# are replaced below too, since it's easier
-	// than manually listing them here.
-	oneBytes := []byte{0x01}
-	oneStr := "01"
-	expectedStrings := [256]string{0x00: "0", 0x4f: "-1",
-		0x50: "OP_RESERVED", 0x61: "OP_NOP", 0x62: "OP_VER",
-		0x63: "OP_IF", 0x64: "OP_NOTIF", 0x65: "OP_VERIF",
-		0x66: "OP_VERNOTIF", 0x67: "OP_ELSE", 0x68: "OP_ENDIF",
-		0x69: "OP_VERIFY", 0x6a: "OP_RETURN", 0x6b: "OP_TOALTSTACK",
-		0x6c: "OP_FROMALTSTACK", 0x6d: "OP_2DROP", 0x6e: "OP_2DUP",
-		0x6f: "OP_3DUP", 0x70: "OP_2OVER", 0x71: "OP_2ROT",
-		0x72: "OP_2SWAP", 0x73: "OP_IFDUP", 0x74: "OP_DEPTH",
-		0x75: "OP_DROP", 0x76: "OP_DUP", 0x77: "OP_NIP",
-		0x78: "OP_OVER", 0x79: "OP_PICK", 0x7a: "OP_ROLL",
-		0x7b: "OP_ROT", 0x7c: "OP_SWAP", 0x7d: "OP_TUCK",
-		0x7e: "OP_CAT", 0x7f: "OP_SUBSTR", 0x80: "OP_LEFT",
-		0x81: "OP_RIGHT", 0x82: "OP_SIZE", 0x83: "OP_INVERT",
-		0x84: "OP_AND", 0x85: "OP_OR", 0x86: "OP_XOR",
-		0x87: "OP_EQUAL", 0x88: "OP_EQUALVERIFY", 0x89: "OP_RESERVED1",
-		0x8a: "OP_RESERVED2", 0x8b: "OP_1ADD", 0x8c: "OP_1SUB",
-		0x8d: "OP_2MUL", 0x8e: "OP_2DIV", 0x8f: "OP_NEGATE",
-		0x90: "OP_ABS", 0x91: "OP_NOT", 0x92: "OP_0NOTEQUAL",
-		0x93: "OP_ADD", 0x94: "OP_SUB", 0x95: "OP_MUL", 0x96: "OP_DIV",
-		0x97: "OP_MOD", 0x98: "OP_LSHIFT", 0x99: "OP_RSHIFT",
-		0x9a: "OP_BOOLAND", 0x9b: "OP_BOOLOR", 0x9c: "OP_NUMEQUAL",
-		0x9d: "OP_NUMEQUALVERIFY", 0x9e: "OP_NUMNOTEQUAL",
-		0x9f: "OP_LESSTHAN", 0xa0: "OP_GREATERTHAN",
-		0xa1: "OP_LESSTHANOREQUAL", 0xa2: "OP_GREATERTHANOREQUAL",
-		0xa3: "OP_MIN", 0xa4: "OP_MAX", 0xa5: "OP_WITHIN",
-		0xa6: "OP_RIPEMD160", 0xa7: "OP_SHA1", 0xa8: "OP_SHA256",
-		0xa9: "OP_HASH160", 0xaa: "OP_HASH256", 0xab: "OP_CODESEPARATOR",
-		0xac: "OP_CHECKSIG", 0xad: "OP_CHECKSIGVERIFY",
-		0xae: "OP_CHECKMULTISIG", 0xaf: "OP_CHECKMULTISIGVERIFY",
-		0xfa: "OP_SMALLINTEGER", 0xfb: "OP_PUBKEYS",
-		0xfd: "OP_PUBKEYHASH", 0xfe: "OP_PUBKEY",
-		0xff: "OP_INVALIDOPCODE", 0xba: "OP_CHECKSIGADD",
-		0xb3: "OP_MERKLEBRANCHVERIFY",
-		// Add new defined opcodes
-		0xc4: "OP_SHA256INITIALIZE", 0xc5: "OP_SHA256UPDATE",
-		0xc6: "OP_SHA256FINALIZE", 0xc7: "OP_INSPECTINPUTOUTPOINT",
-		0xc9: "OP_INSPECTINPUTVALUE", 0xca: "OP_INSPECTINPUTSCRIPTPUBKEY",
-		0xcb: "OP_INSPECTINPUTSEQUENCE", 0xcc: "OP_CHECKSIGFROMSTACK",
-		0xcd: "OP_PUSHCURRENTINPUTINDEX", 0xcf: "OP_INSPECTOUTPUTVALUE",
-		0xd1: "OP_INSPECTOUTPUTSCRIPTPUBKEY", 0xd2: "OP_INSPECTVERSION",
-		0xd3: "OP_INSPECTLOCKTIME", 0xd4: "OP_INSPECTNUMINPUTS",
-		0xd5: "OP_INSPECTNUMOUTPUTS", 0xd6: "OP_TXWEIGHT",
-		0xd7: "OP_NUM2BIN", 0xd8: "OP_BIN2NUM",
-		0xd9: "OP_UNKNOWN217", 0xda: "OP_UNKNOWN218",
-		0xdb: "OP_UNKNOWN219", 0xdc: "OP_UNKNOWN220",
-		0xdd: "OP_UNKNOWN221", 0xde: "OP_UNKNOWN222",
-		0xdf: "OP_UNKNOWN223", 0xe0: "OP_UNKNOWN224",
-		0xe1: "OP_UNKNOWN225", 0xe2: "OP_UNKNOWN226",
-		0xe3: "OP_ECMULSCALARVERIFY", 0xe4: "OP_TWEAKVERIFY",
-		0xf3: "OP_TXID",
-		0xc8: "OP_INSPECTINPUTARKADESCRIPTHASH",
-		0xce: "OP_INSPECTINPUTARKADEWITNESSHASH",
-	}
-	for opcodeVal, expectedStr := range expectedStrings {
-		var data []byte
-		switch {
-		// OP_DATA_1 through OP_DATA_65 display the pushed data.
-		case opcodeVal >= 0x01 && opcodeVal < 0x4c:
-			data = bytes.Repeat(oneBytes, opcodeVal)
-			expectedStr = strings.Repeat(oneStr, opcodeVal)
-
-		// OP_PUSHDATA1.
-		case opcodeVal == 0x4c:
-			data = bytes.Repeat(oneBytes, 1)
-			expectedStr = strings.Repeat(oneStr, 1)
-
-		// OP_PUSHDATA2.
-		case opcodeVal == 0x4d:
-			data = bytes.Repeat(oneBytes, 2)
-			expectedStr = strings.Repeat(oneStr, 2)
-
-		// OP_PUSHDATA4.
-		case opcodeVal == 0x4e:
-			data = bytes.Repeat(oneBytes, 3)
-			expectedStr = strings.Repeat(oneStr, 3)
-
-		// OP_1 through OP_16 display the numbers themselves.
-		case opcodeVal >= 0x51 && opcodeVal <= 0x60:
-			val := byte(opcodeVal - (0x51 - 1))
-			data = []byte{val}
-			expectedStr = strconv.Itoa(int(val))
-
-		// OP_NOP1 through OP_NOP10.
-		case opcodeVal >= 0xb0 && opcodeVal <= 0xb9:
-			switch opcodeVal {
-			case 0xb1:
-				// OP_NOP2 is an alias of OP_CHECKLOCKTIMEVERIFY
-				expectedStr = "OP_CHECKLOCKTIMEVERIFY"
-			case 0xb2:
-				// OP_NOP3 is an alias of OP_CHECKSEQUENCEVERIFY
-				expectedStr = "OP_CHECKSEQUENCEVERIFY"
-			case 0xb3, 0xc8, 0xce:
-				// OP_NOP4 is now OP_MERKLEBRANCHVERIFY
-				expectedStr = "OP_MERKLEBRANCHVERIFY"
-			default:
-				val := byte(opcodeVal - (0xb0 - 1))
-				expectedStr = "OP_NOP" + strconv.Itoa(int(val))
-			}
-
-		// Asset and packet introspection opcodes (0xe5-0xf5).
-		case opcodeVal >= 0xe5 && opcodeVal <= 0xf5:
-			expectedStr = opcodeArray[opcodeVal].name
-
-		// OP_UNKNOWN#.
-		case (opcodeVal >= 0xbb && opcodeVal <= 0xc3) || // Unknown range before SHA256 ops
-			(opcodeVal == 0xd0) || // Unknown between output ops
-			(opcodeVal >= 0xf6 && opcodeVal <= 0xf9) || // Unknown range after new ops
-			opcodeVal == 0xfc:
-			expectedStr = "OP_UNKNOWN" + strconv.Itoa(opcodeVal)
-		}
-
-		var buf strings.Builder
-		disasmOpcode(&buf, &opcodeArray[opcodeVal], data, true)
-		gotStr := buf.String()
-		if gotStr != expectedStr {
-			t.Errorf("pop.print (opcode %x): Unexpected disasm "+
-				"string - got %v, want %v", opcodeVal, gotStr,
-				expectedStr)
+	for opcode, spec := range opcodeSpecs {
+		if spec == nil {
 			continue
 		}
-	}
 
-	// Now, replace the relevant fields and test the full disassembly.
-	expectedStrings[0x00] = "OP_0"
-	expectedStrings[0x4f] = "OP_1NEGATE"
-	for opcodeVal, expectedStr := range expectedStrings {
-		var data []byte
-		switch {
-		// OP_DATA_1 through OP_DATA_65 display the opcode followed by
-		// the pushed data.
-		case opcodeVal >= 0x01 && opcodeVal < 0x4c:
-			data = bytes.Repeat(oneBytes, opcodeVal)
-			expectedStr = fmt.Sprintf("OP_DATA_%d 0x%s", opcodeVal,
-				strings.Repeat(oneStr, opcodeVal))
+		opcodeVal := byte(opcode)
+		t.Run(opcodeArray[opcodeVal].name, func(t *testing.T) {
+			t.Parallel()
 
-		// OP_PUSHDATA1.
-		case opcodeVal == 0x4c:
-			data = bytes.Repeat(oneBytes, 1)
-			expectedStr = fmt.Sprintf("OP_PUSHDATA1 0x%02x 0x%s",
-				len(data), strings.Repeat(oneStr, 1))
+			data := []byte{}
+			expectedCompact := opcodeArray[opcodeVal].name
+			expectedFull := opcodeArray[opcodeVal].name
 
-		// OP_PUSHDATA2.
-		case opcodeVal == 0x4d:
-			data = bytes.Repeat(oneBytes, 2)
-			expectedStr = fmt.Sprintf("OP_PUSHDATA2 0x%04x 0x%s",
-				len(data), strings.Repeat(oneStr, 2))
-
-		// OP_PUSHDATA4.
-		case opcodeVal == 0x4e:
-			data = bytes.Repeat(oneBytes, 3)
-			expectedStr = fmt.Sprintf("OP_PUSHDATA4 0x%08x 0x%s",
-				len(data), strings.Repeat(oneStr, 3))
-
-		// OP_1 through OP_16.
-		case opcodeVal >= 0x51 && opcodeVal <= 0x60:
-			val := byte(opcodeVal - (0x51 - 1))
-			data = []byte{val}
-			expectedStr = "OP_" + strconv.Itoa(int(val))
-
-		// OP_NOP1 through OP_NOP10.
-		case opcodeVal >= 0xb0 && opcodeVal <= 0xb9:
-			switch opcodeVal {
-			case 0xb1:
-				// OP_NOP2 is an alias of OP_CHECKLOCKTIMEVERIFY
-				expectedStr = "OP_CHECKLOCKTIMEVERIFY"
-			case 0xb2:
-				// OP_NOP3 is an alias of OP_CHECKSEQUENCEVERIFY
-				expectedStr = "OP_CHECKSEQUENCEVERIFY"
-			case 0xb3, 0xc8, 0xce:
-				// OP_NOP4 is now OP_MERKLEBRANCHVERIFY
-				expectedStr = "OP_MERKLEBRANCHVERIFY"
-			default:
-				val := byte(opcodeVal - (0xb0 - 1))
-				expectedStr = "OP_NOP" + strconv.Itoa(int(val))
+			if spec.disasm != nil {
+				data = spec.disasm.data
+				expectedCompact = spec.disasm.compact
+				expectedFull = spec.disasm.full
 			}
 
-		// Asset and packet introspection opcodes (0xe5-0xf5).
-		case opcodeVal >= 0xe5 && opcodeVal <= 0xf5:
-			expectedStr = opcodeArray[opcodeVal].name
+			// Compact mode
+			var buf strings.Builder
+			disasmOpcode(&buf, &opcodeArray[opcodeVal], data, true)
+			require.Equal(t, expectedCompact, buf.String(), "compact disasm mismatch")
 
-		// OP_UNKNOWN#.
-		case (opcodeVal >= 0xbb && opcodeVal <= 0xc3) || // Unknown range before SHA256 ops
-			(opcodeVal == 0xd0) || // Unknown between output ops
-			(opcodeVal >= 0xf6 && opcodeVal <= 0xf9) || // Unknown range after new ops
-			opcodeVal == 0xfc:
-			expectedStr = "OP_UNKNOWN" + strconv.Itoa(opcodeVal)
-		}
-
-		var buf strings.Builder
-		disasmOpcode(&buf, &opcodeArray[opcodeVal], data, false)
-		gotStr := buf.String()
-		if gotStr != expectedStr {
-			t.Errorf("pop.print (opcode %x): Unexpected disasm "+
-				"string - got %v, want %v", opcodeVal, gotStr,
-				expectedStr)
-			continue
-		}
+			// Full mode
+			buf.Reset()
+			disasmOpcode(&buf, &opcodeArray[opcodeVal], data, false)
+			require.Equal(t, expectedFull, buf.String(), "full disasm mismatch")
+		})
 	}
 }
 
-func TestOpcodeNum2Bin(t *testing.T) {
-	t.Parallel()
+// Builders
+func constantSpec(op byte, val int64) *opcodeSpec {
+	compact := strconv.FormatInt(val, 10)
+	full := opcodeArray[op].name
+	wantTop := scriptNum(val).Bytes()
+	return &opcodeSpec{
+		opcode: op,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.NoError(t, c.execErr)
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			beforeStack := c.before.GetStack()
+			afterStack := c.after.GetStack()
+			require.Equal(t, len(beforeStack)+1, len(afterStack))
+			require.Equal(t, beforeStack, afterStack[:len(beforeStack)])
+			require.Equal(t, wantTop, afterStack[len(afterStack)-1])
+		},
+		validVectors: []opcodeVector{
+			{name: "push", expectedStack: [][]byte{scriptNum(val).Bytes()}},
+		},
+		disasm: &opcodeDisasm{
+			compact: compact,
+			full:    full,
+		},
+	}
+}
 
-	tests := []struct {
-		name       string
-		num        []byte
-		size       int64
-		want       []byte
-		shouldFail bool
-	}{
-		{"5 as 4 bytes", []byte{0x05}, 4, []byte{0x05, 0x00, 0x00, 0x00}, false},
-		{"-5 as 4 bytes", []byte{0x85}, 4, []byte{0x05, 0x00, 0x00, 0x80}, false},
-		{"-5 as 1 byte", []byte{0x85}, 1, []byte{0x85}, false},
-		{"0 as 4 bytes", nil, 4, []byte{0x00, 0x00, 0x00, 0x00}, false},
-		{"0 as 0 bytes", nil, 0, []byte{}, false},
-		{"255 as 1 byte fails", []byte{0xff, 0x00}, 1, nil, true},
-		{"size over max fails", nil, 521, nil, true},
-		{"negative size fails", nil, -1, nil, true},
+func pushDataPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeStack := c.before.GetStack()
+		afterStack := c.after.GetStack()
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrMinimalData,
+				txscript.ErrElementTooBig,
+			)
+			require.Equal(t, beforeStack, afterStack)
+			return
+		}
+
+		require.Equal(t, len(beforeStack)+1, len(afterStack))
+		require.Equal(t, beforeStack, afterStack[:len(beforeStack)])
+
+		wantTop := c.opcodeData
+		if wantTop == nil {
+			wantTop = []byte{}
+		}
+		require.Truef(
+			t,
+			bytes.Equal(wantTop, afterStack[len(afterStack)-1]),
+			"opcode=%s",
+			opcodeArray[op].name,
+		)
+	}
+}
+
+func dataPushSpec(op byte) *opcodeSpec {
+	data := bytes.Repeat([]byte{0x01}, int(op))
+	if op == OP_DATA_1 {
+		data = []byte{0x17}
+	}
+	compact := hex.EncodeToString(data)
+	full := fmt.Sprintf("%s 0x%s", opcodeArray[op].name, compact)
+
+	spec := &opcodeSpec{
+		opcode:          op,
+		checkProperties: pushDataPropertyChecker(op),
+		validVectors: []opcodeVector{
+			{name: "push", opcodeData: data, expectedStack: [][]byte{data}},
+		},
+		disasm: &opcodeDisasm{
+			data:    data,
+			compact: compact,
+			full:    full,
+		},
+	}
+	if op == OP_DATA_1 {
+		spec.invalidVectors = []opcodeVector{
+			{
+				name:          "non_minimal_small_int",
+				opcodeData:    []byte{0x01},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "non_minimal_negative_one",
+				opcodeData:    []byte{0x81},
+				expectedError: txscript.ErrMinimalData,
+			},
+		}
+	}
+	return spec
+}
+
+func pushDataNSpec(op byte, n int) *opcodeSpec {
+	data := bytes.Repeat([]byte{0x01}, n)
+	compact := strings.Repeat("01", n)
+	full := fmt.Sprintf("%s 0x%0*x 0x%s", opcodeArray[op].name, n*2, len(data), compact)
+
+	spec := &opcodeSpec{
+		opcode:          op,
+		checkProperties: pushDataPropertyChecker(op),
+		disasm: &opcodeDisasm{
+			data:    data,
+			compact: compact,
+			full:    full,
+		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			vm := &Engine{dstack: stack{verifyMinimalData: true}}
-			vm.dstack.PushByteArray(tc.num)
-			vm.dstack.PushInt(scriptNum(tc.size))
+	switch op {
+	case OP_PUSHDATA1:
+		validData := bytes.Repeat([]byte{0x01}, 76)
+		spec.validVectors = []opcodeVector{
+			{name: "push", opcodeData: validData, expectedStack: [][]byte{validData}},
+		}
+		spec.invalidVectors = []opcodeVector{
+			{
+				name:          "non_minimal_direct_push",
+				opcodeData:    []byte{0x17},
+				expectedError: txscript.ErrMinimalData,
+			},
+		}
+	case OP_PUSHDATA2:
+		validData := bytes.Repeat([]byte{0x01}, 256)
+		spec.validVectors = []opcodeVector{
+			{name: "push", opcodeData: validData, expectedStack: [][]byte{validData}},
+		}
+		spec.invalidVectors = []opcodeVector{
+			{
+				name:          "non_minimal_pushdata1",
+				opcodeData:    bytes.Repeat([]byte{0x01}, 255),
+				expectedError: txscript.ErrMinimalData,
+			},
+		}
+	case OP_PUSHDATA4:
+		spec.invalidVectors = []opcodeVector{
+			{
+				name:          "non_minimal_pushdata2",
+				opcodeData:    bytes.Repeat([]byte{0x01}, 256),
+				expectedError: txscript.ErrMinimalData,
+			},
+		}
+	}
 
-			err := opcodeNum2Bin(nil, nil, vm)
-			if tc.shouldFail {
-				if err == nil {
-					t.Fatalf("expected failure, got nil")
+	return spec
+}
+
+func nopSpec(op byte) *opcodeSpec {
+	var err txscript.ErrorCode
+	full := opcodeArray[op].name
+	switch op {
+	case OP_NOP1, OP_NOP5, OP_NOP6, OP_NOP7, OP_NOP8, OP_NOP9, OP_NOP10:
+		err = txscript.ErrDiscourageUpgradableNOPs
+	}
+	checker := unchangedStateChecker()
+	if err != 0 {
+		checker = unchangedStateWithErrorCodeChecker(err)
+	}
+	spec := &opcodeSpec{
+		opcode:          op,
+		checkProperties: checker,
+		disasm: &opcodeDisasm{
+			compact: full,
+			full:    full,
+		},
+	}
+	if err != 0 {
+		spec.invalidVectors = []opcodeVector{{name: "nop", expectedError: err}}
+	} else {
+		spec.validVectors = []opcodeVector{{name: "nop"}}
+	}
+	return spec
+}
+
+func invalidSpec(op byte) *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          op,
+		checkProperties: unchangedStateWithErrorCodeChecker(txscript.ErrReservedOpcode),
+		invalidVectors: []opcodeVector{
+			{name: "invalid", expectedError: txscript.ErrReservedOpcode},
+		},
+	}
+}
+
+func reservedSpec(op byte) *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          op,
+		checkProperties: unchangedStateWithErrorCodeChecker(txscript.ErrReservedOpcode),
+		invalidVectors: []opcodeVector{
+			{name: "reserved", expectedError: txscript.ErrReservedOpcode},
+		},
+	}
+}
+
+func unchangedStateChecker() opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.NoError(t, c.execErr)
+		require.Equal(t, c.before.GetStack(), c.after.GetStack())
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+	}
+}
+
+func unchangedStateWithErrorCodeChecker(code txscript.ErrorCode) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		requireScriptErrorCode(t, c.execErr, code)
+		require.Equal(t, c.before.GetStack(), c.after.GetStack())
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+	}
+}
+
+func errorNoMutationChecker(code txscript.ErrorCode) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		requireScriptErrorCode(t, c.execErr, code)
+		require.Equal(t, c.before.GetStack(), c.after.GetStack())
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+	}
+}
+
+func returnSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_RETURN,
+		checkProperties: errorNoMutationChecker(txscript.ErrEarlyReturn),
+		invalidVectors: []opcodeVector{
+			{name: "early_return", expectedError: txscript.ErrEarlyReturn},
+		},
+	}
+}
+
+func noContextReservedSpec(op byte, inputStack [][]byte) *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          op,
+		checkProperties: errorNoMutationChecker(txscript.ErrReservedOpcode),
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_no_context",
+				inputStack:    inputStack,
+				expectedError: txscript.ErrReservedOpcode,
+			},
+		},
+	}
+}
+
+func tapscriptDisabledSpec(op byte) *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          op,
+		checkProperties: errorNoMutationChecker(txscript.ErrTapscriptCheckMultisig),
+		invalidVectors: []opcodeVector{
+			{name: "disabled", expectedError: txscript.ErrTapscriptCheckMultisig},
+		},
+	}
+}
+
+func ecmulScalarVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_ECMULSCALARVERIFY,
+		checkProperties: ecmulLikePropertyChecker(),
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func tweakVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_TWEAKVERIFY,
+		checkProperties: ecmulLikePropertyChecker(),
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func ecmulLikePropertyChecker() opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+		if c.execErr != nil {
+			requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+			return
+		}
+		require.Equal(t, len(c.before.GetStack())-3, len(c.after.GetStack()))
+	}
+}
+
+func checksigFromStackSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_CHECKSIGFROMSTACK,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				if beforeDepth < 3 {
+					requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
 				}
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
 
-			got, err := vm.dstack.PopByteArray()
-			if err != nil {
-				t.Fatalf("pop: %v", err)
-			}
-			if !bytes.Equal(got, tc.want) {
-				t.Fatalf("got %x, want %x", got, tc.want)
-			}
-		})
+			require.GreaterOrEqual(t, beforeDepth, 3)
+			require.Equal(t, beforeDepth-2, afterDepth)
+			top := c.after.GetStack()[afterDepth-1]
+			require.True(t, len(top) == 0 || bytes.Equal(top, []byte{1}))
+		},
+		validVectors: []opcodeVector{
+			{name: "valid_sig", inputStack: [][]byte{
+				{
+					0xE9, 0x07, 0x83, 0x1F, 0x80, 0x84, 0x8D, 0x10,
+					0x69, 0xA5, 0x37, 0x1B, 0x40, 0x24, 0x10, 0x36,
+					0x4B, 0xDF, 0x1C, 0x5F, 0x83, 0x07, 0xB0, 0x08,
+					0x4C, 0x55, 0xF1, 0xCE, 0x2D, 0xCA, 0x82, 0x15,
+					0x25, 0xF6, 0x6A, 0x4A, 0x85, 0xEA, 0x8B, 0x71,
+					0xE4, 0x82, 0xA7, 0x4F, 0x38, 0x2D, 0x2C, 0xE5,
+					0xEB, 0xEE, 0xE8, 0xFD, 0xB2, 0x17, 0x2F, 0x47,
+					0x7D, 0xF4, 0x90, 0x0D, 0x31, 0x05, 0x36, 0xC0,
+				},
+				{
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				},
+				{
+					0xF9, 0x30, 0x8A, 0x01, 0x92, 0x58, 0xC3, 0x10,
+					0x49, 0x34, 0x4F, 0x85, 0xF8, 0x9D, 0x52, 0x29,
+					0xB5, 0x31, 0xC8, 0x45, 0x83, 0x6F, 0x99, 0xB0,
+					0x86, 0x01, 0xF1, 0x13, 0xBC, 0xE0, 0x36, 0xF9,
+				},
+			}, expectedStack: [][]byte{{1}}},
+			{
+				name:          "empty_sig",
+				inputStack:    [][]byte{nil, nil, nil},
+				expectedStack: [][]byte{emptyByteVector()},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_pk_size",
+				inputStack:    [][]byte{{0x01}, {0x02}, {0x03}},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
 	}
 }
 
-func TestOpcodeBin2Num(t *testing.T) {
-	t.Parallel()
+func merkleBranchVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_MERKLEBRANCHVERIFY,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
 
-	tests := []struct {
-		name       string
-		in         []byte
-		want       []byte
-		shouldFail bool
-	}{
-		{"5 from 4 bytes", []byte{0x05, 0x00, 0x00, 0x00}, []byte{0x05}, false},
-		{"negative zero normalizes", []byte{0x00, 0x00, 0x00, 0x80}, []byte{}, false},
-		{"-5 from 4 bytes", []byte{0x05, 0x00, 0x00, 0x80}, []byte{0x85}, false},
-		{"128 minimal", []byte{0x80, 0x00, 0x00, 0x00}, []byte{0x80, 0x00}, false},
-		{"empty stays zero", []byte{}, []byte{}, false},
-		{"oversized input fails", bytes.Repeat([]byte{0x01}, maxBigNumLen+1), nil, true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			vm := &Engine{dstack: stack{verifyMinimalData: true}}
-			vm.dstack.PushByteArray(tc.in)
-
-			err := opcodeBin2Num(nil, nil, vm)
-			if tc.shouldFail {
-				if err == nil {
-					t.Fatalf("expected failure, got nil")
-				}
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
 
-			got, err := vm.dstack.PopByteArray()
-			if err != nil {
-				t.Fatalf("pop: %v", err)
-			}
-			if !bytes.Equal(got, tc.want) {
-				t.Fatalf("got %x, want %x", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestShiftOpcodesBigNumSemantics(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		setup  func(*stack)
-		opFunc func(*opcode, []byte, *Engine) error
-		want   []byte
-	}{
-		{
-			name: "lshift 5 << 1 = 10",
-			setup: func(s *stack) {
-				s.PushByteArray([]byte{0x05})
-				s.PushByteArray([]byte{0x01})
+			require.GreaterOrEqual(t, beforeDepth, 4)
+			require.Equal(t, beforeDepth-3, afterDepth)
+			require.Len(t, c.after.GetStack()[afterDepth-1], 32)
+		},
+		validVectors: []opcodeVector{
+			{
+				name: "valid_path",
+				inputStack: [][]byte{
+					[]byte("tag_leaf"),
+					[]byte("tag_branch"),
+					bytes.Repeat([]byte{0x01}, 32),
+					bytes.Repeat([]byte{0x00}, 32),
+				},
 			},
-			opFunc: opcodeLshift,
-			want:   []byte{0x0a},
 		},
-		{
-			name: "lshift 255 << 1 = 510",
-			setup: func(s *stack) {
-				s.PushByteArray([]byte{0xff, 0x00})
-				s.PushByteArray([]byte{0x01})
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_proof_len",
+				inputStack:    [][]byte{[]byte("tag_l"), []byte("tag_b"), {0x01}, []byte("leaf")},
+				expectedError: txscript.ErrInvalidStackOperation,
 			},
-			opFunc: opcodeLshift,
-			want:   []byte{0xfe, 0x01},
 		},
-		{
-			name: "rshift arithmetic: -7 >> 1 = -4",
-			setup: func(s *stack) {
-				s.PushByteArray([]byte{0x87}) // -7
-				s.PushByteArray([]byte{0x01})
+	}
+}
+
+func verifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_VERIFY,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(
+					t,
+					c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrVerify,
+				)
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+		},
+		validVectors: []opcodeVector{
+			{name: "true", inputStack: [][]byte{{0x01}}},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "false", inputStack: [][]byte{nil}, expectedError: txscript.ErrVerify},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func ifSpec(op byte) *opcodeSpec {
+	spec := &opcodeSpec{
+		opcode: op,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			branchExecuting := len(c.before.condStack) == 0 ||
+				c.before.condStack[len(c.before.condStack)-1] == txscript.OpCondTrue
+
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(
+					t,
+					c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrMinimalIf,
+				)
+				require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+				require.Equal(t, c.before.condStack, c.after.condStack)
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+				return
+			}
+
+			require.Equal(t, len(c.before.condStack)+1, len(c.after.condStack))
+			if branchExecuting {
+				require.Equal(t, beforeDepth-1, afterDepth)
+			} else {
+				require.Equal(t, beforeDepth, afterDepth)
+			}
+		},
+		validVectors: []opcodeVector{
+			{name: "true", inputStack: [][]byte{{0x01}}},
+			{name: "false", inputStack: [][]byte{nil}},
+			{
+				name:       "nested_skip",
+				inputStack: [][]byte{{0x02}},
+				setupVM: func(vm *Engine) {
+					vm.condStack = append(vm.condStack, txscript.OpCondFalse)
+				},
 			},
-			opFunc: opcodeRshift,
-			want:   []byte{0x84}, // -4
 		},
-		{
-			name: "rshift arithmetic: -1 >> 100 = -1",
-			setup: func(s *stack) {
-				s.PushByteArray([]byte{0x81}) // -1
-				s.PushByteArray([]byte{0x64}) // 100
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "minimal_if_bad_byte",
+				inputStack:    [][]byte{{0x02}},
+				expectedError: txscript.ErrMinimalIf,
 			},
-			opFunc: opcodeRshift,
-			want:   []byte{0x81},
+			{
+				name:          "minimal_if_bad_len",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalIf,
+			},
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			vm := &Engine{dstack: stack{verifyMinimalData: true}}
-			tc.setup(&vm.dstack)
-			if err := tc.opFunc(nil, nil, vm); err != nil {
-				t.Fatalf("%s: %v", tc.name, err)
-			}
-			got, err := vm.dstack.PopByteArray()
-			if err != nil {
-				t.Fatalf("pop: %v", err)
-			}
-			if !bytes.Equal(got, tc.want) {
-				t.Fatalf("got %x, want %x", got, tc.want)
-			}
-		})
-	}
+	return spec
 }
 
-func TestCLTVAcceptsBigNumResult(t *testing.T) {
-	t.Parallel()
-	// 3_000_000_000 = 0xB2D05E00; sign-magnitude LE needs a 0x00 sign byte
-	// because the magnitude MSB (0xb2) has bit 7 set → 5-byte minimal encoding.
-	// This is the kind of 5-byte value arithmetic can produce for locktimes.
-	vm := &Engine{
-		dstack: stack{verifyMinimalData: true},
-		tx: wire.MsgTx{
-			LockTime: 3_000_000_000,
-			TxIn:     []*wire.TxIn{{Sequence: 0}},
+func elseSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_ELSE,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetStack(), c.after.GetStack())
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrUnbalancedConditional)
+				require.Equal(t, c.before.condStack, c.after.condStack)
+				return
+			}
+
+			require.Equal(t, len(c.before.condStack), len(c.after.condStack))
 		},
-		txIdx: 0,
-	}
-	vm.dstack.PushByteArray([]byte{0x00, 0x5e, 0xd0, 0xb2, 0x00})
-	if err := opcodeCheckLockTimeVerify(nil, nil, vm); err != nil {
-		t.Fatalf("CLTV: %v", err)
-	}
-}
-
-func TestCLTVRejectsNegative(t *testing.T) {
-	t.Parallel()
-	vm := &Engine{
-		dstack: stack{verifyMinimalData: true},
-		tx:     wire.MsgTx{LockTime: 3_000_000_000, TxIn: []*wire.TxIn{{Sequence: 0}}},
-	}
-	vm.dstack.PushByteArray([]byte{0x81}) // -1
-	err := opcodeCheckLockTimeVerify(nil, nil, vm)
-	if !isScriptError(err, txscript.ErrNegativeLockTime) {
-		t.Fatalf("want ErrNegativeLockTime, got %v", err)
-	}
-}
-
-func TestCLTVRejectsTooLarge(t *testing.T) {
-	t.Parallel()
-	vm := &Engine{
-		dstack: stack{verifyMinimalData: true},
-		tx:     wire.MsgTx{LockTime: 1, TxIn: []*wire.TxIn{{Sequence: 0}}},
-	}
-	// 9-byte positive value ≥ 2^63: exceeds uint32 so CLTV must reject.
-	v := make([]byte, 9)
-	for i := 0; i < 8; i++ {
-		v[i] = 0xff
-	}
-	v[8] = 0x00
-	vm.dstack.PushByteArray(v)
-	err := opcodeCheckLockTimeVerify(nil, nil, vm)
-	if err == nil {
-		t.Fatalf("expected error for too-large locktime, got nil")
+		validVectors: []opcodeVector{
+			{
+				name: "balanced_true_to_false",
+				setupVM: func(vm *Engine) {
+					vm.condStack = []int{txscript.OpCondTrue}
+				},
+			},
+			{
+				name: "balanced_false_to_true",
+				setupVM: func(vm *Engine) {
+					vm.condStack = []int{txscript.OpCondFalse}
+				},
+			},
+			{
+				name: "balanced_skip_stays_skip",
+				setupVM: func(vm *Engine) {
+					vm.condStack = []int{txscript.OpCondSkip}
+				},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "unbalanced", expectedError: txscript.ErrUnbalancedConditional},
+		},
 	}
 }
 
-func TestCLTVAccepts9ByteBigNumThatFitsInUint32(t *testing.T) {
-	t.Parallel()
-	// 2^40, encoded minimally as [0x00,0x00,0x00,0x00,0x00,0x01] — 6 bytes.
-	// The old MakeScriptNum(..., 5) path would reject this as too big.
-	// With BigNum the Peek succeeds; verifyLockTime rejects it because
-	// 2^40 > tx.LockTime == 1.
-	v := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
-	vm := &Engine{
-		dstack: stack{verifyMinimalData: true},
-		tx:     wire.MsgTx{LockTime: 1, TxIn: []*wire.TxIn{{Sequence: 0}}},
+func endifSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_ENDIF,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetStack(), c.after.GetStack())
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrUnbalancedConditional)
+				require.Equal(t, c.before.condStack, c.after.condStack)
+				return
+			}
+
+			require.Equal(t, len(c.before.condStack)-1, len(c.after.condStack))
+		},
+		validVectors: []opcodeVector{
+			{
+				name: "balanced_pop",
+				setupVM: func(vm *Engine) {
+					vm.condStack = []int{txscript.OpCondTrue, txscript.OpCondFalse}
+				},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "unbalanced", expectedError: txscript.ErrUnbalancedConditional},
+		},
 	}
-	vm.dstack.PushByteArray(v)
-	err := opcodeCheckLockTimeVerify(nil, nil, vm)
-	if err == nil {
-		t.Fatalf("expected error (UnsatisfiedLockTime), got nil")
+}
+
+func toAltStackSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_TOALTSTACK,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeStack := len(c.before.GetStack())
+			afterStack := len(c.after.GetStack())
+			beforeAlt := len(c.before.GetAltStack())
+			afterAlt := len(c.after.GetAltStack())
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				require.Equal(t, c.before.GetStack(), c.after.GetStack())
+				require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+				return
+			}
+
+			require.Equal(t, beforeStack-1, afterStack)
+			require.Equal(t, beforeAlt+1, afterAlt)
+		},
+		validVectors: []opcodeVector{
+			{name: "move", inputStack: [][]byte{{0x01}}, expectedAltStack: [][]byte{{0x01}}},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
 	}
-	if !isScriptError(err, txscript.ErrUnsatisfiedLockTime) {
-		t.Fatalf("want ErrUnsatisfiedLockTime, got %v", err)
+}
+
+func fromAltStackSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_FROMALTSTACK,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeStack := len(c.before.GetStack())
+			afterStack := len(c.after.GetStack())
+			beforeAlt := len(c.before.GetAltStack())
+			afterAlt := len(c.after.GetAltStack())
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				require.Equal(t, c.before.GetStack(), c.after.GetStack())
+				require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+				return
+			}
+
+			require.Equal(t, beforeStack+1, afterStack)
+			require.Equal(t, beforeAlt-1, afterAlt)
+		},
+		validVectors: []opcodeVector{
+			{name: "move_back", inputAltStack: [][]byte{{0x01}}, expectedStack: [][]byte{{0x01}}},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
 	}
+}
+
+func ifDupSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_IFDUP,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				require.Equal(t, c.before.GetStack(), c.after.GetStack())
+				return
+			}
+
+			require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth+1)
+		},
+		validVectors: []opcodeVector{
+			{name: "zero", inputStack: [][]byte{nil}, expectedStack: [][]byte{zeroStackItem()}},
+			{
+				name:          "non_zero",
+				inputStack:    [][]byte{{0x01}},
+				expectedStack: [][]byte{{0x01}, {0x01}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func depthSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_DEPTH,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+			require.NoError(t, c.execErr)
+			require.Equal(t, len(c.before.GetStack())+1, len(c.after.GetStack()))
+		},
+		validVectors: []opcodeVector{
+			{name: "empty", expectedStack: [][]byte{zeroStackItem()}},
+			{
+				name:          "two",
+				inputStack:    [][]byte{{0x01}, {0x02}},
+				expectedStack: [][]byte{{0x01}, {0x02}, scriptNum(2).Bytes()},
+			},
+		},
+	}
+}
+
+func pickSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_PICK,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+				return
+			}
+
+			require.Equal(t, beforeDepth, afterDepth)
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "pick_0",
+				inputStack:    [][]byte{{0x01}, {0x02}, nil},
+				expectedStack: [][]byte{{0x01}, {0x02}, {0x02}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative_index",
+				inputStack:    [][]byte{{0x01}, scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{{0x01}, scriptNum(2).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func rollSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_ROLL,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "roll_1",
+				inputStack:    [][]byte{{0x01}, {0x02}, {0x01}},
+				expectedStack: [][]byte{{0x02}, {0x01}},
+			},
+			{
+				name:          "roll_0",
+				inputStack:    [][]byte{{0x01}, {0x02}, nil},
+				expectedStack: [][]byte{{0x01}, {0x02}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative_index",
+				inputStack:    [][]byte{{0x01}, scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{{0x01}, scriptNum(2).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func stackOpSpec(op byte) *opcodeSpec {
+	vector := opcodeVector{name: "valid"}
+
+	switch op {
+	case OP_2DROP:
+		vector.inputStack = [][]byte{{0x01}, {0x02}}
+		vector.expectedStack = [][]byte{}
+	case OP_2DUP:
+		vector.inputStack = [][]byte{{0x01}, {0x02}}
+		vector.expectedStack = [][]byte{{0x01}, {0x02}, {0x01}, {0x02}}
+	case OP_3DUP:
+		vector.inputStack = [][]byte{{0x01}, {0x02}, {0x03}}
+		vector.expectedStack = [][]byte{{0x01}, {0x02}, {0x03}, {0x01}, {0x02}, {0x03}}
+	case OP_2OVER:
+		vector.inputStack = [][]byte{{0x01}, {0x02}, {0x03}, {0x04}}
+		vector.expectedStack = [][]byte{{0x01}, {0x02}, {0x03}, {0x04}, {0x01}, {0x02}}
+	case OP_2ROT:
+		vector.inputStack = [][]byte{{0x01}, {0x02}, {0x03}, {0x04}, {0x05}, {0x06}}
+		vector.expectedStack = [][]byte{{0x03}, {0x04}, {0x05}, {0x06}, {0x01}, {0x02}}
+	case OP_2SWAP:
+		vector.inputStack = [][]byte{{0x01}, {0x02}, {0x03}, {0x04}}
+		vector.expectedStack = [][]byte{{0x03}, {0x04}, {0x01}, {0x02}}
+	case OP_DROP:
+		vector.inputStack = [][]byte{{0x01}}
+		vector.expectedStack = [][]byte{}
+	case OP_DUP:
+		vector.inputStack = [][]byte{{0x01}}
+		vector.expectedStack = [][]byte{{0x01}, {0x01}}
+	case OP_NIP:
+		vector.inputStack = [][]byte{{0x01}, {0x02}}
+		vector.expectedStack = [][]byte{{0x02}}
+	case OP_OVER:
+		vector.inputStack = [][]byte{{0x01}, {0x02}}
+		vector.expectedStack = [][]byte{{0x01}, {0x02}, {0x01}}
+	case OP_ROT:
+		vector.inputStack = [][]byte{{0x01}, {0x02}, {0x03}}
+		vector.expectedStack = [][]byte{{0x02}, {0x03}, {0x01}}
+	case OP_SWAP:
+		vector.inputStack = [][]byte{{0x01}, {0x02}}
+		vector.expectedStack = [][]byte{{0x02}, {0x01}}
+	case OP_TUCK:
+		vector.inputStack = [][]byte{{0x01}, {0x02}}
+		vector.expectedStack = [][]byte{{0x02}, {0x01}, {0x02}}
+	default:
+		panic(fmt.Sprintf("missing stack op vector mapping for opcode %s", opcodeArray[op].name))
+	}
+
+	return &opcodeSpec{
+		opcode:       op,
+		validVectors: []opcodeVector{vector},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equalf(
+				t,
+				c.before.GetAltStack(),
+				c.after.GetAltStack(),
+				"opcode=%s (0x%02x) phase=%s order=%d",
+				c.opcodeName,
+				c.opcode,
+				c.phase,
+				c.order,
+			)
+			require.Equalf(
+				t,
+				c.before.condStack,
+				c.after.condStack,
+				"opcode=%s (0x%02x) phase=%s order=%d",
+				c.opcodeName,
+				c.opcode,
+				c.phase,
+				c.order,
+			)
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				return
+			}
+
+			require.NoError(t, c.execErr)
+		},
+	}
+}
+
+func catSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_CAT,
+		checkProperties: byteTransformPropertyChecker(OP_CAT),
+		validVectors: []opcodeVector{
+			{
+				name:          "concat",
+				inputStack:    [][]byte{{0x01}, {0x02}},
+				expectedStack: [][]byte{{0x01, 0x02}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{{0x01}},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func substrSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_SUBSTR,
+		checkProperties: byteTransformPropertyChecker(OP_SUBSTR),
+		validVectors: []opcodeVector{
+			{
+				name:          "slice",
+				inputStack:    [][]byte{{0x01, 0x02, 0x03}, {0x01}, {0x01}},
+				expectedStack: [][]byte{{0x02}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_range",
+				inputStack:    [][]byte{{0x01, 0x02, 0x03}, {0x01}, {0x03}},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{{0x01}, {0x01}},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func leftSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_LEFT,
+		checkProperties: byteTransformPropertyChecker(OP_LEFT),
+		validVectors: []opcodeVector{
+			{
+				name:          "take",
+				inputStack:    [][]byte{{0x01, 0x02}, {0x01}},
+				expectedStack: [][]byte{{0x01}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_n",
+				inputStack:    [][]byte{{0x01}, {0x02}},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func rightSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_RIGHT,
+		checkProperties: byteTransformPropertyChecker(OP_RIGHT),
+		validVectors: []opcodeVector{
+			{
+				name:          "take",
+				inputStack:    [][]byte{{0x01, 0x02}, {0x01}},
+				expectedStack: [][]byte{{0x02}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_n",
+				inputStack:    [][]byte{{0x01}, {0x02}},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func sizeSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_SIZE,
+		checkProperties: byteTransformPropertyChecker(OP_SIZE),
+		validVectors: []opcodeVector{
+			{
+				name:          "empty",
+				inputStack:    [][]byte{nil},
+				expectedStack: [][]byte{zeroStackItem(), zeroStackItem()},
+			},
+			{
+				name:          "three",
+				inputStack:    [][]byte{{0x01, 0x02, 0x03}},
+				expectedStack: [][]byte{{0x01, 0x02, 0x03}, {0x03}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func invertSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INVERT,
+		checkProperties: byteTransformPropertyChecker(OP_INVERT),
+		validVectors: []opcodeVector{
+			{
+				name:          "not",
+				inputStack:    [][]byte{{0xAA, 0x55}},
+				expectedStack: [][]byte{{0x55, 0xAA}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func byteTransformPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrInvalidIndex,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+			)
+			require.LessOrEqual(t, afterDepth, beforeDepth)
+			return
+		}
+
+		switch op {
+		case OP_INVERT:
+			require.Equal(t, beforeDepth, afterDepth)
+		case OP_SIZE:
+			require.Equal(t, beforeDepth+1, afterDepth)
+		case OP_CAT, OP_LEFT, OP_RIGHT:
+			require.Equal(t, beforeDepth-1, afterDepth)
+		case OP_SUBSTR:
+			require.Equal(t, beforeDepth-2, afterDepth)
+		default:
+			t.Fatalf("unsupported byte transform %s", opcodeArray[op].name)
+		}
+
+		if op == OP_SIZE {
+			top := c.after.GetStack()[afterDepth-1]
+			require.LessOrEqual(t, len(top), 5)
+		}
+	}
+}
+
+func equalSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_EQUAL,
+		checkProperties: equalPropertyChecker(OP_EQUAL),
+		validVectors: []opcodeVector{
+			{name: "equal", inputStack: [][]byte{{0x01}, {0x01}}, expectedStack: [][]byte{{1}}},
+			{
+				name:          "not_equal",
+				inputStack:    [][]byte{{0x01}, {0x02}},
+				expectedStack: [][]byte{falseStackItem()},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func equalVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_EQUALVERIFY,
+		checkProperties: equalPropertyChecker(OP_EQUALVERIFY),
+		validVectors: []opcodeVector{
+			{name: "equal", inputStack: [][]byte{{0x01}, {0x01}}},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "not_equal",
+				inputStack:    [][]byte{{0x01}, {0x02}},
+				expectedError: txscript.ErrEqualVerify,
+			},
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func equalPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(
+				t,
+				c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrEqualVerify,
+			)
+			require.LessOrEqual(t, afterDepth, beforeDepth)
+			return
+		}
+
+		if op == OP_EQUAL {
+			require.Equal(t, beforeDepth-1, afterDepth)
+			top := c.after.GetStack()[afterDepth-1]
+			require.True(t, len(top) == 0 || bytes.Equal(top, []byte{1}))
+			return
+		}
+
+		require.Equal(t, beforeDepth-2, afterDepth)
+	}
+}
+
+func shiftSpec(op byte) *opcodeSpec {
+	validVectors := []opcodeVector{
+		{name: "shift", inputStack: [][]byte{{0x01}, {0x01}}, expectedStack: [][]byte{{0x02}}},
+		{name: "5 << 1 = 10", inputStack: [][]byte{{0x05}, {0x01}}, expectedStack: [][]byte{{0x0a}}},
+		{name: "255 << 1 = 510", inputStack: [][]byte{{0xff, 0x00}, {0x01}}, expectedStack: [][]byte{{0xfe, 0x01}}},
+	}
+	if op == OP_RSHIFT {
+		validVectors = []opcodeVector{
+			{name: "shift", inputStack: [][]byte{{0x02}, {0x01}}, expectedStack: [][]byte{{0x01}}},
+			{name: "-7 >> 1 = -4", inputStack: [][]byte{{0x87}, {0x01}}, expectedStack: [][]byte{{0x84}}},
+			{name: "-1 >> 100 = -1", inputStack: [][]byte{{0x81}, {0x64}}, expectedStack: [][]byte{{0x81}}},
+		}
+	}
+
+	return &opcodeSpec{
+		opcode: op,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrInvalidIndex,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.LessOrEqual(t, afterDepth, beforeDepth)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+		},
+		validVectors: validVectors,
+		invalidVectors: []opcodeVector{
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "missing_x",
+				inputStack:    [][]byte{{0x01}},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "negative_shift",
+				inputStack:    [][]byte{{0x01}, scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+		},
+	}
+}
+
+func bitwiseSpec(op byte) *opcodeSpec {
+	validInput := [][]byte{{0x0F}, {0xF0}}
+	var expectedStack [][]byte
+	switch op {
+	case OP_AND:
+		expectedStack = [][]byte{{0x00}}
+	case OP_OR:
+		expectedStack = [][]byte{{0xFF}}
+	case OP_XOR:
+		expectedStack = [][]byte{{0xFF}}
+	default:
+		panic(fmt.Sprintf("missing bitwise vector mapping for opcode %s", opcodeArray[op].name))
+	}
+
+	return &opcodeSpec{
+		opcode: op,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				require.LessOrEqual(t, len(c.after.GetStack()), len(c.before.GetStack()))
+				return
+			}
+
+			require.NoError(t, c.execErr)
+		},
+		validVectors: []opcodeVector{
+			{name: "valid", inputStack: validInput, expectedStack: expectedStack},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "mismatch",
+				inputStack:    [][]byte{{0x01}, {0x01, 0x02}},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func hashSpec(op byte, inputHex, expectedHex string, hashLen int) *opcodeSpec {
+	input, err := hex.DecodeString(inputHex)
+	if err != nil {
+		panic(fmt.Sprintf("invalid crypto input hex for opcode %s: %v", opcodeArray[op].name, err))
+	}
+	expected, err := hex.DecodeString(expectedHex)
+	if err != nil {
+		panic(
+			fmt.Sprintf("invalid crypto expected hex for opcode %s: %v", opcodeArray[op].name, err),
+		)
+	}
+
+	return &opcodeSpec{
+		opcode: op,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				require.LessOrEqual(t, afterDepth, beforeDepth)
+				return
+			}
+
+			require.Equal(t, beforeDepth, afterDepth)
+			top := c.after.GetStack()[afterDepth-1]
+			require.Len(t, top, hashLen)
+		},
+		validVectors: []opcodeVector{
+			{name: "hash", inputStack: [][]byte{input}, expectedStack: [][]byte{expected}},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+type unaryBigNumCase struct {
+	name string
+	in   BigNum
+	out  BigNum
+}
+
+type binaryBigNumCase struct {
+	name string
+	a    BigNum
+	b    BigNum
+	out  BigNum
+}
+
+func mustBigNumBytes(n BigNum) []byte {
+	b, err := n.Bytes()
+	if err != nil {
+		panic(fmt.Sprintf("BigNum.Bytes: %v", err))
+	}
+	return b
+}
+
+func mustBigNumFromBigInt(v *big.Int) BigNum {
+	n := BigNum{big: new(big.Int).Set(v), useBig: true}
+	if _, err := n.Bytes(); err != nil {
+		panic(fmt.Sprintf("invalid BigNum test value: %v", err))
+	}
+	return n
+}
+
+func binaryBigNumVector(tc binaryBigNumCase) opcodeVector {
+	return opcodeVector{
+		name: tc.name,
+		inputStack: [][]byte{
+			mustBigNumBytes(tc.a),
+			mustBigNumBytes(tc.b),
+		},
+		expectedStack: [][]byte{mustBigNumBytes(tc.out)},
+	}
+}
+
+func unaryBigNumVector(tc unaryBigNumCase) opcodeVector {
+	return opcodeVector{
+		name:          tc.name,
+		inputStack:    [][]byte{mustBigNumBytes(tc.in)},
+		expectedStack: [][]byte{mustBigNumBytes(tc.out)},
+	}
+}
+
+func maxPositiveBigNum(bytesLen int) BigNum {
+	b := bytes.Repeat([]byte{0xff}, bytesLen)
+	b[bytesLen-1] = 0x7f
+	n, err := BigNumFromBytes(b)
+	if err != nil {
+		panic(fmt.Sprintf("BigNumFromBytes(maxPositiveBigNum): %v", err))
+	}
+	return n
+}
+
+func requireCanonicalBoolStackItem(t *testing.T, got []byte, want bool) {
+	t.Helper()
+	if want {
+		require.Equal(t, []byte{0x01}, got)
+		return
+	}
+	require.Equal(t, zeroStackItem(), got)
+}
+
+func arithmeticBigNumPropertyChecker(
+	eval func(a, b BigNum) (BigNum, error),
+	errChecks ...func(*testing.T, error),
+) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			for _, check := range errChecks {
+				check(t, c.execErr)
+			}
+			require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+			return
+		}
+
+		require.Equal(t, beforeDepth-1, afterDepth)
+
+		b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+		require.NoError(t, err)
+		a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+		require.NoError(t, err)
+		want, err := eval(a, b)
+		require.NoError(t, err)
+		got, err := BigNumFromBytes(c.after.GetStack()[afterDepth-1])
+		require.NoError(t, err)
+		require.Zero(t, want.Cmp(got))
+	}
+}
+
+func comparisonBigNumPropertyChecker(
+	cmp func(a, b BigNum) bool,
+	errChecks ...func(*testing.T, error),
+) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			for _, check := range errChecks {
+				check(t, c.execErr)
+			}
+			require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+			return
+		}
+
+		require.Equal(t, beforeDepth-1, afterDepth)
+
+		b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+		require.NoError(t, err)
+		a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+		require.NoError(t, err)
+		requireCanonicalBoolStackItem(t, c.after.GetStack()[afterDepth-1], cmp(a, b))
+	}
+}
+
+func unaryBigNumPropertyChecker(
+	eval func(BigNum) BigNum,
+	errChecks ...func(*testing.T, error),
+) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			for _, check := range errChecks {
+				check(t, c.execErr)
+			}
+			require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+			return
+		}
+
+		require.Equal(t, beforeDepth, afterDepth)
+
+		in, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+		require.NoError(t, err)
+		want := eval(in)
+		got, err := BigNumFromBytes(c.after.GetStack()[afterDepth-1])
+		require.NoError(t, err)
+		require.Zero(t, want.Cmp(got))
+	}
+}
+
+func unaryBoolBigNumPropertyChecker(
+	eval func(BigNum) bool,
+	errChecks ...func(*testing.T, error),
+) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			for _, check := range errChecks {
+				check(t, c.execErr)
+			}
+			require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+			return
+		}
+
+		require.Equal(t, beforeDepth, afterDepth)
+
+		in, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+		require.NoError(t, err)
+		requireCanonicalBoolStackItem(t, c.after.GetStack()[afterDepth-1], eval(in))
+	}
+}
+
+func requireBigNumScriptErrorCodes(t *testing.T, err error) {
+	t.Helper()
+	requireScriptErrorCodeIn(t, err,
+		txscript.ErrInvalidStackOperation,
+		txscript.ErrNumberTooBig,
+		txscript.ErrMinimalData,
+	)
+}
+
+func requireBigNumDivisionError(t *testing.T, err error) {
+	t.Helper()
+	require.True(t,
+		errors.Is(err, ErrBigNumDivisionByZero) ||
+			isScriptError(err, txscript.ErrInvalidStackOperation) ||
+			isScriptError(err, txscript.ErrNumberTooBig) ||
+			isScriptError(err, txscript.ErrMinimalData),
+		"unexpected division error: %T: %v", err, err,
+	)
+}
+
+func requireBigNumModuloError(t *testing.T, err error) {
+	t.Helper()
+	require.True(t,
+		errors.Is(err, ErrBigNumModuloByZero) ||
+			isScriptError(err, txscript.ErrInvalidStackOperation) ||
+			isScriptError(err, txscript.ErrNumberTooBig) ||
+			isScriptError(err, txscript.ErrMinimalData),
+		"unexpected modulo error: %T: %v", err, err,
+	)
+}
+
+func oneAddSpec() *opcodeSpec {
+	maxIntPlusOne := mustBigNumFromBigInt(
+		new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1)),
+	)
+	max520 := maxPositiveBigNum(maxBigNumLen)
+	return &opcodeSpec{
+		opcode: OP_1ADD,
+		checkProperties: unaryBigNumPropertyChecker(
+			func(n BigNum) BigNum { return n.Add(BigNumFromInt64(1)) },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "small", in: BigNumFromInt64(1), out: BigNumFromInt64(2)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "negative_to_zero",
+					in:   BigNumFromInt64(-1),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "promotes_past_int64",
+					in:   BigNumFromInt64(math.MaxInt64),
+					out:  maxIntPlusOne,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "oversized_result",
+				inputStack:    [][]byte{mustBigNumBytes(max520)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func oneSubSpec() *opcodeSpec {
+	minIntMinusOne := mustBigNumFromBigInt(
+		new(big.Int).Sub(big.NewInt(math.MinInt64), big.NewInt(1)),
+	)
+	negMax520 := maxPositiveBigNum(maxBigNumLen).Negate()
+	return &opcodeSpec{
+		opcode: OP_1SUB,
+		checkProperties: unaryBigNumPropertyChecker(
+			func(n BigNum) BigNum { return n.Sub(BigNumFromInt64(1)) },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "small", in: BigNumFromInt64(1), out: BigNumFromInt64(0)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "zero_to_negative",
+					in:   BigNumFromInt64(0),
+					out:  BigNumFromInt64(-1),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "promotes_past_int64",
+					in:   BigNumFromInt64(math.MinInt64),
+					out:  minIntMinusOne,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "oversized_result",
+				inputStack:    [][]byte{mustBigNumBytes(negMax520)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func twoMulSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	max520 := maxPositiveBigNum(maxBigNumLen)
+	return &opcodeSpec{
+		opcode: OP_2MUL,
+		checkProperties: unaryBigNumPropertyChecker(
+			func(n BigNum) BigNum { return n.Add(n) },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "small", in: BigNumFromInt64(3), out: BigNumFromInt64(6)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "negative",
+					in:   BigNumFromInt64(-3),
+					out:  BigNumFromInt64(-6),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "promotes_past_int64",
+					in:   BigNumFromInt64(1 << 62),
+					out:  twoTo63,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "oversized_result",
+				inputStack:    [][]byte{mustBigNumBytes(max520)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func twoDivSpec() *opcodeSpec {
+	minusTwoTo62 := mustBigNumFromBigInt(new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 62)))
+	return &opcodeSpec{
+		opcode: OP_2DIV,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			unaryBigNumPropertyChecker(
+				func(n BigNum) BigNum {
+					result, err := n.Div(BigNumFromInt64(2))
+					require.NoError(t, err)
+					return result
+				},
+				requireBigNumDivisionError,
+			)(t, c)
+		},
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "small", in: BigNumFromInt64(6), out: BigNumFromInt64(3)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "positive_odd_truncates",
+					in:   BigNumFromInt64(7),
+					out:  BigNumFromInt64(3),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "negative_odd_truncates",
+					in:   BigNumFromInt64(-7),
+					out:  BigNumFromInt64(-3),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "min_int64_halves",
+					in:   BigNumFromInt64(math.MinInt64),
+					out:  minusTwoTo62,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func absSpec() *opcodeSpec {
+	minInt64Abs := mustBigNumFromBigInt(new(big.Int).Neg(big.NewInt(math.MinInt64)))
+	return &opcodeSpec{
+		opcode: OP_ABS,
+		checkProperties: unaryBigNumPropertyChecker(
+			func(n BigNum) BigNum { return n.Abs() },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "negative", in: BigNumFromInt64(-5), out: BigNumFromInt64(5)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "positive", in: BigNumFromInt64(5), out: BigNumFromInt64(5)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "promotes_past_int64",
+					in:   BigNumFromInt64(math.MinInt64),
+					out:  minInt64Abs,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func notSpec() *opcodeSpec {
+	bigNonZero := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_NOT,
+		checkProperties: unaryBoolBigNumPropertyChecker(
+			func(n BigNum) bool { return n.IsZero() },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "zero", in: BigNumFromInt64(0), out: BigNumFromInt64(1)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "one", in: BigNumFromInt64(1), out: BigNumFromInt64(0)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "small_non_zero",
+					in:   BigNumFromInt64(5),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "big_non_zero", in: bigNonZero, out: BigNumFromInt64(0)},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func zeroNotEqualSpec() *opcodeSpec {
+	bigNonZero := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_0NOTEQUAL,
+		checkProperties: unaryBoolBigNumPropertyChecker(
+			func(n BigNum) bool { return !n.IsZero() },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "zero", in: BigNumFromInt64(0), out: BigNumFromInt64(0)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "one", in: BigNumFromInt64(1), out: BigNumFromInt64(1)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "small_non_zero",
+					in:   BigNumFromInt64(5),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "big_non_zero", in: bigNonZero, out: BigNumFromInt64(1)},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func modSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_MOD,
+		checkProperties: arithmeticBigNumPropertyChecker(
+			func(a, b BigNum) (BigNum, error) { return a.Mod(b) },
+			requireBigNumModuloError,
+		),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(13),
+					b:    BigNumFromInt64(3),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative_dividend",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(-1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative_divisor",
+					a:    BigNumFromInt64(7),
+					b:    BigNumFromInt64(-2),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "min_int64_mod_minus_one",
+					a:    BigNumFromInt64(math.MinInt64),
+					b:    BigNumFromInt64(-1),
+					out:  BigNumFromInt64(0),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name: "mod_zero",
+				inputStack: [][]byte{
+					mustBigNumBytes(BigNumFromInt64(1)),
+					mustBigNumBytes(BigNumFromInt64(0)),
+				},
+				expectedExecErr: ErrBigNumModuloByZero,
+			},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func boolAndSpec() *opcodeSpec {
+	bigNonZero := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_BOOLAND,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireBigNumScriptErrorCodes(t, c.execErr)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+			b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			requireCanonicalBoolStackItem(
+				t,
+				c.after.GetStack()[afterDepth-1],
+				!a.IsZero() && !b.IsZero(),
+			)
+		},
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(10),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "right_zero",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(0),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "left_zero",
+					a:    BigNumFromInt64(0),
+					b:    BigNumFromInt64(7),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big_non_zero",
+					a:    bigNonZero,
+					b:    BigNumFromInt64(1),
+					out:  BigNumFromInt64(1),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func boolOrSpec() *opcodeSpec {
+	bigNonZero := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_BOOLOR,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireBigNumScriptErrorCodes(t, c.execErr)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+			b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			requireCanonicalBoolStackItem(
+				t,
+				c.after.GetStack()[afterDepth-1],
+				!a.IsZero() || !b.IsZero(),
+			)
+		},
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(0),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "both_zero",
+					a:    BigNumFromInt64(0),
+					b:    BigNumFromInt64(0),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "right_non_zero",
+					a:    BigNumFromInt64(0),
+					b:    BigNumFromInt64(7),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big_non_zero",
+					a:    bigNonZero,
+					b:    BigNumFromInt64(0),
+					out:  BigNumFromInt64(1),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func numEqualSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_NUMEQUAL,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireBigNumScriptErrorCodes(t, c.execErr)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+			b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			requireCanonicalBoolStackItem(t, c.after.GetStack()[afterDepth-1], a.Cmp(b) == 0)
+		},
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "not_equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(6),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative_equal",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(-7),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big_equal",
+					a:    twoTo63,
+					b:    twoTo63,
+					out:  BigNumFromInt64(1),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func numNotEqualSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_NUMNOTEQUAL,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireBigNumScriptErrorCodes(t, c.execErr)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+			b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			requireCanonicalBoolStackItem(t, c.after.GetStack()[afterDepth-1], a.Cmp(b) != 0)
+		},
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "not_equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(6),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "sign_differs",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(7),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big_not_equal",
+					a:    twoTo63,
+					b:    BigNumFromInt64(math.MaxInt64),
+					out:  BigNumFromInt64(1),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func minSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_MIN,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireBigNumScriptErrorCodes(t, c.execErr)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+			b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			want := b
+			if a.Cmp(b) < 0 {
+				want = a
+			}
+			got, err := BigNumFromBytes(c.after.GetStack()[afterDepth-1])
+			require.NoError(t, err)
+			require.Zero(t, want.Cmp(got))
+		},
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(10),
+					out:  BigNumFromInt64(5),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "reversed",
+					a:    BigNumFromInt64(10),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(5),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(-7),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big_width",
+					a:    BigNumFromInt64(math.MaxInt64),
+					b:    twoTo63,
+					out:  BigNumFromInt64(math.MaxInt64),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func maxSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_MAX,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireBigNumScriptErrorCodes(t, c.execErr)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+			b, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			a, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			want := b
+			if a.Cmp(b) > 0 {
+				want = a
+			}
+			got, err := BigNumFromBytes(c.after.GetStack()[afterDepth-1])
+			require.NoError(t, err)
+			require.Zero(t, want.Cmp(got))
+		},
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(10),
+					out:  BigNumFromInt64(10),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "reversed",
+					a:    BigNumFromInt64(10),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(10),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(2),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big_width",
+					a:    BigNumFromInt64(math.MaxInt64),
+					b:    twoTo63,
+					out:  twoTo63,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func negateSpec() *opcodeSpec {
+	minInt64Negated := mustBigNumFromBigInt(new(big.Int).Neg(big.NewInt(math.MinInt64)))
+	return &opcodeSpec{
+		opcode: OP_NEGATE,
+		checkProperties: unaryBigNumPropertyChecker(
+			func(n BigNum) BigNum { return n.Negate() },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			unaryBigNumVector(
+				unaryBigNumCase{name: "small", in: BigNumFromInt64(5), out: BigNumFromInt64(-5)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "zero", in: BigNumFromInt64(0), out: BigNumFromInt64(0)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{name: "negative", in: BigNumFromInt64(-7), out: BigNumFromInt64(7)},
+			),
+			unaryBigNumVector(
+				unaryBigNumCase{
+					name: "promotes past int64",
+					in:   BigNumFromInt64(math.MinInt64),
+					out:  minInt64Negated,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func addSpec() *opcodeSpec {
+	maxIntPlusOne := mustBigNumFromBigInt(
+		new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1)),
+	)
+	max520 := maxPositiveBigNum(maxBigNumLen)
+	return &opcodeSpec{
+		opcode: OP_ADD,
+		checkProperties: arithmeticBigNumPropertyChecker(func(a, b BigNum) (BigNum, error) {
+			return a.Add(b), nil
+		}, requireBigNumScriptErrorCodes),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(1),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(3),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative plus positive",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(-5),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "promotes past int64",
+					a:    BigNumFromInt64(math.MaxInt64),
+					b:    BigNumFromInt64(1),
+					out:  maxIntPlusOne,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "oversized_result",
+				inputStack:    [][]byte{mustBigNumBytes(max520), mustBigNumBytes(max520)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func subSpec() *opcodeSpec {
+	minIntMinusOne := mustBigNumFromBigInt(
+		new(big.Int).Sub(big.NewInt(math.MinInt64), big.NewInt(1)),
+	)
+	max520 := maxPositiveBigNum(maxBigNumLen)
+	negMax520 := max520.Negate()
+	return &opcodeSpec{
+		opcode: OP_SUB,
+		checkProperties: arithmeticBigNumPropertyChecker(func(a, b BigNum) (BigNum, error) {
+			return a.Sub(b), nil
+		}, requireBigNumScriptErrorCodes),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(3),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "subtract negative",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(-2),
+					out:  BigNumFromInt64(7),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "promotes past int64",
+					a:    BigNumFromInt64(math.MinInt64),
+					b:    BigNumFromInt64(1),
+					out:  minIntMinusOne,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "oversized_result",
+				inputStack:    [][]byte{mustBigNumBytes(max520), mustBigNumBytes(negMax520)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func mulSpec() *opcodeSpec {
+	twoTo64 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 64))
+	max520 := maxPositiveBigNum(maxBigNumLen)
+	return &opcodeSpec{
+		opcode: OP_MUL,
+		checkProperties: arithmeticBigNumPropertyChecker(func(a, b BigNum) (BigNum, error) {
+			return a.Mul(b), nil
+		}, requireBigNumScriptErrorCodes),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(3),
+					b:    BigNumFromInt64(4),
+					out:  BigNumFromInt64(12),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative",
+					a:    BigNumFromInt64(-3),
+					b:    BigNumFromInt64(4),
+					out:  BigNumFromInt64(-12),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "promotes past int64",
+					a:    BigNumFromInt64(1 << 32),
+					b:    BigNumFromInt64(1 << 32),
+					out:  twoTo64,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name: "oversized_result",
+				inputStack: [][]byte{
+					mustBigNumBytes(max520),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func divSpec() *opcodeSpec {
+	minIntDivNegOne := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_DIV,
+		checkProperties: arithmeticBigNumPropertyChecker(func(a, b BigNum) (BigNum, error) {
+			return a.Div(b)
+		}, requireBigNumDivisionError),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "small",
+					a:    BigNumFromInt64(12),
+					b:    BigNumFromInt64(3),
+					out:  BigNumFromInt64(4),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative dividend truncates",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(-3),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "negative divisor truncates",
+					a:    BigNumFromInt64(7),
+					b:    BigNumFromInt64(-2),
+					out:  BigNumFromInt64(-3),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "promotes past int64",
+					a:    BigNumFromInt64(math.MinInt64),
+					b:    BigNumFromInt64(-1),
+					out:  minIntDivNegOne,
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name: "div_zero",
+				inputStack: [][]byte{
+					mustBigNumBytes(BigNumFromInt64(1)),
+					mustBigNumBytes(BigNumFromInt64(0)),
+				},
+				expectedExecErr: ErrBigNumDivisionByZero,
+			},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func lessThanSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_LESSTHAN,
+		checkProperties: comparisonBigNumPropertyChecker(
+			func(a, b BigNum) bool { return a.Cmp(b) < 0 },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(10),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "false equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "false negative",
+					a:    BigNumFromInt64(-2),
+					b:    BigNumFromInt64(-7),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big width true",
+					a:    BigNumFromInt64(math.MaxInt64),
+					b:    twoTo63,
+					out:  BigNumFromInt64(1),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func lessThanOrEqualSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_LESSTHANOREQUAL,
+		checkProperties: comparisonBigNumPropertyChecker(
+			func(a, b BigNum) bool { return a.Cmp(b) <= 0 },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true less",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "false greater",
+					a:    BigNumFromInt64(10),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big width false",
+					a:    twoTo63,
+					b:    BigNumFromInt64(math.MaxInt64),
+					out:  BigNumFromInt64(0),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func greaterThanSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_GREATERTHAN,
+		checkProperties: comparisonBigNumPropertyChecker(
+			func(a, b BigNum) bool { return a.Cmp(b) > 0 },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true",
+					a:    BigNumFromInt64(10),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "false equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true negative",
+					a:    BigNumFromInt64(-2),
+					b:    BigNumFromInt64(-7),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big width false",
+					a:    BigNumFromInt64(math.MaxInt64),
+					b:    twoTo63,
+					out:  BigNumFromInt64(0),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func greaterThanOrEqualSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_GREATERTHANOREQUAL,
+		checkProperties: comparisonBigNumPropertyChecker(
+			func(a, b BigNum) bool { return a.Cmp(b) >= 0 },
+			requireBigNumScriptErrorCodes,
+		),
+		validVectors: []opcodeVector{
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "equal",
+					a:    BigNumFromInt64(5),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "true greater",
+					a:    BigNumFromInt64(10),
+					b:    BigNumFromInt64(5),
+					out:  BigNumFromInt64(1),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "false less",
+					a:    BigNumFromInt64(-7),
+					b:    BigNumFromInt64(2),
+					out:  BigNumFromInt64(0),
+				},
+			),
+			binaryBigNumVector(
+				binaryBigNumCase{
+					name: "big width true",
+					a:    twoTo63,
+					b:    BigNumFromInt64(math.MaxInt64),
+					out:  BigNumFromInt64(1),
+				},
+			),
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "non_minimal",
+				inputStack:    [][]byte{{0x01, 0x00}, mustBigNumBytes(BigNumFromInt64(2))},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func numEqualVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_NUMEQUALVERIFY,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumEqualVerify,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-2, afterDepth)
+		},
+		validVectors: []opcodeVector{
+			{name: "equal", inputStack: [][]byte{scriptNum(5).Bytes(), scriptNum(5).Bytes()}},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "not_equal",
+				inputStack:    [][]byte{scriptNum(5).Bytes(), scriptNum(6).Bytes()},
+				expectedError: txscript.ErrNumEqualVerify,
+			},
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func withinSpec() *opcodeSpec {
+	twoTo63 := mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 63))
+	return &opcodeSpec{
+		opcode: OP_WITHIN,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-3)
+				return
+			}
+
+			require.Equal(t, beforeDepth-2, afterDepth)
+
+			maxVal, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			minVal, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			x, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-3])
+			require.NoError(t, err)
+			requireCanonicalBoolStackItem(
+				t,
+				c.after.GetStack()[afterDepth-1],
+				x.Cmp(minVal) >= 0 && x.Cmp(maxVal) < 0,
+			)
+		},
+		validVectors: []opcodeVector{
+			{
+				name: "in",
+				inputStack: [][]byte{
+					mustBigNumBytes(BigNumFromInt64(5)),
+					mustBigNumBytes(BigNumFromInt64(0)),
+					mustBigNumBytes(BigNumFromInt64(10)),
+				},
+				expectedStack: [][]byte{{1}},
+			},
+			{
+				name: "out",
+				inputStack: [][]byte{
+					mustBigNumBytes(BigNumFromInt64(11)),
+					mustBigNumBytes(BigNumFromInt64(0)),
+					mustBigNumBytes(BigNumFromInt64(10)),
+				},
+				expectedStack: [][]byte{falseStackItem()},
+			},
+			{
+				name: "equal_to_min",
+				inputStack: [][]byte{
+					mustBigNumBytes(BigNumFromInt64(-7)),
+					mustBigNumBytes(BigNumFromInt64(-7)),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedStack: [][]byte{{1}},
+			},
+			{
+				name: "equal_to_max_is_out",
+				inputStack: [][]byte{
+					mustBigNumBytes(BigNumFromInt64(2)),
+					mustBigNumBytes(BigNumFromInt64(-7)),
+					mustBigNumBytes(BigNumFromInt64(2)),
+				},
+				expectedStack: [][]byte{falseStackItem()},
+			},
+			{
+				name: "big_width_in",
+				inputStack: [][]byte{
+					mustBigNumBytes(twoTo63),
+					mustBigNumBytes(BigNumFromInt64(math.MaxInt64)),
+					mustBigNumBytes(mustBigNumFromBigInt(new(big.Int).Lsh(big.NewInt(1), 64))),
+				},
+				expectedStack: [][]byte{{1}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "underflow",
+				inputStack:    [][]byte{},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name: "non_minimal",
+				inputStack: [][]byte{
+					{0x01, 0x00},
+					mustBigNumBytes(BigNumFromInt64(0)),
+					mustBigNumBytes(BigNumFromInt64(10)),
+				},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_input",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					mustBigNumBytes(BigNumFromInt64(0)),
+					mustBigNumBytes(BigNumFromInt64(10)),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func num2BinSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_NUM2BIN,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.True(t, afterDepth <= beforeDepth && afterDepth >= beforeDepth-2)
+				return
+			}
+
+			require.Equal(t, beforeDepth-1, afterDepth)
+
+			size, err := MakeScriptNum(c.before.GetStack()[beforeDepth-1], true, maxScriptNumLen)
+			require.NoError(t, err)
+			num, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-2])
+			require.NoError(t, err)
+			want, err := num.FixedBytes(int(size))
+			require.NoError(t, err)
+			require.Equal(t, want, c.after.GetStack()[afterDepth-1])
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "5_as_4_bytes",
+				inputStack:    [][]byte{{0x05}, scriptNum(4).Bytes()},
+				expectedStack: [][]byte{{0x05, 0x00, 0x00, 0x00}},
+			},
+			{
+				name:          "neg5_as_4_bytes",
+				inputStack:    [][]byte{{0x85}, scriptNum(4).Bytes()},
+				expectedStack: [][]byte{{0x05, 0x00, 0x00, 0x80}},
+			},
+			{
+				name:          "neg5_as_1_byte",
+				inputStack:    [][]byte{{0x85}, scriptNum(1).Bytes()},
+				expectedStack: [][]byte{{0x85}},
+			},
+			{
+				name:          "zero_as_4_bytes",
+				inputStack:    [][]byte{nil, scriptNum(4).Bytes()},
+				expectedStack: [][]byte{{0x00, 0x00, 0x00, 0x00}},
+			},
+			{
+				name:          "zero_as_0_bytes",
+				inputStack:    [][]byte{nil, scriptNum(0).Bytes()},
+				expectedStack: [][]byte{emptyByteVector()},
+			},
+			{
+				name:          "128_as_2_bytes",
+				inputStack:    [][]byte{{0x80, 0x00}, scriptNum(2).Bytes()},
+				expectedStack: [][]byte{{0x80, 0x00}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "missing_num",
+				inputStack:    [][]byte{scriptNum(1).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "negative_size",
+				inputStack:    [][]byte{nil, scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "size_over_max",
+				inputStack:    [][]byte{nil, scriptNum(521).Bytes()},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "num_does_not_fit",
+				inputStack:    [][]byte{{0xff, 0x00}, scriptNum(1).Bytes()},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+			{
+				name:          "non_minimal_num",
+				inputStack:    [][]byte{{0x01, 0x00}, scriptNum(1).Bytes()},
+				expectedError: txscript.ErrMinimalData,
+			},
+			{
+				name: "oversized_num",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, maxBigNumLen+1),
+					scriptNum(1).Bytes(),
+				},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func bin2NumSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_BIN2NUM,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeDepth := len(c.before.GetStack())
+			afterDepth := len(c.after.GetStack())
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumberTooBig,
+				)
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+				return
+			}
+
+			require.Equal(t, beforeDepth, afterDepth)
+			want := minimallyEncode(c.before.GetStack()[beforeDepth-1])
+			require.Equal(t, want, c.after.GetStack()[afterDepth-1])
+			_, err := BigNumFromBytes(c.after.GetStack()[afterDepth-1])
+			require.NoError(t, err)
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "5_from_4_bytes",
+				inputStack:    [][]byte{{0x05, 0x00, 0x00, 0x00}},
+				expectedStack: [][]byte{{0x05}},
+			},
+			{
+				name:          "negative_zero_normalizes",
+				inputStack:    [][]byte{{0x00, 0x00, 0x00, 0x80}},
+				expectedStack: [][]byte{emptyByteVector()},
+			},
+			{
+				name:          "neg5_from_4_bytes",
+				inputStack:    [][]byte{{0x05, 0x00, 0x00, 0x80}},
+				expectedStack: [][]byte{{0x85}},
+			},
+			{
+				name:          "128_minimal",
+				inputStack:    [][]byte{{0x80, 0x00, 0x00, 0x00}},
+				expectedStack: [][]byte{{0x80, 0x00}},
+			},
+			{
+				name:          "empty_stays_zero",
+				inputStack:    [][]byte{emptyByteVector()},
+				expectedStack: [][]byte{emptyByteVector()},
+			},
+			{
+				name:          "already_minimal",
+				inputStack:    [][]byte{{0x85}},
+				expectedStack: [][]byte{{0x85}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "oversized_input",
+				inputStack:    [][]byte{bytes.Repeat([]byte{0x01}, maxBigNumLen+1)},
+				expectedError: txscript.ErrNumberTooBig,
+			},
+		},
+	}
+}
+
+func txWeightSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_TXWEIGHT,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.NoError(t, c.execErr)
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+			require.Equal(t, len(c.before.GetStack())+1, len(c.after.GetStack()))
+			require.Len(t, c.after.GetStack()[len(c.after.GetStack())-1], 4)
+		},
+		validVectors: []opcodeVector{
+			{name: "push", expectedStack: [][]byte{opcodeWorldTxWeight()}},
+		},
+	}
+}
+
+func txIDSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_TXID,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.NoError(t, c.execErr)
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+			require.Equal(t, len(c.before.GetStack())+1, len(c.after.GetStack()))
+			top := c.after.GetStack()[len(c.after.GetStack())-1]
+			require.Len(t, top, 32)
+			h := c.before.tx.TxHash()
+			require.Equal(t, h[:], top)
+		},
+		validVectors: []opcodeVector{{name: "push"}},
+	}
+}
+
+func le64(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, v)
+	return b
+}
+
+func assetSpec(op byte) *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          op,
+		checkProperties: errorNoMutationChecker(txscript.ErrInvalidStackOperation),
+		invalidVectors: []opcodeVector{
+			{name: "no_assets", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func checkLockTimeVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_CHECKLOCKTIMEVERIFY,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetStack(), c.after.GetStack())
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+			if c.execErr == nil {
+				return
+			}
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrNegativeLockTime,
+				txscript.ErrUnsatisfiedLockTime,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+			)
+		},
+		validVectors: []opcodeVector{
+			{
+				name:       "satisfied",
+				inputStack: [][]byte{scriptNum(100).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 200
+					w.tx.TxIn[0].Sequence = 0
+				},
+			},
+			{
+				name:       "satisfied_5_byte_bignum",
+				inputStack: [][]byte{{0x00, 0x5e, 0xd0, 0xb2, 0x00}},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 3_000_000_000
+					w.tx.TxIn[0].Sequence = 0
+				},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:       "not_satisfied",
+				inputStack: [][]byte{scriptNum(300).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 200
+					w.tx.TxIn[0].Sequence = 0
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+			{
+				name:       "too_large_for_uint32",
+				inputStack: [][]byte{{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00}},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 1
+					w.tx.TxIn[0].Sequence = 0
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+			{
+				name:       "bignum_above_uint32",
+				inputStack: [][]byte{{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 1
+					w.tx.TxIn[0].Sequence = 0
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrNegativeLockTime,
+			},
+			{
+				name:       "mismatched_type",
+				inputStack: [][]byte{scriptNum(int64(txscript.LockTimeThreshold) + 1).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 200
+					w.tx.TxIn[0].Sequence = 0
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+			{
+				name:       "finalized_input",
+				inputStack: [][]byte{scriptNum(100).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.LockTime = 200
+					w.tx.TxIn[0].Sequence = wire.MaxTxInSequenceNum
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+		},
+	}
+}
+
+func checkSequenceVerifySpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_CHECKSEQUENCEVERIFY,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetStack(), c.after.GetStack())
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+			if c.execErr == nil {
+				return
+			}
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrNegativeLockTime,
+				txscript.ErrUnsatisfiedLockTime,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+			)
+		},
+		validVectors: []opcodeVector{
+			{
+				name:       "satisfied",
+				inputStack: [][]byte{scriptNum(50).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.Version = 2
+					w.tx.TxIn[0].Sequence = 100
+				},
+			},
+			{
+				name:       "disabled_stack_flag_nop",
+				inputStack: [][]byte{scriptNum(int64(wire.SequenceLockTimeDisabled)).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.Version = 1
+					w.tx.TxIn[0].Sequence = wire.MaxTxInSequenceNum
+				},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:       "not_satisfied",
+				inputStack: [][]byte{scriptNum(150).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.Version = 2
+					w.tx.TxIn[0].Sequence = 100
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrNegativeLockTime,
+			},
+			{
+				name:       "version_too_low",
+				inputStack: [][]byte{scriptNum(50).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.Version = 1
+					w.tx.TxIn[0].Sequence = 100
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+			{
+				name:       "tx_sequence_disabled",
+				inputStack: [][]byte{scriptNum(50).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx.Version = 2
+					w.tx.TxIn[0].Sequence = wire.SequenceLockTimeDisabled
+				},
+				expectedError: txscript.ErrUnsatisfiedLockTime,
+			},
+		},
+	}
+}
+
+func sha256InitializeSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_SHA256INITIALIZE,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				return
+			}
+
+			beforeStack := c.before.GetStack()
+			afterStack := c.after.GetStack()
+			require.Equal(t, len(beforeStack), len(afterStack))
+			require.Equal(t, beforeStack[:len(beforeStack)-1], afterStack[:len(afterStack)-1])
+			require.NotEmpty(t, afterStack[len(afterStack)-1])
+			require.NotEqual(t, beforeStack[len(beforeStack)-1], afterStack[len(afterStack)-1])
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "init_golden",
+				inputStack:    [][]byte{[]byte("Hello")},
+				expectedStack: [][]byte{sha256InitGolden},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func sha256UpdateSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_SHA256UPDATE,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				return
+			}
+
+			beforeStack := c.before.GetStack()
+			afterStack := c.after.GetStack()
+			require.Equal(t, len(beforeStack)-1, len(afterStack))
+			require.Equal(t, beforeStack[:len(beforeStack)-2], afterStack[:len(afterStack)-1])
+			require.NotEmpty(t, afterStack[len(afterStack)-1])
+			require.NotEqual(t, beforeStack[len(beforeStack)-1], afterStack[len(afterStack)-1])
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "valid_update_golden",
+				inputStack:    [][]byte{sha256InitGolden, []byte(" World")},
+				expectedStack: [][]byte{sha256UpdateGolden},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_state",
+				inputStack:    [][]byte{{0x01, 0x02}, []byte("x")},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow_data", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "underflow_state",
+				inputStack:    [][]byte{[]byte("x")},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+func sha256FinalizeSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_SHA256FINALIZE,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			if c.execErr != nil {
+				requireScriptErrorCode(t, c.execErr, txscript.ErrInvalidStackOperation)
+				return
+			}
+
+			beforeStack := c.before.GetStack()
+			afterStack := c.after.GetStack()
+			require.Equal(t, len(beforeStack)-1, len(afterStack))
+			require.Equal(t, beforeStack[:len(beforeStack)-2], afterStack[:len(afterStack)-1])
+			require.Len(t, afterStack[len(afterStack)-1], 32)
+			require.NotEqual(t, beforeStack[len(beforeStack)-1], afterStack[len(afterStack)-1])
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "valid_finalize_golden",
+				inputStack:    [][]byte{sha256UpdateGolden, []byte("!")},
+				expectedStack: [][]byte{sha256FinalizeGolden},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "invalid_state",
+				inputStack:    [][]byte{{0x01, 0x02}, []byte("x")},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow_data", expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "underflow_state",
+				inputStack:    [][]byte{[]byte("x")},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+		},
+	}
+}
+
+var sha256InitGolden = mustDecodeHex(
+	"097f060102ff8200000070ff80006c736861036a09e667bb67ae853c6ef372a54ff53a510e527f9b05688c1f83d9ab5be0cd1948656c6c6f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005",
+)
+
+var sha256UpdateGolden = mustDecodeHex(
+	"097f060102ff8200000070ff80006c736861036a09e667bb67ae853c6ef372a54ff53a510e527f9b05688c1f83d9ab5be0cd1948656c6c6f20576f726c640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b",
+)
+
+var sha256FinalizeGolden = mustDecodeHex(
+	"7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069",
+)
+
+func inspectInputOutpointSpec() *opcodeSpec {
+	input0Hash := hashWithSalt([]byte("opcode-vectors"), 0x10)
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTOUTPOINT,
+		checkProperties: inspectInputPropertyChecker(OP_INSPECTINPUTOUTPOINT),
+		validVectors: []opcodeVector{
+			{
+				name:          "input0",
+				inputStack:    [][]byte{nil},
+				expectedStack: [][]byte{hashBytes(input0Hash), {10}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputValueSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTVALUE,
+		checkProperties: inspectInputPropertyChecker(OP_INSPECTINPUTVALUE),
+		validVectors: []opcodeVector{
+			{name: "val0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{0x88, 0x13}}},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "no_prev_fetcher",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.prevFetcher = nil },
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputScriptPubkeySpec() *opcodeSpec {
+	prevScriptHash := sha256Bytes([]byte{OP_1, 0x20})
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTSCRIPTPUBKEY,
+		checkProperties: inspectInputPropertyChecker(OP_INSPECTINPUTSCRIPTPUBKEY),
+		validVectors: []opcodeVector{
+			{
+				name:       "spk0",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					prevTx := wire.MsgTx{TxOut: make([]*wire.TxOut, 11)}
+					prevTx.TxOut[10] = &wire.TxOut{PkScript: []byte{OP_1, 0x20}}
+					attachOpcodePrevArkTx(w, prevTx)
+				},
+				expectedStack: [][]byte{prevScriptHash, {0x81}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "no_prev_fetcher",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.prevFetcher = nil },
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "missing_prevout",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.tx.TxIn[0].PreviousOutPoint = wire.OutPoint{} },
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputSequenceSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTSEQUENCE,
+		checkProperties: inspectInputPropertyChecker(OP_INSPECTINPUTSEQUENCE),
+		validVectors: []opcodeVector{
+			{name: "seq0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{100, 0, 0, 0}}},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectOutputValueSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTOUTPUTVALUE,
+		checkProperties: inspectOutputPropertyChecker(OP_INSPECTOUTPUTVALUE),
+		validVectors: []opcodeVector{
+			{name: "val0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{0x58, 0x1b}}},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectOutputScriptPubkeySpec() *opcodeSpec {
+	outputScriptHash := sha256Bytes([]byte{OP_TRUE})
+	return &opcodeSpec{
+		opcode:          OP_INSPECTOUTPUTSCRIPTPUBKEY,
+		checkProperties: inspectOutputPropertyChecker(OP_INSPECTOUTPUTSCRIPTPUBKEY),
+		validVectors: []opcodeVector{
+			{
+				name:          "spk0",
+				inputStack:    [][]byte{nil},
+				expectedStack: [][]byte{outputScriptHash, {0x81}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func pushCurrentInputIndexSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_PUSHCURRENTINPUTINDEX,
+		checkProperties: inspectMetaPropertyChecker(OP_PUSHCURRENTINPUTINDEX),
+		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{zeroStackItem()}}},
+	}
+}
+
+func inspectVersionSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTVERSION,
+		checkProperties: inspectMetaPropertyChecker(OP_INSPECTVERSION),
+		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{{2, 0, 0, 0}}}},
+	}
+}
+
+func inspectLocktimeSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTLOCKTIME,
+		checkProperties: inspectMetaPropertyChecker(OP_INSPECTLOCKTIME),
+		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{{144, 0, 0, 0}}}},
+	}
+}
+
+func inspectNumInputsSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTNUMINPUTS,
+		checkProperties: inspectMetaPropertyChecker(OP_INSPECTNUMINPUTS),
+		validVectors: []opcodeVector{
+			{name: "push", expectedStack: [][]byte{scriptNum(1).Bytes()}},
+		},
+	}
+}
+
+func inspectNumOutputsSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTNUMOUTPUTS,
+		checkProperties: inspectMetaPropertyChecker(OP_INSPECTNUMOUTPUTS),
+		validVectors: []opcodeVector{
+			{name: "push", expectedStack: [][]byte{scriptNum(1).Bytes()}},
+		},
+	}
+}
+
+func inspectPacketSpec() *opcodeSpec {
+	const packetType = 2
+	const maxPacketType = 255
+	payload := []byte{0xde, 0xad, 0xbe, 0xef}
+	maxPayload := []byte{0xff, 0x00, 0xff}
+	largePayload := bytes.Repeat([]byte{0xab}, 1000)
+
+	return &opcodeSpec{
+		opcode:          OP_INSPECTPACKET,
+		checkProperties: inspectPacketPropertyChecker(OP_INSPECTPACKET),
+		validVectors: []opcodeVector{
+			{
+				name:       "found",
+				inputStack: [][]byte{scriptNum(packetType).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx = makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: packetType, Data: payload})
+				},
+				expectedStack: [][]byte{payload, {1}},
+			},
+			{
+				name:       "not_found",
+				inputStack: [][]byte{scriptNum(9).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx = makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: packetType, Data: payload})
+				},
+				expectedStack: [][]byte{nil, nil},
+			},
+			{
+				name:          "no_extension",
+				inputStack:    [][]byte{scriptNum(packetType).Bytes()},
+				expectedStack: [][]byte{nil, nil},
+			},
+			{
+				name:       "max_type",
+				inputStack: [][]byte{scriptNum(maxPacketType).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx = makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: maxPacketType, Data: maxPayload})
+				},
+				expectedStack: [][]byte{maxPayload, {1}},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "negative_type", inputStack: [][]byte{scriptNum(-1).Bytes()}, expectedError: txscript.ErrInvalidStackOperation},
+			{name: "type_out_of_range", inputStack: [][]byte{scriptNum(256).Bytes()}, expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:       "malformed_extension",
+				inputStack: [][]byte{scriptNum(packetType).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx = makeOpcodeTxWithMalformedExtension([]byte{'A', 'R', 'K', packetType})
+				},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:       "large_content",
+				inputStack: [][]byte{scriptNum(4).Bytes()},
+				setupWorld: func(w *opcodeWorld) {
+					w.tx = makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: 4, Data: largePayload})
+				},
+				expectedError: txscript.ErrElementTooBig,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputPacketSpec() *opcodeSpec {
+	const packetType = 2
+	payload := []byte{0xde, 0xad, 0xbe, 0xef}
+	largePayload := bytes.Repeat([]byte{0xab}, 1000)
+
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTPACKET,
+		checkProperties: inspectPacketPropertyChecker(OP_INSPECTINPUTPACKET),
+		validVectors: []opcodeVector{
+			{
+				name:       "found",
+				inputStack: [][]byte{scriptNum(packetType).Bytes(), nil},
+				setupWorld: func(w *opcodeWorld) {
+					attachOpcodePrevArkTx(w, makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: packetType, Data: payload}))
+				},
+				expectedStack: [][]byte{payload, {1}},
+			},
+			{
+				name:       "not_found",
+				inputStack: [][]byte{scriptNum(9).Bytes(), nil},
+				setupWorld: func(w *opcodeWorld) {
+					attachOpcodePrevArkTx(w, makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: packetType, Data: payload}))
+				},
+				expectedStack: [][]byte{nil, nil},
+			},
+			{
+				name:       "prev_tx_no_extension",
+				inputStack: [][]byte{scriptNum(packetType).Bytes(), nil},
+				setupWorld: func(w *opcodeWorld) {
+					attachOpcodePrevArkTx(w, makeOpcodePlainTx())
+				},
+				expectedStack: [][]byte{nil, nil},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{name: "negative_index", inputStack: [][]byte{scriptNum(packetType).Bytes(), scriptNum(-1).Bytes()}, expectedError: txscript.ErrInvalidIndex},
+			{name: "index_out_of_range", inputStack: [][]byte{scriptNum(packetType).Bytes(), scriptNum(9).Bytes()}, expectedError: txscript.ErrInvalidIndex},
+			{name: "type_out_of_range", inputStack: [][]byte{scriptNum(256).Bytes(), nil}, expectedError: txscript.ErrInvalidStackOperation},
+			{
+				name:          "no_prev_fetcher",
+				inputStack:    [][]byte{scriptNum(packetType).Bytes(), nil},
+				setupWorld:    func(w *opcodeWorld) { w.prevFetcher = nil },
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "prevout_tx_not_available",
+				inputStack:    [][]byte{scriptNum(packetType).Bytes(), nil},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:       "malformed_prev_tx_extension",
+				inputStack: [][]byte{scriptNum(packetType).Bytes(), nil},
+				setupWorld: func(w *opcodeWorld) {
+					attachOpcodePrevArkTx(w, makeOpcodeTxWithMalformedExtension([]byte{'A', 'R', 'K', packetType}))
+				},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:       "large_content",
+				inputStack: [][]byte{scriptNum(4).Bytes(), nil},
+				setupWorld: func(w *opcodeWorld) {
+					attachOpcodePrevArkTx(w, makeOpcodeTxWithExtension(extension.UnknownPacket{PacketType: 4, Data: largePayload}))
+				},
+				expectedError: txscript.ErrElementTooBig,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+			{name: "single_stack_element", inputStack: [][]byte{scriptNum(packetType).Bytes()}, expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrInvalidIndex,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+			)
+			require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+			return
+		}
+
+		switch op {
+		case OP_INSPECTINPUTOUTPOINT, OP_INSPECTINPUTSCRIPTPUBKEY:
+			require.Equal(t, beforeDepth+1, afterDepth)
+		case OP_INSPECTINPUTVALUE, OP_INSPECTINPUTSEQUENCE:
+			require.Equal(t, beforeDepth, afterDepth)
+		default:
+			t.Fatalf("unsupported inspect input op %s", opcodeArray[op].name)
+		}
+
+		top := c.after.GetStack()[afterDepth-1]
+		switch op {
+		case OP_INSPECTINPUTOUTPOINT:
+			require.LessOrEqual(t, len(top), 5)
+			require.Len(t, c.after.GetStack()[afterDepth-2], 32)
+		case OP_INSPECTINPUTVALUE:
+			index, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			prevOut := c.before.prevOutFetcher.FetchPrevOutput(c.before.tx.TxIn[int(index.BigInt().Int64())].PreviousOutPoint)
+			require.NotNil(t, prevOut)
+			want, err := BigNumFromUint64(uint64(prevOut.Value)).Bytes()
+			require.NoError(t, err)
+			require.Equal(t, want, top)
+		case OP_INSPECTINPUTSCRIPTPUBKEY:
+			require.LessOrEqual(t, len(top), 5)
+			programOrHash := c.after.GetStack()[afterDepth-2]
+			require.NotEmpty(t, programOrHash)
+		case OP_INSPECTINPUTSEQUENCE:
+			require.Len(t, top, 4)
+		}
+	}
+}
+
+func inspectOutputPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrInvalidIndex,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+			)
+			require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+			return
+		}
+
+		switch op {
+		case OP_INSPECTOUTPUTVALUE:
+			require.Equal(t, beforeDepth, afterDepth)
+			index, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			want, err := BigNumFromUint64(uint64(c.before.tx.TxOut[int(index.BigInt().Int64())].Value)).Bytes()
+			require.NoError(t, err)
+			require.Equal(t, want, c.after.GetStack()[afterDepth-1])
+		case OP_INSPECTOUTPUTSCRIPTPUBKEY:
+			require.Equal(t, beforeDepth+1, afterDepth)
+			require.LessOrEqual(t, len(c.after.GetStack()[afterDepth-1]), 5)
+			require.NotEmpty(t, c.after.GetStack()[afterDepth-2])
+		default:
+			t.Fatalf("unsupported inspect output op %s", opcodeArray[op].name)
+		}
+	}
+}
+
+func inspectMetaPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+		require.NoError(t, c.execErr)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		require.Equal(t, beforeDepth+1, afterDepth)
+
+		top := c.after.GetStack()[afterDepth-1]
+		switch op {
+		case OP_INSPECTVERSION, OP_INSPECTLOCKTIME:
+			require.Len(t, top, 4)
+		case OP_PUSHCURRENTINPUTINDEX, OP_INSPECTNUMINPUTS, OP_INSPECTNUMOUTPUTS:
+			require.LessOrEqual(t, len(top), 5)
+		default:
+			t.Fatalf("unsupported inspect meta op %s", opcodeArray[op].name)
+		}
+	}
+}
+
+func inspectInputArkadeScriptHashSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTARKADESCRIPTHASH,
+		checkProperties: inspectInputArkadePropertyChecker(),
+		validVectors: []opcodeVector{
+			{
+				name:       "valid",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					w.packet = IntrospectorPacket{{Vin: 0, Script: []byte{OP_TRUE}}}
+				},
+				expectedStack: [][]byte{ArkadeScriptHash([]byte{OP_TRUE})},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "missing_entry",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.packet = IntrospectorPacket{{Vin: 1, Script: []byte{OP_TRUE}}} },
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "no_packet",
+				inputStack:    [][]byte{nil},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputArkadeWitnessHashSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode:          OP_INSPECTINPUTARKADEWITNESSHASH,
+		checkProperties: inspectInputArkadePropertyChecker(),
+		validVectors: []opcodeVector{
+			{
+				name:       "valid",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					w.packet = IntrospectorPacket{{Vin: 0, Witness: wire.TxWitness{{0x01}}}}
+				},
+			},
+			{
+				name:       "empty_witness",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					w.packet = IntrospectorPacket{{Vin: 0, Witness: wire.TxWitness{}}}
+				},
+				expectedStack: [][]byte{make([]byte, 32)},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative",
+				inputStack:    [][]byte{scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "missing_entry",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.packet = IntrospectorPacket{{Vin: 1, Witness: wire.TxWitness{{0x01}}}} },
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "no_packet",
+				inputStack:    [][]byte{nil},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func inspectInputArkadePropertyChecker() opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrInvalidIndex,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+			)
+			require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+			return
+		}
+
+		require.Equal(t, beforeDepth, afterDepth)
+		require.Len(t, c.after.GetStack()[afterDepth-1], 32)
+	}
+}
+
+func inspectPacketPropertyChecker(op byte) opcodePropertyChecker {
+	return func(t *testing.T, c opcodeCheckContext) {
+		t.Helper()
+		require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+		require.Equal(t, c.before.condStack, c.after.condStack)
+
+		beforeDepth := len(c.before.GetStack())
+		afterDepth := len(c.after.GetStack())
+		if c.execErr != nil {
+			requireScriptErrorCodeIn(t, c.execErr,
+				txscript.ErrInvalidStackOperation,
+				txscript.ErrInvalidIndex,
+				txscript.ErrNumberTooBig,
+				txscript.ErrMinimalData,
+				txscript.ErrElementTooBig,
+			)
+			switch op {
+			case OP_INSPECTPACKET:
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1)
+			case OP_INSPECTINPUTPACKET:
+				require.True(t, afterDepth == beforeDepth || afterDepth == beforeDepth-1 || afterDepth == beforeDepth-2)
+			default:
+				t.Fatalf("unsupported inspect packet op %s", opcodeArray[op].name)
+			}
+			return
+		}
+
+		switch op {
+		case OP_INSPECTPACKET:
+			require.Equal(t, beforeDepth+1, afterDepth)
+		case OP_INSPECTINPUTPACKET:
+			require.Equal(t, beforeDepth, afterDepth)
+		default:
+			t.Fatalf("unsupported inspect packet op %s", opcodeArray[op].name)
+		}
+
+		flag := c.after.GetStack()[afterDepth-1]
+		require.True(t, bytes.Equal(flag, zeroStackItem()) || bytes.Equal(flag, []byte{1}))
+		require.LessOrEqual(t, len(c.after.GetStack()[afterDepth-2]), txscript.MaxScriptElementSize)
+	}
+}
+
+func buildOpcodeWorld() *opcodeWorld {
+	seed := []byte("opcode-vectors")
+	outpoint0 := wire.OutPoint{Hash: hashWithSalt(seed, 0x10), Index: 10}
+	tx := wire.MsgTx{
+		Version:  2,
+		LockTime: 144,
+		TxIn:     []*wire.TxIn{{PreviousOutPoint: outpoint0, Sequence: 100}},
+		TxOut:    []*wire.TxOut{{Value: 7000, PkScript: []byte{OP_TRUE}}},
+	}
+	prevouts := map[wire.OutPoint]*wire.TxOut{
+		outpoint0: {Value: 5000, PkScript: []byte{OP_1, 0x20}},
+	}
+	return &opcodeWorld{
+		tx:          tx,
+		prevouts:    prevouts,
+		prevFetcher: newTestArkPrevOutFetcher(txscript.NewMultiPrevOutFetcher(prevouts), nil, nil),
+	}
+}
+
+func makeOpcodePlainTx() wire.MsgTx {
+	return wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0},
+		}},
+	}
+}
+
+func makeOpcodeTxWithExtension(packets ...extension.Packet) wire.MsgTx {
+	ext := extension.Extension(packets)
+	txOut, err := ext.TxOut()
+	if err != nil {
+		panic(fmt.Sprintf("Extension.TxOut: %v", err))
+	}
+	tx := makeOpcodePlainTx()
+	tx.TxOut = []*wire.TxOut{txOut}
+	return tx
+}
+
+func makeOpcodeTxWithMalformedExtension(payload []byte) wire.MsgTx {
+	tx := makeOpcodePlainTx()
+	tx.TxOut = []*wire.TxOut{{
+		Value:    0,
+		PkScript: append([]byte{txscript.OP_RETURN, byte(len(payload))}, payload...),
+	}}
+	return tx
+}
+
+func attachOpcodePrevArkTx(w *opcodeWorld, prevTx wire.MsgTx) {
+	outpoint := w.tx.TxIn[0].PreviousOutPoint
+	w.prevFetcher = newTestArkPrevOutFetcher(
+		txscript.NewMultiPrevOutFetcher(w.prevouts),
+		map[wire.OutPoint]*wire.MsgTx{outpoint: &prevTx},
+		map[wire.OutPoint]uint32{outpoint: outpoint.Index},
+	)
+}
+
+func newOpcodeEngine(world *opcodeWorld, txIdx int) (*Engine, error) {
+	txCopy := world.tx.Copy()
+	spk := []byte{OP_TRUE}
+	inputAmount := int64(0)
+
+	if txIdx >= 0 && txIdx < len(txCopy.TxIn) {
+		if witness := world.witnessByVin[txIdx]; len(witness) > 0 {
+			txCopy.TxIn[txIdx].Witness = cloneWitness(witness)
+		}
+		if script := world.execScriptByVin[txIdx]; len(script) > 0 {
+			spk = cloneBytes(script)
+		}
+		if world.prevFetcher != nil {
+			if prevOut := world.prevFetcher.FetchPrevOutput(txCopy.TxIn[txIdx].PreviousOutPoint); prevOut != nil {
+				inputAmount = prevOut.Value
+			}
+		}
+	}
+
+	vm, err := NewEngine(spk, txCopy, txIdx, txscript.NewSigCache(32), nil, inputAmount, world.prevFetcher)
+	if err != nil {
+		return nil, err
+	}
+	vm.dstack.verifyMinimalData = true
+	vm.astack.verifyMinimalData = true
+	return vm, nil
+}
+
+func invokeOpcodeWithData(opcode byte, data []byte, vm *Engine) error {
+	op := &opcodeArray[opcode]
+	if op.opfunc == nil {
+		return nil
+	}
+	if data == nil {
+		if op.length > 1 {
+			data = make([]byte, op.length-1)
+		}
+	}
+	return vm.executeOpcode(op, data)
+}
+
+func requireScriptErrorCode(t *testing.T, err error, code txscript.ErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	scriptErr, ok := err.(txscript.Error)
+	require.Truef(t, ok, "expected txscript.Error, got %T: %v", err, err)
+	require.Equal(t, code, scriptErr.ErrorCode)
+}
+
+func requireScriptErrorCodeIn(t *testing.T, err error, codes ...txscript.ErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	scriptErr, ok := err.(txscript.Error)
+	require.Truef(t, ok, "expected txscript.Error, got %T: %v", err, err)
+	if slices.Contains(codes, scriptErr.ErrorCode) {
+		return
+	}
+	t.Fatalf("unexpected txscript error code: got=%v want one of=%v", scriptErr.ErrorCode, codes)
+}
+
+func hashWithSalt(seed []byte, salt byte) chainhash.Hash {
+	b := make([]byte, len(seed)+1)
+	copy(b, seed)
+	b[len(seed)] = salt
+	sum := sha256.Sum256(b)
+	var h chainhash.Hash
+	copy(h[:], sum[:])
+	return h
+}
+
+func mustDecodeHex(hexStr string) []byte {
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		panic(fmt.Sprintf("invalid hex string: %v", err))
+	}
+	return b
+}
+
+func zeroStackItem() []byte {
+	return scriptNum(0).Bytes()
+}
+
+func falseStackItem() []byte {
+	return fromBool(false)
+}
+
+func emptyByteVector() []byte {
+	return []byte{}
+}
+
+func opcodeWorldTxWeight() []byte {
+	world := buildOpcodeWorld()
+	weight := make([]byte, 4)
+	binary.LittleEndian.PutUint32(weight, uint32(world.tx.SerializeSizeStripped()*4))
+	return weight
+}
+
+func hashBytes(h chainhash.Hash) []byte {
+	return append([]byte(nil), h[:]...)
+}
+
+func sha256Bytes(data []byte) []byte {
+	sum := sha256.Sum256(data)
+	return append([]byte(nil), sum[:]...)
 }

--- a/pkg/arkade/testdata/fuzz/FuzzOpcodes/0c4534cdd5e00666
+++ b/pkg/arkade/testdata/fuzz/FuzzOpcodes/0c4534cdd5e00666
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("%7Z'\x00AXXX\"")

--- a/pkg/arkade/testdata/fuzz/FuzzOpcodes/1415e15e6896c7cf
+++ b/pkg/arkade/testdata/fuzz/FuzzOpcodes/1415e15e6896c7cf
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("&! 7\xb8\xa3+a\x80\x000")

--- a/pkg/arkade/testdata/fuzz/FuzzOpcodes/343f7661205be8db
+++ b/pkg/arkade/testdata/fuzz/FuzzOpcodes/343f7661205be8db
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\x01GZ\x00\x00XXXX\x00\"")

--- a/pkg/arkade/testdata/fuzz/FuzzOpcodes/ab582ac4da10b417
+++ b/pkg/arkade/testdata/fuzz/FuzzOpcodes/ab582ac4da10b417
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("&\x00 7\xb8\xa3+a\x80X0")

--- a/pkg/arkade/tokenizer_fuzz_test.go
+++ b/pkg/arkade/tokenizer_fuzz_test.go
@@ -1,0 +1,68 @@
+package arkade
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzArkadeScriptTokenizer(f *testing.F) {
+	fix := readFixtures(f)
+
+	for _, tc := range fix.Valid {
+		for _, entry := range tc.Packet {
+			f.Add(entry.Script)
+		}
+	}
+
+	for _, tc := range fix.Invalid {
+		if !tc.HasEntries {
+			continue
+		}
+
+		for _, entry := range tc.Entries {
+			f.Add(entry.Script)
+		}
+	}
+
+	// Handcrafted edge seeds for tokenizer branches.
+	f.Add([]byte{})
+	f.Add([]byte{OP_FALSE})
+	f.Add([]byte{OP_TRUE})
+
+	for i := uint8(1); i <= 75; i++ {
+		f.Add([]byte{i})
+		f.Add([]byte{i, 0xAA})
+		buf := append([]byte{i}, bytes.Repeat([]byte{0xAA}, int(i))...)
+		f.Add(buf)
+		buf = append([]byte{i}, bytes.Repeat([]byte{0xAA}, int(i+1))...)
+		f.Add(buf)
+	}
+
+	f.Add([]byte{OP_PUSHDATA1})
+	f.Add([]byte{OP_PUSHDATA1, 0x00})
+	f.Add([]byte{OP_PUSHDATA1, 0x01, 0xAA})
+	f.Add([]byte{OP_PUSHDATA1, 0x02, 0xAA})
+	f.Add([]byte{OP_PUSHDATA2})
+	f.Add([]byte{OP_PUSHDATA2, 0x01})
+	f.Add([]byte{OP_PUSHDATA2, 0x00, 0x00})
+	f.Add([]byte{OP_PUSHDATA2, 0x02, 0x00, 0xAA, 0xBB})
+	f.Add([]byte{OP_PUSHDATA2, 0x03, 0x00, 0xAA})
+	f.Add([]byte{OP_PUSHDATA4})
+	f.Add([]byte{OP_PUSHDATA4, 0x01, 0x00, 0x00})
+	f.Add([]byte{OP_PUSHDATA4, 0x00, 0x00, 0x00, 0x00})
+	f.Add([]byte{OP_PUSHDATA4, 0x02, 0x00, 0x00, 0x00, 0xAA, 0xBB})
+	f.Add([]byte{OP_PUSHDATA4, 0x03, 0x00, 0x00, 0x00, 0xAA})
+	f.Add([]byte{OP_PUSHDATA4, 0x00, 0x00, 0x00, 0x80})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		tokenizer := MakeScriptTokenizer(0, data)
+		for tokenizer.Next() {
+			_ = tokenizer.Opcode()
+			_ = tokenizer.Data()
+			_ = tokenizer.ByteIndex()
+			_ = tokenizer.OpcodePosition()
+		}
+		_ = tokenizer.Script()
+		_ = tokenizer.Err()
+	})
+}


### PR DESCRIPTION
Works towards #39 

Fuzz Targets:
- [x] ArkadeScript Tokenizer [2c88976](https://github.com/ArkLabsHQ/introspector/pull/43/commits/2c88976cfb98d36c9bbd12694292942880594d21)
- [x] All Opcodes [22e5439](https://github.com/ArkLabsHQ/introspector/pull/43/commits/22e5439d434f7a915a65de05cd69a3976832254f)
- [x] Engine [8cc9b8c](https://github.com/ArkLabsHQ/introspector/pull/43/commits/8cc9b8ceb955fc155fda9ccaad141d17d654acb1)

Future refactoring work:
- Tweak world builders to Increase coverage - current coverage of fuzz tests with local cached corpus: 81% of `pkg/arkade`
- Refactor fuzz helpers - a lot of this is AI generated and could be condensed while maintaining coverage