### PR TITLE
Asset introspection pushes LE64 instead of scriptNum

### DIFF
--- a/pkg/arkade/asset_opcodes.go
+++ b/pkg/arkade/asset_opcodes.go
@@ -10,15 +10,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 )
 
-// pushAmountLE64 encodes a uint64 as 8-byte little-endian and pushes it onto
-// the data stack. This is consistent with how OP_INSPECTOUTPUTVALUE pushes
-// satoshi values, allowing scripts to use 64-bit arithmetic ops directly.
-func pushAmountLE64(vm *Engine, amount uint64) {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, amount)
-	vm.dstack.PushByteArray(buf)
-}
-
 // opcodeInspectNumAssetGroups pushes the total number of asset groups in the packet onto the stack.
 func opcodeInspectNumAssetGroups(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
@@ -58,8 +49,10 @@ func opcodeInspectAssetGroupAssetId(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectAssetGroupCtrl pops a group index k and pushes the control asset reference (txid, index).
-// Pushes -1 if there is no control asset.
+// opcodeInspectAssetGroupCtrl pops a group index k and pushes a tagged control
+// asset reference.
+// Found:   pushes 1, txid, index.
+// Missing: pushes 0, empty txid, 0.
 func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -77,11 +70,14 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 	group := vm.assetPacket[int(k)]
 
 	if group.ControlAsset == nil {
-		vm.dstack.PushInt(-1)
+		vm.dstack.PushInt(0)
+		vm.dstack.PushByteArray(nil)
+		vm.dstack.PushInt(0)
 		return nil
 	}
 
 	if group.ControlAsset.Type == asset.AssetRefByID {
+		vm.dstack.PushInt(1)
 		vm.dstack.PushByteArray(group.ControlAsset.AssetId.Txid[:])
 		vm.dstack.PushInt(scriptNum(group.ControlAsset.AssetId.Index))
 		return nil
@@ -95,9 +91,11 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 		if ctrlGroup.AssetId == nil {
 			// Referenced group is a fresh issuance, use current tx hash and the group index
 			txHash := vm.tx.TxHash()
+			vm.dstack.PushInt(1)
 			vm.dstack.PushByteArray(txHash[:])
 			vm.dstack.PushInt(scriptNum(group.ControlAsset.GroupIndex))
 		} else {
+			vm.dstack.PushInt(1)
 			vm.dstack.PushByteArray(ctrlGroup.AssetId.Txid[:])
 			vm.dstack.PushInt(scriptNum(ctrlGroup.AssetId.Index))
 		}
@@ -107,8 +105,10 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 	return scriptError(txscript.ErrInvalidStackOperation, "invalid control asset type")
 }
 
-// opcodeFindAssetGroupByAssetId pops an asset ID (gidx, txid) and searches for the matching group index.
-// Pushes the group index if found, or -1 if not found.
+// opcodeFindAssetGroupByAssetId pops an asset ID (gidx, txid) and searches for
+// the matching group index.
+// Found:   pushes 1, group index.
+// Missing: pushes 0, 0.
 func opcodeFindAssetGroupByAssetId(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -135,6 +135,7 @@ func opcodeFindAssetGroupByAssetId(op *opcode, data []byte, vm *Engine) error {
 		if group.AssetId == nil {
 			txHash := vm.tx.TxHash()
 			if txHash.IsEqual(&searchTxid) && scriptNum(i) == gidx {
+				vm.dstack.PushInt(1)
 				vm.dstack.PushInt(scriptNum(i))
 				return nil
 			}
@@ -142,12 +143,14 @@ func opcodeFindAssetGroupByAssetId(op *opcode, data []byte, vm *Engine) error {
 		}
 
 		if group.AssetId.Txid.IsEqual(&searchTxid) && scriptNum(group.AssetId.Index) == gidx {
+			vm.dstack.PushInt(1)
 			vm.dstack.PushInt(scriptNum(i))
 			return nil
 		}
 	}
 
-	vm.dstack.PushInt(-1)
+	vm.dstack.PushInt(0)
+	vm.dstack.PushInt(0)
 	return nil
 }
 
@@ -397,7 +400,7 @@ func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 
 // opcodeInspectOutAssetLookup pops gidx, txid, and output index o, then looks up the asset amount.
 // Found:     pushes 1 (success flag) then the amount as 8-byte LE64.
-// Not found: pushes 0 (failure flag only — no amount on stack).
+// Not found: pushes 0 (failure flag) then 0 as 8-byte LE64.
 func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -453,6 +456,7 @@ func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	vm.dstack.PushInt(0)
+	vm.dstack.PushByteArray(make([]byte, 8))
 	return nil
 }
 
@@ -536,7 +540,7 @@ func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 
 // opcodeInspectInAssetLookup pops gidx, txid, and input index i, then looks up the asset amount.
 // Found:     pushes 1 (success flag) then the amount as 8-byte LE64.
-// Not found: pushes 0 (failure flag only — no amount on stack).
+// Not found: pushes 0 (failure flag) then 0 as 8-byte LE64.
 func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -599,6 +603,7 @@ func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	vm.dstack.PushInt(0)
+	vm.dstack.PushByteArray(make([]byte, 8))
 	return nil
 }
 
@@ -652,4 +657,13 @@ func safeSumOutputs(outputs []asset.AssetOutput) *big.Int {
 		sum.Add(sum, new(big.Int).SetUint64(output.Amount))
 	}
 	return sum
+}
+
+// pushAmountLE64 encodes a uint64 as 8-byte little-endian and pushes it onto
+// the data stack. This is consistent with how OP_INSPECTOUTPUTVALUE pushes
+// satoshi values, allowing scripts to use 64-bit arithmetic ops directly.
+func pushAmountLE64(vm *Engine, amount uint64) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, amount)
+	vm.dstack.PushByteArray(buf)
 }

--- a/pkg/arkade/asset_opcodes.go
+++ b/pkg/arkade/asset_opcodes.go
@@ -51,8 +51,8 @@ func opcodeInspectAssetGroupAssetId(op *opcode, data []byte, vm *Engine) error {
 
 // opcodeInspectAssetGroupCtrl pops a group index k and pushes a tagged control
 // asset reference.
-// Found:   pushes 1, txid, index.
-// Missing: pushes 0, empty txid, 0.
+// Found:   pushes txid, index, 1.
+// Missing: pushes empty txid, 0, 0.
 func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -70,16 +70,16 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 	group := vm.assetPacket[int(k)]
 
 	if group.ControlAsset == nil {
-		vm.dstack.PushInt(0)
 		vm.dstack.PushByteArray(nil)
+		vm.dstack.PushInt(0)
 		vm.dstack.PushInt(0)
 		return nil
 	}
 
 	if group.ControlAsset.Type == asset.AssetRefByID {
-		vm.dstack.PushInt(1)
 		vm.dstack.PushByteArray(group.ControlAsset.AssetId.Txid[:])
 		vm.dstack.PushInt(scriptNum(group.ControlAsset.AssetId.Index))
+		vm.dstack.PushInt(1)
 		return nil
 	}
 
@@ -91,13 +91,13 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 		if ctrlGroup.AssetId == nil {
 			// Referenced group is a fresh issuance, use current tx hash and the group index
 			txHash := vm.tx.TxHash()
-			vm.dstack.PushInt(1)
 			vm.dstack.PushByteArray(txHash[:])
 			vm.dstack.PushInt(scriptNum(group.ControlAsset.GroupIndex))
-		} else {
 			vm.dstack.PushInt(1)
+		} else {
 			vm.dstack.PushByteArray(ctrlGroup.AssetId.Txid[:])
 			vm.dstack.PushInt(scriptNum(ctrlGroup.AssetId.Index))
+			vm.dstack.PushInt(1)
 		}
 		return nil
 	}
@@ -107,7 +107,7 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 
 // opcodeFindAssetGroupByAssetId pops an asset ID (gidx, txid) and searches for
 // the matching group index.
-// Found:   pushes 1, group index.
+// Found:   pushes group index, 1.
 // Missing: pushes 0, 0.
 func opcodeFindAssetGroupByAssetId(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
@@ -135,16 +135,16 @@ func opcodeFindAssetGroupByAssetId(op *opcode, data []byte, vm *Engine) error {
 		if group.AssetId == nil {
 			txHash := vm.tx.TxHash()
 			if txHash.IsEqual(&searchTxid) && scriptNum(i) == gidx {
-				vm.dstack.PushInt(1)
 				vm.dstack.PushInt(scriptNum(i))
+				vm.dstack.PushInt(1)
 				return nil
 			}
 			continue
 		}
 
 		if group.AssetId.Txid.IsEqual(&searchTxid) && scriptNum(group.AssetId.Index) == gidx {
-			vm.dstack.PushInt(1)
 			vm.dstack.PushInt(scriptNum(i))
+			vm.dstack.PushInt(1)
 			return nil
 		}
 	}
@@ -399,8 +399,8 @@ func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 }
 
 // opcodeInspectOutAssetLookup pops gidx, txid, and output index o, then looks up the asset amount.
-// Found:     pushes 1 (success flag) then the amount as 8-byte LE64.
-// Not found: pushes 0 (failure flag) then 0 as 8-byte LE64.
+// Found:     pushes the amount as 8-byte LE64, then 1 (success flag).
+// Not found: pushes 0 as 8-byte LE64, then 0 (failure flag).
 func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -448,15 +448,15 @@ func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 
 		for _, output := range group.Outputs {
 			if uint32(output.Vout) == uint32(o) {
-				vm.dstack.PushInt(1)
 				pushAmountLE64(vm, output.Amount)
+				vm.dstack.PushInt(1)
 				return nil
 			}
 		}
 	}
 
-	vm.dstack.PushInt(0)
 	vm.dstack.PushByteArray(make([]byte, 8))
+	vm.dstack.PushInt(0)
 	return nil
 }
 
@@ -539,8 +539,8 @@ func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 }
 
 // opcodeInspectInAssetLookup pops gidx, txid, and input index i, then looks up the asset amount.
-// Found:     pushes 1 (success flag) then the amount as 8-byte LE64.
-// Not found: pushes 0 (failure flag) then 0 as 8-byte LE64.
+// Found:     pushes the amount as 8-byte LE64, then 1 (success flag).
+// Not found: pushes 0 as 8-byte LE64, then 0 (failure flag).
 func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -595,15 +595,15 @@ func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 			}
 
 			if inputTxid.IsEqual(&searchTxid) {
-				vm.dstack.PushInt(1)
 				pushAmountLE64(vm, input.Amount)
+				vm.dstack.PushInt(1)
 				return nil
 			}
 		}
 	}
 
-	vm.dstack.PushInt(0)
 	vm.dstack.PushByteArray(make([]byte, 8))
+	vm.dstack.PushInt(0)
 	return nil
 }
 

--- a/pkg/arkade/asset_opcodes.go
+++ b/pkg/arkade/asset_opcodes.go
@@ -2,12 +2,22 @@ package arkade
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"math/big"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 )
+
+// pushAmountLE64 encodes a uint64 as 8-byte little-endian and pushes it onto
+// the data stack. This is consistent with how OP_INSPECTOUTPUTVALUE pushes
+// satoshi values, allowing scripts to use 64-bit arithmetic ops directly.
+func pushAmountLE64(vm *Engine, amount uint64) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, amount)
+	vm.dstack.PushByteArray(buf)
+}
 
 // opcodeInspectNumAssetGroups pushes the total number of asset groups in the packet onto the stack.
 func opcodeInspectNumAssetGroups(op *opcode, data []byte, vm *Engine) error {
@@ -243,7 +253,7 @@ func opcodeInspectAssetGroup(op *opcode, data []byte, vm *Engine) error {
 			vm.dstack.PushByteArray(input.Txid[:])
 		}
 		vm.dstack.PushInt(scriptNum(input.Vin))
-		vm.dstack.PushInt(scriptNum(input.Amount))
+		pushAmountLE64(vm, input.Amount)
 
 	case 1:
 		if int(j) >= len(group.Outputs) || j < 0 {
@@ -253,7 +263,7 @@ func opcodeInspectAssetGroup(op *opcode, data []byte, vm *Engine) error {
 
 		vm.dstack.PushInt(1)
 		vm.dstack.PushInt(scriptNum(output.Vout))
-		vm.dstack.PushInt(scriptNum(output.Amount))
+		pushAmountLE64(vm, output.Amount)
 
 	default:
 		return scriptError(txscript.ErrInvalidStackOperation, "invalid source value")
@@ -290,24 +300,24 @@ func opcodeInspectAssetGroupSum(op *opcode, data []byte, vm *Engine) error {
 		if !sum.IsUint64() {
 			return scriptError(txscript.ErrInvalidStackOperation, "amount overflow")
 		}
-		vm.dstack.PushInt(scriptNum(sum.Uint64()))
+		pushAmountLE64(vm, sum.Uint64())
 	case 1:
 		sum := safeSumOutputs(group.Outputs)
 		if !sum.IsUint64() {
 			return scriptError(txscript.ErrInvalidStackOperation, "amount overflow")
 		}
-		vm.dstack.PushInt(scriptNum(sum.Uint64()))
+		pushAmountLE64(vm, sum.Uint64())
 	case 2:
 		inSum := safeSumInputs(group.Inputs)
 		if !inSum.IsUint64() {
 			return scriptError(txscript.ErrInvalidStackOperation, "amount overflow")
 		}
-		vm.dstack.PushInt(scriptNum(inSum.Uint64()))
+		pushAmountLE64(vm, inSum.Uint64())
 		outSum := safeSumOutputs(group.Outputs)
 		if !outSum.IsUint64() {
 			return scriptError(txscript.ErrInvalidStackOperation, "amount overflow")
 		}
-		vm.dstack.PushInt(scriptNum(outSum.Uint64()))
+		pushAmountLE64(vm, outSum.Uint64())
 	default:
 		return scriptError(txscript.ErrInvalidStackOperation, "invalid source value")
 	}
@@ -374,7 +384,7 @@ func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 				if scriptNum(idx) == t {
 					vm.dstack.PushByteArray(assetTxid[:])
 					vm.dstack.PushInt(scriptNum(gidx))
-					vm.dstack.PushInt(scriptNum(output.Amount))
+					pushAmountLE64(vm, output.Amount)
 					return nil
 				}
 				idx++
@@ -386,7 +396,8 @@ func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 }
 
 // opcodeInspectOutAssetLookup pops gidx, txid, and output index o, then looks up the asset amount.
-// Pushes the amount if found, or -1 if not found.
+// Found:     pushes 1 (success flag) then the amount as 8-byte LE64.
+// Not found: pushes 0 (failure flag only — no amount on stack).
 func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -434,13 +445,14 @@ func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 
 		for _, output := range group.Outputs {
 			if uint32(output.Vout) == uint32(o) {
-				vm.dstack.PushInt(scriptNum(output.Amount))
+				vm.dstack.PushInt(1)
+				pushAmountLE64(vm, output.Amount)
 				return nil
 			}
 		}
 	}
 
-	vm.dstack.PushInt(-1)
+	vm.dstack.PushInt(0)
 	return nil
 }
 
@@ -511,7 +523,7 @@ func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 
 					vm.dstack.PushByteArray(inputTxid[:])
 					vm.dstack.PushInt(scriptNum(gidx))
-					vm.dstack.PushInt(scriptNum(input.Amount))
+					pushAmountLE64(vm, input.Amount)
 					return nil
 				}
 				idx++
@@ -523,7 +535,8 @@ func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 }
 
 // opcodeInspectInAssetLookup pops gidx, txid, and input index i, then looks up the asset amount.
-// Pushes the amount if found, or -1 if not found.
+// Found:     pushes 1 (success flag) then the amount as 8-byte LE64.
+// Not found: pushes 0 (failure flag only — no amount on stack).
 func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -578,13 +591,14 @@ func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 			}
 
 			if inputTxid.IsEqual(&searchTxid) {
-				vm.dstack.PushInt(scriptNum(input.Amount))
+				vm.dstack.PushInt(1)
+				pushAmountLE64(vm, input.Amount)
 				return nil
 			}
 		}
 	}
 
-	vm.dstack.PushInt(-1)
+	vm.dstack.PushInt(0)
 	return nil
 }
 

--- a/pkg/arkade/asset_opcodes_test.go
+++ b/pkg/arkade/asset_opcodes_test.go
@@ -1,6 +1,7 @@
 package arkade
 
 import (
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -9,6 +10,12 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 )
+
+func amountLE64(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, v)
+	return b
+}
 
 func TestAssetOpcodes(t *testing.T) {
 	t.Parallel()
@@ -83,6 +90,21 @@ func TestAssetOpcodes(t *testing.T) {
 			},
 			Inputs:  nil,
 			Outputs: []asset.AssetOutput{{Vout: 1, Amount: 200}},
+		},
+	}
+
+	// Packet with amounts exceeding the former scriptNum 4-byte limit (2^31-1).
+	// Group 0: existing asset, 2 inputs totaling 10B, 1 output of 3B.
+	largeAmountPacket := asset.Packet{
+		{
+			AssetId: &asset.AssetId{Txid: assetTxid, Index: 3},
+			Inputs: []asset.AssetInput{
+				{Type: asset.AssetInputTypeLocal, Vin: 0, Amount: 7_000_000_000},
+				{Type: asset.AssetInputTypeLocal, Vin: 1, Amount: 3_000_000_000},
+			},
+			Outputs: []asset.AssetOutput{
+				{Vout: 0, Amount: 3_000_000_000},
+			},
 		},
 	}
 
@@ -351,7 +373,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // item index
 				AddInt64(0). // source=0 (input)
 				AddOp(OP_INSPECTASSETGROUP).
-				AddInt64(500). // amount
+				AddData(amountLE64(500)). // amount (LE64)
 				AddOp(OP_EQUALVERIFY).
 				AddInt64(0). // vin
 				AddOp(OP_EQUALVERIFY).
@@ -369,7 +391,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(1). // item index
 				AddInt64(0). // source=0 (input)
 				AddOp(OP_INSPECTASSETGROUP).
-				AddInt64(300). // amount
+				AddData(amountLE64(300)). // amount (LE64)
 				AddOp(OP_EQUALVERIFY).
 				AddInt64(1). // vin
 				AddOp(OP_EQUALVERIFY).
@@ -389,7 +411,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // item index
 				AddInt64(1). // source=1 (output)
 				AddOp(OP_INSPECTASSETGROUP).
-				AddInt64(800). // amount
+				AddData(amountLE64(800)). // amount (LE64)
 				AddOp(OP_EQUALVERIFY).
 				AddInt64(0). // vout
 				AddOp(OP_EQUALVERIFY).
@@ -429,7 +451,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // group index
 				AddInt64(0). // source=0 (inputs)
 				AddOp(OP_INSPECTASSETGROUPSUM).
-				AddInt64(800). // 500 + 300
+				AddData(amountLE64(800)). // 500 + 300 (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -441,7 +463,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // group index
 				AddInt64(1). // source=1 (outputs)
 				AddOp(OP_INSPECTASSETGROUPSUM).
-				AddInt64(800). // single output of 800
+				AddData(amountLE64(800)). // single output of 800 (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -453,9 +475,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // group index
 				AddInt64(2). // source=2 (both)
 				AddOp(OP_INSPECTASSETGROUPSUM).
-				AddInt64(800). // output sum
+				AddData(amountLE64(800)). // output sum (LE64)
 				AddOp(OP_EQUALVERIFY).
-				AddInt64(800). // input sum
+				AddData(amountLE64(800)). // input sum (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -467,7 +489,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(1). // group 1
 				AddInt64(1). // source=1 (outputs)
 				AddOp(OP_INSPECTASSETGROUPSUM).
-				AddInt64(3000). // 1000 + 2000
+				AddData(amountLE64(3000)). // 1000 + 2000 (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -530,7 +552,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // output index
 				AddInt64(0). // asset index
 				AddOp(OP_INSPECTOUTASSETAT).
-				AddInt64(800). // amount
+				AddData(amountLE64(800)). // amount (LE64)
 				AddOp(OP_EQUALVERIFY).
 				AddInt64(0). // gidx (group index in packet)
 				AddOp(OP_EQUALVERIFY).
@@ -559,7 +581,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(0).           // gidx (group index in packet)
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
-				AddInt64(800). // expected amount
+				AddData(amountLE64(800)). // expected amount (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -572,8 +596,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(0).           // gidx 0
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
-				AddInt64(-1). // not found
-				AddOp(OP_EQUAL),
+				AddOp(OP_NOT), // flag=0 → NOT → true
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -625,7 +648,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // input index
 				AddInt64(0). // asset index
 				AddOp(OP_INSPECTINASSETAT).
-				AddInt64(500). // amount
+				AddData(amountLE64(500)). // amount (LE64)
 				AddOp(OP_EQUALVERIFY).
 				AddInt64(0). // gidx (group index)
 				AddOp(OP_EQUALVERIFY).
@@ -643,7 +666,7 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(1). // input index
 				AddInt64(0). // asset index
 				AddOp(OP_INSPECTINASSETAT).
-				AddInt64(300). // amount
+				AddData(amountLE64(300)). // amount (LE64)
 				AddOp(OP_EQUALVERIFY).
 				AddInt64(0). // gidx (group index)
 				AddOp(OP_EQUALVERIFY).
@@ -673,7 +696,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid (group's asset txid for local)
 				AddInt64(0).           // gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
-				AddInt64(500).
+				AddData(amountLE64(500)). // expected amount (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -687,7 +712,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(intentTxid[:]). // txid (intent txid)
 				AddInt64(0).            // gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
-				AddInt64(300).
+				AddData(amountLE64(300)). // expected amount (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -700,10 +727,111 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(5).           // wrong gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
-				AddInt64(-1). // not found
-				AddOp(OP_EQUAL),
+				AddOp(OP_NOT), // flag=0 → NOT → true
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
+			},
+		},
+
+		// ========== Edge cases: large amounts (> 2^31, formerly broken via scriptNum) ==========
+		{
+			name: "large_amount_group_output_read",
+			// 3 billion > 2^31-1: would have failed with ErrNumberTooBig under scriptNum.
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // group index
+				AddInt64(0). // item index
+				AddInt64(1). // source=1 (output)
+				AddOp(OP_INSPECTASSETGROUP).
+				AddData(amountLE64(3_000_000_000)). // amount (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(0). // vout
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(1). // type
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: largeAmountPacket},
+			},
+		},
+		{
+			name: "large_amount_group_input_read",
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // group index
+				AddInt64(0). // item index
+				AddInt64(0). // source=0 (input)
+				AddOp(OP_INSPECTASSETGROUP).
+				AddData(amountLE64(7_000_000_000)). // amount (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(0). // vin
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(1). // type (local)
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: largeAmountPacket},
+			},
+		},
+		{
+			name: "large_amount_sum",
+			// Sum of 7B + 3B = 10B, well above 2^32.
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // group index
+				AddInt64(2). // source=2 (both)
+				AddOp(OP_INSPECTASSETGROUPSUM).
+				AddData(amountLE64(3_000_000_000)). // output sum (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddData(amountLE64(10_000_000_000)). // input sum: 7B + 3B (LE64)
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: largeAmountPacket},
+			},
+		},
+		{
+			name: "large_amount_add64",
+			// Verify pushed LE64 amount feeds directly into OP_ADD64.
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // group index
+				AddInt64(0). // source=0 (inputs)
+				AddOp(OP_INSPECTASSETGROUPSUM).       // pushes 10B as LE64
+				AddData(amountLE64(500_000_000)).      // 0.5B
+				AddOp(OP_ADD64).                       // 10B + 0.5B
+				AddOp(OP_VERIFY).                      // success flag
+				AddData(amountLE64(10_500_000_000)).    // expected sum
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: largeAmountPacket},
+			},
+		},
+		{
+			name: "large_amount_comparison64",
+			// Verify pushed LE64 amount works with OP_GREATERTHANOREQUAL64.
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // output index
+				AddInt64(0). // asset index
+				AddOp(OP_INSPECTOUTASSETAT).
+				AddData(amountLE64(2_000_000_000)). // threshold
+				AddOp(OP_GREATERTHANOREQUAL64).     // 3B >= 2B → true
+				AddOp(OP_VERIFY).
+				AddInt64(0). // gidx
+				AddOp(OP_EQUALVERIFY).
+				AddData(assetTxid[:]). // txid
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: largeAmountPacket},
+			},
+		},
+		{
+			name: "large_amount_lookup_found",
+			// Lookup with large amount returns flag + LE64.
+			script: txscript.NewScriptBuilder().
+				AddInt64(0).           // output index
+				AddData(assetTxid[:]). // txid
+				AddInt64(0).           // gidx
+				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddData(amountLE64(3_000_000_000)). // expected amount (LE64)
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1). // verify success flag
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: largeAmountPacket},
 			},
 		},
 	}

--- a/pkg/arkade/asset_opcodes_test.go
+++ b/pkg/arkade/asset_opcodes_test.go
@@ -232,6 +232,8 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(7). // expected ctrl gidx
 				AddOp(OP_EQUALVERIFY).
 				AddData(ctrlTxid[:]). // expected ctrl txid
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -242,8 +244,11 @@ func TestAssetOpcodes(t *testing.T) {
 			script: txscript.NewScriptBuilder().
 				AddInt64(1). // group 1 has no control asset
 				AddOp(OP_INSPECTASSETGROUPCTRL).
-				AddInt64(-1). // expected -1
-				AddOp(OP_EQUAL),
+				AddInt64(0). // expected missing index
+				AddOp(OP_EQUALVERIFY).
+				AddData(nil). // expected missing txid
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_NOT), // flag=0
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -257,6 +262,8 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(0). // expected ctrl gidx (group 0's AssetId.Index)
 				AddOp(OP_EQUALVERIFY).
 				AddData(assetTxid[:]). // expected ctrl txid (group 0's AssetId.Txid)
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: ctrlByGroupPacket},
@@ -271,6 +278,8 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(3).           // gidx to search
 				AddOp(OP_FINDASSETGROUPBYASSETID).
 				AddInt64(0). // expected group index
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_1).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -282,8 +291,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid to search
 				AddInt64(99).          // wrong gidx
 				AddOp(OP_FINDASSETGROUPBYASSETID).
-				AddInt64(-1). // not found
-				AddOp(OP_EQUAL),
+				AddInt64(0). // expected missing index
+				AddOp(OP_EQUALVERIFY).
+				AddOp(OP_NOT), // flag=0
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -596,6 +606,8 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(0).           // gidx 0
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddData(make([]byte, 8)). // expected dummy LE64
+				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_NOT), // flag=0 → NOT → true
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -727,13 +739,13 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(5).           // wrong gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
+				AddData(make([]byte, 8)). // expected dummy LE64
+				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_NOT), // flag=0 → NOT → true
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
 		},
-
-		// ========== Edge cases: large amounts (> 2^31, formerly broken via scriptNum) ==========
 		{
 			name: "large_amount_group_output_read",
 			// 3 billion > 2^31-1: would have failed with ErrNumberTooBig under scriptNum.

--- a/pkg/arkade/asset_opcodes_test.go
+++ b/pkg/arkade/asset_opcodes_test.go
@@ -229,11 +229,11 @@ func TestAssetOpcodes(t *testing.T) {
 			script: txscript.NewScriptBuilder().
 				AddInt64(0). // group 0 has control asset by ID
 				AddOp(OP_INSPECTASSETGROUPCTRL).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
 				AddInt64(7). // expected ctrl gidx
 				AddOp(OP_EQUALVERIFY).
 				AddData(ctrlTxid[:]). // expected ctrl txid
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_1).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -244,11 +244,12 @@ func TestAssetOpcodes(t *testing.T) {
 			script: txscript.NewScriptBuilder().
 				AddInt64(1). // group 1 has no control asset
 				AddOp(OP_INSPECTASSETGROUPCTRL).
+				AddOp(OP_NOT). // flag=0
+				AddOp(OP_VERIFY).
 				AddInt64(0). // expected missing index
 				AddOp(OP_EQUALVERIFY).
 				AddData(nil). // expected missing txid
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_NOT), // flag=0
+				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -259,11 +260,11 @@ func TestAssetOpcodes(t *testing.T) {
 			script: txscript.NewScriptBuilder().
 				AddInt64(1). // group 1
 				AddOp(OP_INSPECTASSETGROUPCTRL).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
 				AddInt64(0). // expected ctrl gidx (group 0's AssetId.Index)
 				AddOp(OP_EQUALVERIFY).
 				AddData(assetTxid[:]). // expected ctrl txid (group 0's AssetId.Txid)
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_1).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: ctrlByGroupPacket},
@@ -277,9 +278,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid to search
 				AddInt64(3).           // gidx to search
 				AddOp(OP_FINDASSETGROUPBYASSETID).
-				AddInt64(0). // expected group index
-				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(0). // expected group index
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -291,9 +292,10 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid to search
 				AddInt64(99).          // wrong gidx
 				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_NOT). // flag=0
+				AddOp(OP_VERIFY).
 				AddInt64(0). // expected missing index
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_NOT), // flag=0
+				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -591,9 +593,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(0).           // gidx (group index in packet)
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
-				AddData(amountLE64(800)). // expected amount (LE64)
-				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_1). // verify success flag
+				AddOp(OP_EQUALVERIFY).
+				AddData(amountLE64(800)). // expected amount (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -606,9 +608,10 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(0).           // gidx 0
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddOp(OP_NOT). // flag=0 → NOT → true
+				AddOp(OP_VERIFY).
 				AddData(make([]byte, 8)). // expected dummy LE64
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_NOT), // flag=0 → NOT → true
+				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -708,9 +711,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid (group's asset txid for local)
 				AddInt64(0).           // gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
-				AddData(amountLE64(500)). // expected amount (LE64)
-				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_1). // verify success flag
+				AddOp(OP_EQUALVERIFY).
+				AddData(amountLE64(500)). // expected amount (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -724,9 +727,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(intentTxid[:]). // txid (intent txid)
 				AddInt64(0).            // gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
-				AddData(amountLE64(300)). // expected amount (LE64)
-				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_1). // verify success flag
+				AddOp(OP_EQUALVERIFY).
+				AddData(amountLE64(300)). // expected amount (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -739,9 +742,10 @@ func TestAssetOpcodes(t *testing.T) {
 				AddData(assetTxid[:]). // txid
 				AddInt64(5).           // wrong gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
+				AddOp(OP_NOT). // flag=0 → NOT → true
+				AddOp(OP_VERIFY).
 				AddData(make([]byte, 8)). // expected dummy LE64
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_NOT), // flag=0 → NOT → true
+				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -832,15 +836,15 @@ func TestAssetOpcodes(t *testing.T) {
 		},
 		{
 			name: "large_amount_lookup_found",
-			// Lookup with large amount returns flag + LE64.
+			// Lookup with large amount returns LE64 + flag.
 			script: txscript.NewScriptBuilder().
 				AddInt64(0).           // output index
 				AddData(assetTxid[:]). // txid
 				AddInt64(0).           // gidx
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
-				AddData(amountLE64(3_000_000_000)). // expected amount (LE64)
-				AddOp(OP_EQUALVERIFY).
 				AddOp(OP_1). // verify success flag
+				AddOp(OP_EQUALVERIFY).
+				AddData(amountLE64(3_000_000_000)). // expected amount (LE64)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: largeAmountPacket},

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -2102,7 +2102,8 @@ func pushScriptPubKey(scriptPubKey []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectInputScriptPubkey pops the input index from the stack and pushes the scriptPubKey of the current input onto the stack.
+// opcodeInspectInputScriptPubkey pops the input index from the stack and pushes
+// the scriptPubKey of the current input onto the stack.
 // Stack transformation: [... index] -> [... scriptPubKey]
 func opcodeInspectInputScriptPubkey(op *opcode, data []byte, vm *Engine) error {
 	index, err := vm.dstack.PopInt()
@@ -2123,7 +2124,21 @@ func opcodeInspectInputScriptPubkey(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidIndex, "previous output not found")
 	}
 
-	return pushScriptPubKey(prevOut.PkScript, vm)
+	if txscript.IsWitnessProgram(prevOut.PkScript) {
+		version, program, err := txscript.ExtractWitnessProgramInfo(prevOut.PkScript)
+		if err != nil {
+			return err
+		}
+
+		vm.dstack.PushByteArray(program)
+		vm.dstack.PushInt(scriptNum(version))
+		return nil
+	}
+
+	hash := sha256.Sum256(prevOut.PkScript)
+	vm.dstack.PushByteArray(hash[:])
+	vm.dstack.PushInt(-1)
+	return nil
 }
 
 // opcodeInspectInputSequence pops the input index from the stack and pushes the sequence number of the current input onto the stack.
@@ -2169,7 +2184,7 @@ func opcodeInspectOutputValue(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectOutputScriptPubkey pushes the scriptPubKey of the output at the given index onto the stack.
+// opcodeInspectOutputScriptkey pushes the scriptPubKey of the output at the given index onto the stack.
 // Stack transformation: [... index] -> [... scriptPubKey]
 func opcodeInspectOutputScriptPubkey(op *opcode, data []byte, vm *Engine) error {
 	index, err := vm.dstack.PopInt()

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -2102,8 +2102,7 @@ func pushScriptPubKey(scriptPubKey []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectInputScriptPubkey pops the input index from the stack and pushes
-// the scriptPubKey of the current input onto the stack.
+// opcodeInspectInputScriptPubkey pops the input index from the stack and pushes the scriptPubKey of the current input onto the stack.
 // Stack transformation: [... index] -> [... scriptPubKey]
 func opcodeInspectInputScriptPubkey(op *opcode, data []byte, vm *Engine) error {
 	index, err := vm.dstack.PopInt()
@@ -2124,21 +2123,7 @@ func opcodeInspectInputScriptPubkey(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidIndex, "previous output not found")
 	}
 
-	if txscript.IsWitnessProgram(prevOut.PkScript) {
-		version, program, err := txscript.ExtractWitnessProgramInfo(prevOut.PkScript)
-		if err != nil {
-			return err
-		}
-
-		vm.dstack.PushByteArray(program)
-		vm.dstack.PushInt(scriptNum(version))
-		return nil
-	}
-
-	hash := sha256.Sum256(prevOut.PkScript)
-	vm.dstack.PushByteArray(hash[:])
-	vm.dstack.PushInt(-1)
-	return nil
+	return pushScriptPubKey(prevOut.PkScript, vm)
 }
 
 // opcodeInspectInputSequence pops the input index from the stack and pushes the sequence number of the current input onto the stack.
@@ -2184,7 +2169,7 @@ func opcodeInspectOutputValue(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectOutputScriptkey pushes the scriptPubKey of the output at the given index onto the stack.
+// opcodeInspectOutputScriptPubkey pushes the scriptPubKey of the output at the given index onto the stack.
 // Stack transformation: [... index] -> [... scriptPubKey]
 func opcodeInspectOutputScriptPubkey(op *opcode, data []byte, vm *Engine) error {
 	index, err := vm.dstack.PopInt()

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -551,11 +551,11 @@ func createArkadeScriptWithAssetIntrospection(t *testing.T, alicePkScript []byte
 		AddOp(arkade.OP_INSPECTNUMASSETGROUPS).
 		AddInt64(1).
 		AddOp(arkade.OP_EQUALVERIFY).
-		// Check: sum of outputs for group 0 equals assetAmount
+		// Check: sum of outputs for group 0 equals assetAmount (LE64)
 		AddInt64(0). // group index
 		AddInt64(1). // source = outputs
 		AddOp(arkade.OP_INSPECTASSETGROUPSUM).
-		AddInt64(assetAmount).
+		AddData(uint64LE(uint64(assetAmount))).
 		AddOp(arkade.OP_EQUAL).
 		Script()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes asset amount handling in asset introspection opcodes by moving amount values from `scriptNum` to 8-byte little-endian (`LE64`) stack values, and updates lookup semantics to a flag+value pattern.

### Why

Asset amounts are defined as `uint64`, but previously they were pushed as `scriptNum` (`int64`) and later parsed with a 4-byte `MakeScriptNum` limit via `PopInt()`. That created correctness bugs for larger amounts:

- values above `2^63-1` could wrap on cast to `int64`
- values above ~`2^31-1` could fail with `ErrNumberTooBig` when re-read as script numbers

### What changed

- Added LE64 push helper in `asset_opcodes.go` and switched amount pushes to LE64 for:
  - `OP_INSPECTASSETGROUP` (input/output amount fields)
  - `OP_INSPECTASSETGROUPSUM`
  - `OP_INSPECTOUTASSETAT`
  - `OP_INSPECTINASSETAT`
- Updated lookup opcode semantics:
  - `OP_INSPECTOUTASSETLOOKUP`
  - `OP_INSPECTINASSETLOOKUP`
  - **Found:** push `1` then `<amount LE64>`
  - **Not found:** push `0` only
- Updated tests to compare amounts as LE64 and assert new lookup stack layout.
- Updated integration test script helper in `test/utils_test.go` to compare asset sums as LE64.

### Script ergonomics improvement (Issue #40)

Using asset lookup amounts is now simpler and more consistent with 64-bit ops, matching the direction in [Issue #40](https://github.com/ArkLabsHQ/introspector/issues/40):

- no `-1` sentinel handling boilerplate
- no `OP_SCRIPTNUMTOLE64` conversion step before `OP_ADD64` / `OP_MUL64` / comparisons
- straightforward found-check via top-stack flag (`OP_VERIFY`), with amount already in LE64

### Edge cases covered

Added explicit tests for large amounts and arithmetic/comparison interoperability:

- large amount reads from group/input/output paths
- large group sums (e.g. 10B)
- direct use with `OP_ADD64`
- direct use with `OP_GREATERTHANOREQUAL64`
- lookup found path with large amount using flag+LE64

### Breaking change / migration note

This is a **breaking stack-shape/encoding change** for scripts using asset amount outputs:

- Amounts are now LE64 byte arrays, not `scriptNum`.
- Lookup opcodes now return `flag + amount` (found) or `flag` only (not found), replacing the old `-1` sentinel behavior.