### PR TITLE
chore: bump go version 1.26.1 -> 1.26.2

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Check formatting
         run: |
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: 1.26.1
+          go-version: 1.26.2
 
       - name: Build binaries
         run: make build-all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run unit tests
         run: make test
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run Nigiri
         uses: vulpemventures/nigiri-github-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/api-spec/go.mod
+++ b/api-spec/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/introspector/api-spec
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/meshapi/grpc-api-gateway v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/introspector
 
-go 1.26.1
+go 1.26.2
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/pkg/arkade/go.mod
+++ b/pkg/arkade/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/introspector/pkg/arkade
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/introspector/pkg/client
 
-go 1.26.1
+go 1.26.2
 
 replace github.com/ArkLabsHQ/introspector/api-spec => ../../api-spec
 


### PR DESCRIPTION
In reaction to [CVE-2026-32282](https://access.redhat.com/security/cve/cve-2026-32282) flagged by Trivy.