### PR TITLE
Test: tweaking and signature signing/verify with odd and even keys

### DIFF
--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -8,7 +8,8 @@ services:
     ports:
       - 7073:7073
     environment:
-      - INTROSPECTOR_SECRET_KEY=f40f6e7a5cf262f4093d4605b8f40cbaf9da9e59bf32f24bb27a4ffc74f71eab
+       # public key has odd y
+      - INTROSPECTOR_SECRET_KEY=5646b2e23bbb82491fb4ef262079ff17594d5e873fc6bcea5f1453edbe1029b1
       - INTROSPECTOR_NO_TLS=true
     volumes:
       - type: tmpfs

--- a/pkg/arkade/tweak.go
+++ b/pkg/arkade/tweak.go
@@ -4,6 +4,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 var (
@@ -40,7 +41,7 @@ func ComputeArkadeScriptPublicKey(pubKey *btcec.PublicKey, scriptHash []byte) *b
 func ComputeArkadeScriptPrivateKey(privKey *btcec.PrivateKey, scriptHash []byte) *btcec.PrivateKey {
 	privKeyScalar := privKey.Key
 	pubKeyBytes := privKey.PubKey().SerializeCompressed()
-	if pubKeyBytes[0] == 0x03 {
+	if pubKeyBytes[0] == secp256k1.PubKeyFormatCompressedOdd {
 		privKeyScalar.Negate()
 	}
 

--- a/pkg/arkade/tweak_test.go
+++ b/pkg/arkade/tweak_test.go
@@ -1,0 +1,127 @@
+package arkade
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArkadeScriptKeyTweaking(t *testing.T) {
+	testVector := []struct {
+		name                string
+		script              []byte
+		priv                *btcec.PrivateKey
+		prefix              byte
+		expectedTweakedPref byte
+	}{
+		{
+			name:                "even",
+			script:              []byte("OP_TRUE"),
+			priv:                mustPrivKeyFromSeedWithPrefix(t, "private-key-seed-even", secp256k1.PubKeyFormatCompressedEven),
+			prefix:              secp256k1.PubKeyFormatCompressedEven,
+			expectedTweakedPref: 0,
+		},
+		{
+			name:                "odd",
+			script:              []byte("OP_TRUE"),
+			priv:                mustPrivKeyFromSeedWithPrefix(t, "private-key-seed-odd", secp256k1.PubKeyFormatCompressedOdd),
+			prefix:              secp256k1.PubKeyFormatCompressedOdd,
+			expectedTweakedPref: 0,
+		},
+		{
+			name:                "even_to_tweaked_odd",
+			script:              []byte("OP_TRUE"), // don't change script or tweaked key might not be odd
+			priv:                mustPrivKeyFromHexString(t, "05717677ccec3c6ec975b8356b104808b6e149b82d9816d2d7c3b25dd658c220"),
+			prefix:              secp256k1.PubKeyFormatCompressedEven,
+			expectedTweakedPref: secp256k1.PubKeyFormatCompressedOdd,
+		},
+		{
+			name:                "even_to_tweaked_even",
+			script:              []byte("OP_TRUE"), // don't change script or tweaked key might not be even
+			priv:                mustPrivKeyFromHexString(t, "2b6f9e9c6b1b6ada475009bb6ac01e7cacc5879ab2610b1ad017cf7e467665af"),
+			prefix:              secp256k1.PubKeyFormatCompressedEven,
+			expectedTweakedPref: secp256k1.PubKeyFormatCompressedEven,
+		},
+	}
+
+	for _, tc := range testVector {
+		t.Run(fmt.Sprintf("roundtrip_%s", tc.name), func(t *testing.T) {
+			require.Equal(t, tc.prefix, tc.priv.PubKey().SerializeCompressed()[0])
+
+			scriptHash := ArkadeScriptHash(tc.script)
+			tweakedPriv := ComputeArkadeScriptPrivateKey(tc.priv, scriptHash)
+			expectedTweakedPub := ComputeArkadeScriptPublicKey(tc.priv.PubKey(), scriptHash)
+
+			require.Equal(
+				t,
+				schnorr.SerializePubKey(expectedTweakedPub),
+				schnorr.SerializePubKey(tweakedPriv.PubKey()),
+			)
+		})
+
+		t.Run(fmt.Sprintf("verify_sig_%s", tc.name), func(t *testing.T) {
+			require.Equal(t, tc.prefix, tc.priv.PubKey().SerializeCompressed()[0])
+
+			scriptHash := ArkadeScriptHash(tc.script)
+			tweakedPriv := ComputeArkadeScriptPrivateKey(tc.priv, scriptHash)
+			tweakedPub := ComputeArkadeScriptPublicKey(tc.priv.PubKey(), scriptHash)
+
+			msg := sha256.Sum256([]byte("yo"))
+			sig, err := schnorr.Sign(tweakedPriv, msg[:])
+			require.NoError(t, err)
+
+			parsedSig, err := schnorr.ParseSignature(sig.Serialize())
+			require.NoError(t, err)
+
+			xOnlyPub := schnorr.SerializePubKey(tweakedPub)
+			parsedPub, err := schnorr.ParsePubKey(xOnlyPub)
+			require.NoError(t, err)
+
+			require.True(t, parsedSig.Verify(msg[:], parsedPub))
+			require.False(t, parsedSig.Verify(msg[:], tc.priv.PubKey()))
+
+			if tc.expectedTweakedPref != 0 {
+				require.Equal(t, tc.expectedTweakedPref, tweakedPriv.PubKey().SerializeCompressed()[0])
+			}
+		})
+	}
+}
+
+func mustPrivKeyFromSeedWithPrefix(t *testing.T, seed string, prefix byte) *btcec.PrivateKey {
+	t.Helper()
+	digest := sha256.Sum256([]byte(seed))
+	privKey, _ := btcec.PrivKeyFromBytes(digest[:])
+
+	if prefix != secp256k1.PubKeyFormatCompressedEven && prefix != secp256k1.PubKeyFormatCompressedOdd {
+		t.Fatalf("unsupported compressed prefix 0x%x", prefix)
+	}
+
+	if privKey.PubKey().SerializeCompressed()[0] == prefix {
+		return privKey
+	}
+
+	negated := privKey.Key
+	negated.Negate()
+	result := &btcec.PrivateKey{Key: negated}
+	require.Equal(t, prefix, result.PubKey().SerializeCompressed()[0])
+	return result
+}
+
+func mustHexToBytes(t *testing.T, hexStr string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	return data
+}
+
+func mustPrivKeyFromHexString(t *testing.T, hex string) *btcec.PrivateKey {
+	t.Helper()
+	priv, _ := btcec.PrivKeyFromBytes(mustHexToBytes(t, hex))
+	return priv
+}


### PR DESCRIPTION
Changes:
- d2593cf: add unit coverage for Arkade script key tweaking roundtrip and signature verification across odd/even parity cases.
- 4ea9cce: replace parity magic values with secp256k1 compressed-key constants for clarity and correctness.
- 974d637: update E2E fixtures to use a private key that yields odd-Y pubkeys, exercising the parity-sensitive path.

Note: Running the unit test after reverting 9e9d703 fails as expected with:
```
--- FAIL: TestArkadeScriptKeyTweaking (0.01s)
    --- PASS: TestArkadeScriptKeyTweaking/roundtrip_even (0.00s)
    --- PASS: TestArkadeScriptKeyTweaking/verify_sig_even (0.00s)
    --- FAIL: TestArkadeScriptKeyTweaking/roundtrip_odd (0.00s)
    --- FAIL: TestArkadeScriptKeyTweaking/verify_sig_odd (0.00s)
    --- PASS: TestArkadeScriptKeyTweaking/roundtrip_even_to_tweaked_odd (0.00s)
    --- PASS: TestArkadeScriptKeyTweaking/verify_sig_even_to_tweaked_odd (0.00s)
    --- PASS: TestArkadeScriptKeyTweaking/roundtrip_even_to_tweaked_even (0.00s)
    --- PASS: TestArkadeScriptKeyTweaking/verify_sig_even_to_tweaked_even (0.00s)
```