### PR TITLE
chore: update to arkd 0.9.3

### DIFF
--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -62,7 +62,7 @@ services:
 
   arkd-wallet:
     restart: unless-stopped
-    image: ghcr.io/arkade-os/arkd-wallet:v0.9.0
+    image: ghcr.io/arkade-os/arkd-wallet:v0.9.3
     container_name: arkd-wallet
     depends_on:
       - nbxplorer
@@ -79,7 +79,7 @@ services:
         target: /app/data
   arkd:
     build:
-      context: https://github.com/arkade-os/arkd.git#v0.9.0
+      context: https://github.com/arkade-os/arkd.git#v0.9.3
       dockerfile: Dockerfile
     container_name: arkd
     restart: unless-stopped
@@ -91,11 +91,11 @@ services:
     environment:
       - ARKD_LOG_LEVEL=6
       - ARKD_NO_MACAROONS=true
-      - ARKD_VTXO_TREE_EXPIRY=20
+      - ARKD_VTXO_TREE_EXPIRY=512
       - ARKD_SCHEDULER_TYPE=block
       - ARKD_UNILATERAL_EXIT_DELAY=512
       - ARKD_BOARDING_EXIT_DELAY=1024
-      - ARKD_CHECKPOINT_EXIT_DELAY=10
+      - ARKD_CHECKPOINT_EXIT_DELAY=512
       - ARKD_DATADIR=./data/regtest
       - ARKD_WALLET_ADDR=arkd-wallet:6060
       - ARKD_ESPLORA_URL=http://chopsticks:3000

--- a/test/asset_test.go
+++ b/test/asset_test.go
@@ -19,7 +19,6 @@ import (
 	arksdk "github.com/arkade-os/go-sdk"
 	"github.com/arkade-os/go-sdk/client"
 	mempoolexplorer "github.com/arkade-os/go-sdk/explorer/mempool"
-	"github.com/arkade-os/go-sdk/indexer"
 	"github.com/arkade-os/go-sdk/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -183,20 +182,13 @@ func TestOffchainTxWithAsset(t *testing.T) {
 		encodedValidCheckpoints = append(encodedValidCheckpoints, signed)
 	}
 
+	waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, validTx, 0)
+
 	// Submit to introspector - should succeed as the asset introspection opcodes will validate correctly
 	_, _, err = introspectorClient.SubmitTx(ctx, signedTx, encodedValidCheckpoints)
 	require.NoError(t, err)
 
-	idxr := setupIndexer(t)
-
-	opts := indexer.GetVtxosRequestOption{}
-	err = opts.WithOutpoints([]types.Outpoint{{Txid: validTx.UnsignedTx.TxID(), VOut: 0}})
-	require.NoError(t, err)
-	vtxos, err := idxr.GetVtxos(ctx, opts)
-	require.NoError(t, err)
-	require.Len(t, vtxos.Vtxos, 1)
-	require.True(t, vtxos.Vtxos[0].Preconfirmed)
-	require.False(t, vtxos.Vtxos[0].Spent)
+	waitForVtxos()
 }
 
 // TestSettlementWithAsset tests the settlement flow with an asset packet in the intent.
@@ -358,19 +350,13 @@ func TestSettlementWithAsset(t *testing.T) {
 		encodedMintCheckpoints = append(encodedMintCheckpoints, signed)
 	}
 
+	waitForMintVtxo := watchForPreconfirmedVtxos(t, indexerSvc, mintTx, 0)
+
 	// Submit mint tx to introspector
 	_, _, err = introspectorClient.SubmitTx(ctx, signedMintTx, encodedMintCheckpoints)
 	require.NoError(t, err)
 
-	opts := indexer.GetVtxosRequestOption{}
-	err = opts.WithOutpoints([]types.Outpoint{{Txid: mintTx.UnsignedTx.TxID(), VOut: 0}})
-	require.NoError(t, err)
-
-	vtxos, err := indexerSvc.GetVtxos(ctx, opts)
-	require.NoError(t, err)
-	require.Len(t, vtxos.Vtxos, 1)
-	require.True(t, vtxos.Vtxos[0].Preconfirmed)
-	require.False(t, vtxos.Vtxos[0].Spent)
+	waitForMintVtxo()
 
 	// =========================================================================
 	// Phase 3: Settle the VTXO with a transfer asset packet

--- a/test/contract_id_test.go
+++ b/test/contract_id_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	mempoolexplorer "github.com/arkade-os/go-sdk/explorer/mempool"
-	"github.com/arkade-os/go-sdk/indexer"
 	"github.com/arkade-os/go-sdk/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -76,19 +75,9 @@ func TestContractIdWithAssetIdentity(t *testing.T) {
 		return encodedCheckpoints
 	}
 
-	assertOutput0Preconfirmed := func(candidateTx *psbt.Packet) {
-		opts := indexer.GetVtxosRequestOption{}
-		err := opts.WithOutpoints([]types.Outpoint{{Txid: candidateTx.UnsignedTx.TxID(), VOut: 0}})
-		require.NoError(t, err)
-
-		vtxos, err := indexerSvc.GetVtxos(ctx, opts)
-		require.NoError(t, err)
-		require.Len(t, vtxos.Vtxos, 1)
-		require.True(t, vtxos.Vtxos[0].Preconfirmed)
-		require.False(t, vtxos.Vtxos[0].Spent)
-	}
-
 	submitWithArkd := func(candidateTx *psbt.Packet, checkpoints []*psbt.Packet) {
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, candidateTx, 0)
+
 		encodedTx, err := candidateTx.B64Encode()
 		require.NoError(t, err)
 
@@ -109,17 +98,19 @@ func TestContractIdWithAssetIdentity(t *testing.T) {
 
 		require.NoError(t, grpcClient.FinalizeTx(ctx, txid, finalCheckpoints))
 
-		assertOutput0Preconfirmed(candidateTx)
+		waitForVtxos()
 	}
 
 	submitWithIntrospector := func(candidateTx *psbt.Packet, checkpoints []*psbt.Packet) {
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, candidateTx, 0)
+
 		encodedTx, err := candidateTx.B64Encode()
 		require.NoError(t, err)
 
 		_, _, err = introspectorClient.SubmitTx(ctx, encodedTx, encodeCheckpoints(checkpoints))
 		require.NoError(t, err)
 
-		assertOutput0Preconfirmed(candidateTx)
+		waitForVtxos()
 	}
 
 	// =========================================================================

--- a/test/counter_contract_test.go
+++ b/test/counter_contract_test.go
@@ -57,6 +57,8 @@ func TestCounterContractWithPacketIntrospection(t *testing.T) {
 	counterPkScript := p2trScriptForVtxoScript(t, counterVtxoScript)
 
 	submitAndFinalize := func(candidateTx *psbt.Packet, checkpoints []*psbt.Packet) {
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, candidateTx, 0)
+
 		encodedTx, err := candidateTx.B64Encode()
 		require.NoError(t, err)
 
@@ -65,7 +67,7 @@ func TestCounterContractWithPacketIntrospection(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		requirePreconfirmedVtxo(t, ctx, indexerSvc, candidateTx, 0)
+		waitForVtxos()
 	}
 
 	submitExpectIntrospectorFailure := func(candidateTx *psbt.Packet, checkpoints []*psbt.Packet) {
@@ -177,8 +179,10 @@ func deployCounterFromWallet(
 	)
 	addCounterPacket(t, deployTx, 0)
 	requireCounterPacket(t, deployTx.UnsignedTx, 0)
+
+	waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, deployTx, 0)
 	submitWithArkd(t, ctx, deployTx, deployCheckpoints, aliceWallet, grpcClient)
-	requirePreconfirmedVtxo(t, ctx, indexerSvc, deployTx, 0)
+	waitForVtxos()
 
 	return deployTx
 }

--- a/test/cross_input_script_validation_test.go
+++ b/test/cross_input_script_validation_test.go
@@ -958,6 +958,10 @@ func (env *crossInputTestEnv) submitAndExpectFailure(t *testing.T, candidateTx *
 func (env *crossInputTestEnv) submitAndFinalize(t *testing.T, candidateTx *psbt.Packet, checkpoints []*psbt.Packet) {
 	t.Helper()
 
+	// Subscribe to output 0's script BEFORE submit so the event arrives once the
+	// async projection pipeline writes the vtxo.
+	waitForVtxos := watchForPreconfirmedVtxos(t, env.indexerSvc, candidateTx, 0)
+
 	// Step 1: Sign the candidate tx locally and sign every checkpoint.
 	encodedTx, err := candidateTx.B64Encode()
 	require.NoError(t, err)
@@ -979,14 +983,6 @@ func (env *crossInputTestEnv) submitAndFinalize(t *testing.T, candidateTx *psbt.
 	_, _, err = env.introspectorClient.SubmitTx(env.ctx, signedTx, signedCheckpoints)
 	require.NoError(t, err)
 
-	// Step 3: Verify the finalized output via the indexer.
-	opts := indexer.GetVtxosRequestOption{}
-	err = opts.WithOutpoints([]types.Outpoint{{Txid: candidateTx.UnsignedTx.TxID(), VOut: 0}})
-	require.NoError(t, err)
-
-	vtxos, err := env.indexerSvc.GetVtxos(env.ctx, opts)
-	require.NoError(t, err)
-	require.Len(t, vtxos.Vtxos, 1)
-	require.True(t, vtxos.Vtxos[0].Preconfirmed)
-	require.False(t, vtxos.Vtxos[0].Spent)
+	// Step 3: Wait for the subscription event and assert preconfirmed/unspent.
+	waitForVtxos()
 }

--- a/test/pay_2_out_test.go
+++ b/test/pay_2_out_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	mempoolexplorer "github.com/arkade-os/go-sdk/explorer/mempool"
-	"github.com/arkade-os/go-sdk/indexer"
 	inmemorystoreconfig "github.com/arkade-os/go-sdk/store/inmemory"
 	"github.com/arkade-os/go-sdk/types"
 	singlekeywallet "github.com/arkade-os/go-sdk/wallet/singlekey"
@@ -337,21 +336,10 @@ func TestPayToTwoOutputs(t *testing.T) {
 		encodedValidCheckpoints = append(encodedValidCheckpoints, signed)
 	}
 
+	waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, validTx, 0, 1)
+
 	_, _, err = introspectorClient.SubmitTx(ctx, signedTx, encodedValidCheckpoints)
 	require.NoError(t, err)
 
-	indexerOpts := setupIndexer(t)
-	opts := indexer.GetVtxosRequestOption{}
-	err = opts.WithOutpoints([]types.Outpoint{
-		{Txid: validTx.UnsignedTx.TxID(), VOut: 0},
-		{Txid: validTx.UnsignedTx.TxID(), VOut: 1},
-	})
-	require.NoError(t, err)
-	vtxos, err := indexerOpts.GetVtxos(ctx, opts)
-	require.NoError(t, err)
-	require.Len(t, vtxos.Vtxos, 2)
-	for _, vtxo := range vtxos.Vtxos {
-		require.True(t, vtxo.Preconfirmed)
-		require.False(t, vtxo.Spent)
-	}
+	waitForVtxos()
 }

--- a/test/recursive_covenant_test.go
+++ b/test/recursive_covenant_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	mempoolexplorer "github.com/arkade-os/go-sdk/explorer/mempool"
-	"github.com/arkade-os/go-sdk/indexer"
 	"github.com/arkade-os/go-sdk/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -185,6 +184,8 @@ func TestRecursivePolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	submitAndFinalize := func(candidateTx *psbt.Packet, checkpoints []*psbt.Packet) {
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, candidateTx, 0, 1)
+
 		encodedTx, err := candidateTx.B64Encode()
 		require.NoError(t, err)
 
@@ -203,20 +204,8 @@ func TestRecursivePolicy(t *testing.T) {
 
 		_, _, err = introspectorClient.SubmitTx(ctx, signedTx, signedCheckpoints)
 		require.NoError(t, err)
-		indexerOpts := setupIndexer(t)
-		opts := indexer.GetVtxosRequestOption{}
-		err = opts.WithOutpoints([]types.Outpoint{
-			{Txid: candidateTx.UnsignedTx.TxID(), VOut: 0},
-			{Txid: candidateTx.UnsignedTx.TxID(), VOut: 1},
-		})
-		require.NoError(t, err)
-		vtxos, err := indexerOpts.GetVtxos(ctx, opts)
-		require.NoError(t, err)
-		require.Len(t, vtxos.Vtxos, 2)
-		for _, vtxo := range vtxos.Vtxos {
-			require.True(t, vtxo.Preconfirmed)
-			require.False(t, vtxo.Spent)
-		}
+
+		waitForVtxos()
 	}
 
 	submitAndExpectFailure := func(inputs []offchain.VtxoInput, outputs []*wire.TxOut) {

--- a/test/tx_test.go
+++ b/test/tx_test.go
@@ -169,7 +169,6 @@ func TestSubmitOffchain(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to process transaction")
 	}
 
-
 	t.Run("single_input_invalid_script", func(t *testing.T) {
 		fundAndSettleAlice(t, ctx, alice, 10000)
 

--- a/test/tx_test.go
+++ b/test/tx_test.go
@@ -169,17 +169,6 @@ func TestSubmitOffchain(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to process transaction")
 	}
 
-	assertPreconfirmed := func(t *testing.T, idxr indexer.Indexer, txid string, vout uint32) {
-		t.Helper()
-		opts := indexer.GetVtxosRequestOption{}
-		err := opts.WithOutpoints([]types.Outpoint{{Txid: txid, VOut: vout}})
-		require.NoError(t, err)
-		vtxos, err := idxr.GetVtxos(t.Context(), opts)
-		require.NoError(t, err)
-		require.Len(t, vtxos.Vtxos, 1)
-		require.True(t, vtxos.Vtxos[0].Preconfirmed)
-		require.False(t, vtxos.Vtxos[0].Spent)
-	}
 
 	t.Run("single_input_invalid_script", func(t *testing.T) {
 		fundAndSettleAlice(t, ctx, alice, 10000)
@@ -347,9 +336,10 @@ func TestSubmitOffchain(t *testing.T) {
 			require.NoError(t, err)
 			signedValidCheckpoints = append(signedValidCheckpoints, signed)
 		}
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, validTx, 0)
 		_, _, err = introspectorClient.SubmitTx(ctx, signedTx, signedValidCheckpoints)
 		require.NoError(t, err)
-		assertPreconfirmed(t, indexerSvc, validTx.UnsignedTx.TxID(), 0)
+		waitForVtxos()
 	})
 
 	t.Run("multi_input_same_introspector_success", func(t *testing.T) {
@@ -401,9 +391,10 @@ func TestSubmitOffchain(t *testing.T) {
 			require.NoError(t, err)
 			signedCheckpoints = append(signedCheckpoints, signed)
 		}
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, validTx, 0)
 		_, _, err = introspectorClient.SubmitTx(ctx, signedTx, signedCheckpoints)
 		require.NoError(t, err)
-		assertPreconfirmed(t, indexerSvc, validTx.UnsignedTx.TxID(), 0)
+		waitForVtxos()
 	})
 
 	t.Run("not_finalizer_on_all_owned_inputs", func(t *testing.T) {
@@ -571,9 +562,10 @@ func TestSubmitOffchain(t *testing.T) {
 		signedCheckpoints[1] = introBSigned
 		signedTx, err = altIntroWallet.SignTransaction(ctx, explorer, signedTx)
 		require.NoError(t, err)
+		waitForVtxos := watchForPreconfirmedVtxos(t, indexerSvc, candidateTx, 0)
 		_, _, err = introspectorClient.SubmitTx(ctx, signedTx, signedCheckpoints)
 		require.NoError(t, err)
-		assertPreconfirmed(t, indexerSvc, candidateTx.UnsignedTx.TxID(), 0)
+		waitForVtxos()
 	})
 }
 

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -626,24 +626,77 @@ func submitWithArkd(
 	require.NoError(t, grpcClient.FinalizeTx(ctx, txid, finalCheckpoints))
 }
 
-func requirePreconfirmedVtxo(
+// watchForPreconfirmedVtxos subscribes to the output scripts of candidateTx at the
+// given vouts BEFORE the tx is submitted, and returns a wait function.
+func watchForPreconfirmedVtxos(
 	t *testing.T,
-	ctx context.Context,
 	indexerSvc indexer.Indexer,
 	candidateTx *psbt.Packet,
-	vout uint32,
-) {
+	vouts ...uint32,
+) func() {
 	t.Helper()
 
-	opts := indexer.GetVtxosRequestOption{}
-	err := opts.WithOutpoints([]types.Outpoint{{Txid: candidateTx.UnsignedTx.TxID(), VOut: vout}})
+	ctx := t.Context()
+
+	hexScripts := make([]string, 0, len(vouts))
+	wantedVouts := make(map[uint32]struct{}, len(vouts))
+	for _, vout := range vouts {
+		hexScripts = append(
+			hexScripts,
+			hex.EncodeToString(candidateTx.UnsignedTx.TxOut[vout].PkScript),
+		)
+		wantedVouts[vout] = struct{}{}
+	}
+
+	subId, err := indexerSvc.SubscribeForScripts(ctx, "", hexScripts)
 	require.NoError(t, err)
 
-	vtxos, err := indexerSvc.GetVtxos(ctx, opts)
+	eventCh, closeFn, err := indexerSvc.GetSubscription(ctx, subId)
 	require.NoError(t, err)
-	require.Len(t, vtxos.Vtxos, 1)
-	require.True(t, vtxos.Vtxos[0].Preconfirmed)
-	require.False(t, vtxos.Vtxos[0].Spent)
+
+	return func() {
+		t.Helper()
+		defer func() {
+			// nolint:errcheck
+			indexerSvc.UnsubscribeForScripts(ctx, subId, hexScripts)
+			closeFn()
+		}()
+
+		txid := candidateTx.UnsignedTx.TxID()
+		got := make(map[uint32]types.Vtxo, len(vouts))
+
+		timeout := time.After(10 * time.Second)
+		for len(got) < len(vouts) {
+			select {
+			case event, ok := <-eventCh:
+				if !ok {
+					require.FailNow(t, "subscription channel closed before all vtxos received")
+					return
+				}
+				require.NoError(t, event.Err)
+				for _, v := range event.NewVtxos {
+					if v.Txid != txid {
+						continue
+					}
+					if _, ok := wantedVouts[v.VOut]; ok {
+						got[v.VOut] = v
+					}
+				}
+			case <-timeout:
+				require.FailNowf(
+					t,
+					"timeout waiting for vtxo subscription event",
+					"got %d/%d", len(got), len(vouts),
+				)
+				return
+			}
+		}
+
+		for _, v := range got {
+			require.True(t, v.Preconfirmed, "vtxo %s:%d must be preconfirmed", v.Txid, v.VOut)
+			require.False(t, v.Spent, "vtxo %s:%d must not be spent", v.Txid, v.VOut)
+		}
+	}
 }
 
 // createIssuanceAssetPacket creates a simple asset issuance packet with one output


### PR DESCRIPTION
* update test env to 0.9.3 release
* rely on the stream to wait for VTXO, instead of indexer. it avoids to make the tests flaky and stick with what's done by arkd e2e tests (NotifyIncomingFunds from go-sdk).
