### PR TITLE
Opcode count compute limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The service can be configured using environment variables:
 | `EMULATOR_TLS_EXTRA_DOMAINS` | Additional domains for TLS cert | [] |
 | `EMULATOR_LOG_LEVEL` | Log level (0-6) | 4 (Debug) |
 | `EMULATOR_ARKD_URL` | URL of the `arkd` instance used for attempted finalization in [`SubmitTx`](#submittx) | Required |
+| `EMULATOR_COMPUTE_LIMITS` | Comma-separated `OPCODE=limit` overrides for per-input opcode execution caps, for example `OP_ECPAIRING=8,OP_MODEXP=128`. Overrides are applied on top of defaults; use an empty value such as `OP_ECADD=` to remove a default cap. | Default compute limits |
 
 ## Development
 

--- a/internal/application/intent.go
+++ b/internal/application/intent.go
@@ -55,6 +55,7 @@ func (s *service) SubmitIntent(ctx context.Context, intent Intent) (*psbt.Packet
 			ptx.UnsignedTx,
 			prevOutFetcher,
 			inputIndex,
+			arkade.WithComputeLimits(s.computeLimits),
 		); err != nil {
 			log.WithError(err).WithField("input_index", inputIndex).Error("arkade script execution failed")
 			return nil, fmt.Errorf("failed to execute arkade script at input %d: %w", inputIndex, err)

--- a/internal/application/intent.go
+++ b/internal/application/intent.go
@@ -55,7 +55,7 @@ func (s *service) SubmitIntent(ctx context.Context, intent Intent) (*psbt.Packet
 			ptx.UnsignedTx,
 			prevOutFetcher,
 			inputIndex,
-			arkade.WithComputeLimits(s.computeLimits),
+			arkade.WithExactComputeLimits(s.computeLimits),
 		); err != nil {
 			log.WithError(err).WithField("input_index", inputIndex).Error("arkade script execution failed")
 			return nil, fmt.Errorf("failed to execute arkade script at input %d: %w", inputIndex, err)

--- a/internal/application/onchain.go
+++ b/internal/application/onchain.go
@@ -57,7 +57,12 @@ func (s *service) SubmitOnchainTx(ctx context.Context, tx OnchainTx) (*psbt.Pack
 		}
 
 		log.Debugf("executing arkade script: %x", script.Script())
-		if err := script.Execute(ptx.UnsignedTx, prevOutFetcher, inputIndex); err != nil {
+		if err := script.Execute(
+			ptx.UnsignedTx,
+			prevOutFetcher,
+			inputIndex,
+			arkade.WithComputeLimits(s.computeLimits),
+		); err != nil {
 			return nil, fmt.Errorf("failed to execute arkade script: %w vin=%d", err, inputIndex)
 		}
 		log.Debugf("execution of %x succeeded", script.Script())

--- a/internal/application/onchain.go
+++ b/internal/application/onchain.go
@@ -61,7 +61,7 @@ func (s *service) SubmitOnchainTx(ctx context.Context, tx OnchainTx) (*psbt.Pack
 			ptx.UnsignedTx,
 			prevOutFetcher,
 			inputIndex,
-			arkade.WithComputeLimits(s.computeLimits),
+			arkade.WithExactComputeLimits(s.computeLimits),
 		); err != nil {
 			return nil, fmt.Errorf("failed to execute arkade script: %w vin=%d", err, inputIndex)
 		}

--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/intent"
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/arkade-os/go-sdk/client"
 	grpcclient "github.com/arkade-os/go-sdk/client/grpc"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -60,9 +61,10 @@ type service struct {
 	deprecatedPublicKeys []string
 	arkdClient           client.TransportClient
 	arkdPubKey           *btcec.PublicKey
+	computeLimits        arkade.ComputeLimits
 }
 
-func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btcec.PrivateKey, arkdURL string) (Service, error) {
+func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btcec.PrivateKey, arkdURL string, computeLimits arkade.ComputeLimits) (Service, error) {
 	if secretKey == nil {
 		return nil, fmt.Errorf("current signer key is required")
 	}
@@ -111,6 +113,7 @@ func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btc
 		deprecatedPublicKeys: deprecatedPublicKeys,
 		arkdClient:           arkdClient,
 		arkdPubKey:           arkdPubKey,
+		computeLimits:        computeLimits,
 	}, nil
 }
 

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -68,7 +68,7 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 			arkPtx.UnsignedTx,
 			prevOutFetcher,
 			inputIndex,
-			arkade.WithComputeLimits(s.computeLimits),
+			arkade.WithExactComputeLimits(s.computeLimits),
 		); err != nil {
 			return nil, fmt.Errorf("failed to execute arkade script: %w vin=%d", err, inputIndex)
 		}

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -68,6 +68,7 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 			arkPtx.UnsignedTx,
 			prevOutFetcher,
 			inputIndex,
+			arkade.WithComputeLimits(s.computeLimits),
 		); err != nil {
 			return nil, fmt.Errorf("failed to execute arkade script: %w vin=%d", err, inputIndex)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,7 +125,8 @@ func parseComputeLimits(raw string) (arkade.ComputeLimits, error) {
 	for pair := range strings.SplitSeq(raw, ",") {
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
-			continue
+			return nil, fmt.Errorf(
+				"invalid empty compute limit override in %q", raw)
 		}
 		name, value, ok := strings.Cut(pair, "=")
 		if !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/emulator/internal/application"
+	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/btcsuite/btcd/btcec/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -23,6 +25,7 @@ const (
 	TLSExtraDomains = "TLS_EXTRA_DOMAINS"
 	LogLevel        = "LOG_LEVEL"
 	ArkdURL         = "ARKD_URL"
+	ComputeLimits   = "COMPUTE_LIMITS"
 )
 
 var (
@@ -43,6 +46,7 @@ type Config struct {
 	TLSExtraIPs     []string
 	TLSExtraDomains []string
 	ArkdURL         string
+	ComputeLimits   arkade.ComputeLimits
 }
 
 func LoadConfig() (*Config, error) {
@@ -84,6 +88,11 @@ func LoadConfig() (*Config, error) {
 	logLevel := viper.GetInt(LogLevel)
 	log.SetLevel(log.Level(logLevel))
 
+	computeLimits, err := parseComputeLimits(viper.GetString(ComputeLimits))
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		CurrentKey:      currentKey,
 		DeprecatedKeys:  deprecatedKeys,
@@ -93,11 +102,52 @@ func LoadConfig() (*Config, error) {
 		TLSExtraIPs:     viper.GetStringSlice(TLSExtraIPs),
 		TLSExtraDomains: viper.GetStringSlice(TLSExtraDomains),
 		ArkdURL:         viper.GetString(ArkdURL),
+		ComputeLimits:   computeLimits,
 	}
 	if cfg.ArkdURL == "" {
 		return nil, fmt.Errorf("missing arkd url")
 	}
 	return cfg, nil
+}
+
+// parseComputeLimits builds the per-input opcode compute brake from the
+// EMULATOR_COMPUTE_LIMITS override, applied on top of the engine defaults. The
+// override is a comma-separated list of OPCODE=limit pairs, e.g.
+// "OP_ECPAIRING=8,OP_MODEXP=128"; an empty value yields the defaults unchanged.
+// It errors on an unknown opcode name, a non-integer limit, or a negative
+// limit.
+func parseComputeLimits(raw string) (arkade.ComputeLimits, error) {
+	limits := arkade.DefaultComputeLimits()
+	if strings.TrimSpace(raw) == "" {
+		return limits, nil
+	}
+
+	for pair := range strings.SplitSeq(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			return nil, fmt.Errorf(
+				"invalid compute limit override %q, want OPCODE=limit", pair)
+		}
+		name = strings.TrimSpace(name)
+		op, ok := arkade.OpcodeByName[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown opcode %q in compute limits", name)
+		}
+		limit, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit for opcode %q: %w", name, err)
+		}
+		limits[op] = limit
+	}
+
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	return limits, nil
 }
 
 func parsePrivateKey(keyHex, name string) (*btcec.PrivateKey, error) {
@@ -124,5 +174,5 @@ func parsePrivateKey(keyHex, name string) (*btcec.PrivateKey, error) {
 }
 
 func (c *Config) AppService(ctx context.Context) (application.Service, error) {
-	return application.New(ctx, c.CurrentKey, c.DeprecatedKeys, c.ArkdURL)
+	return application.New(ctx, c.CurrentKey, c.DeprecatedKeys, c.ArkdURL, c.ComputeLimits)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,12 @@ func parseComputeLimits(raw string) (arkade.ComputeLimits, error) {
 		if !ok {
 			return nil, fmt.Errorf("unknown opcode %q in compute limits", name)
 		}
-		limit, err := strconv.Atoi(strings.TrimSpace(value))
+		value = strings.TrimSpace(value)
+		if value == "" {
+			delete(limits, op)
+			continue
+		}
+		limit, err := strconv.Atoi(value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid limit for opcode %q: %w", name, err)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -337,10 +337,11 @@ func TestLoadConfigParsesComputeLimitsOverride(t *testing.T) {
 	cfg, err := loadConfigForTest(t, map[string]string{
 		"EMULATOR_SECRET_KEY":     testKeyHex(1),
 		"EMULATOR_ARKD_URL":       "http://arkd:7070",
-		"EMULATOR_COMPUTE_LIMITS": "OP_ECPAIRING=8",
+		"EMULATOR_COMPUTE_LIMITS": "OP_ECPAIRING=8,OP_MODEXP=128",
 	})
 	require.NoError(t, err)
 	require.Equal(t, 8, cfg.ComputeLimits[arkade.OP_ECPAIRING])
+	require.Equal(t, 128, cfg.ComputeLimits[arkade.OP_MODEXP])
 }
 
 func TestLoadConfigDefaultsComputeLimitsWhenUnset(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -308,6 +308,16 @@ func TestParseComputeLimitsMalformedPairErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseComputeLimitsEmptyPairErrors(t *testing.T) {
+	_, err := parseComputeLimits(",")
+	require.Error(t, err)
+}
+
+func TestParseComputeLimitsTrailingCommaErrors(t *testing.T) {
+	_, err := parseComputeLimits("OP_ECPAIRING=8,")
+	require.Error(t, err)
+}
+
 func TestParseComputeLimitsNegativeErrors(t *testing.T) {
 	_, err := parseComputeLimits("OP_ECPAIRING=-1")
 	require.Error(t, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -293,6 +293,16 @@ func TestParseComputeLimitsOverridesMultipleOpcodesWithSpaces(t *testing.T) {
 	require.Equal(t, 128, got[arkade.OP_MODEXP])
 }
 
+func TestParseComputeLimitsEmptyValueRemovesLimit(t *testing.T) {
+	got, err := parseComputeLimits("OP_ECADD=")
+	require.NoError(t, err)
+
+	_, ok := got[arkade.OP_ECADD]
+	require.False(t, ok)
+	require.Equal(t, arkade.DefaultComputeLimits()[arkade.OP_ECPAIRING],
+		got[arkade.OP_ECPAIRING])
+}
+
 func TestParseComputeLimitsUnknownOpcodeErrors(t *testing.T) {
 	_, err := parseComputeLimits("OP_NOT_A_REAL_OPCODE=5")
 	require.ErrorContains(t, err, "OP_NOT_A_REAL_OPCODE")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -266,4 +267,67 @@ func TestLoadConfigIgnoresOldEnvPrefix(t *testing.T) {
 
 	_, err := LoadConfig()
 	require.Error(t, err)
+}
+
+func TestParseComputeLimitsEmptyReturnsDefaults(t *testing.T) {
+	got, err := parseComputeLimits("")
+	require.NoError(t, err)
+	require.Equal(t, arkade.DefaultComputeLimits(), got)
+}
+
+func TestParseComputeLimitsOverridesSingleOpcode(t *testing.T) {
+	got, err := parseComputeLimits("OP_ECPAIRING=8")
+	require.NoError(t, err)
+
+	require.Equal(t, 8, got[arkade.OP_ECPAIRING])
+	// Unspecified opcodes keep their defaults.
+	require.Equal(t, arkade.DefaultComputeLimits()[arkade.OP_MODEXP],
+		got[arkade.OP_MODEXP])
+}
+
+func TestParseComputeLimitsOverridesMultipleOpcodesWithSpaces(t *testing.T) {
+	got, err := parseComputeLimits(" OP_ECPAIRING=8 , OP_MODEXP=128 ")
+	require.NoError(t, err)
+
+	require.Equal(t, 8, got[arkade.OP_ECPAIRING])
+	require.Equal(t, 128, got[arkade.OP_MODEXP])
+}
+
+func TestParseComputeLimitsUnknownOpcodeErrors(t *testing.T) {
+	_, err := parseComputeLimits("OP_NOT_A_REAL_OPCODE=5")
+	require.ErrorContains(t, err, "OP_NOT_A_REAL_OPCODE")
+}
+
+func TestParseComputeLimitsNonIntegerErrors(t *testing.T) {
+	_, err := parseComputeLimits("OP_ECPAIRING=lots")
+	require.Error(t, err)
+}
+
+func TestParseComputeLimitsMalformedPairErrors(t *testing.T) {
+	_, err := parseComputeLimits("OP_ECPAIRING")
+	require.Error(t, err)
+}
+
+func TestParseComputeLimitsNegativeErrors(t *testing.T) {
+	_, err := parseComputeLimits("OP_ECPAIRING=-1")
+	require.Error(t, err)
+}
+
+func TestLoadConfigParsesComputeLimitsOverride(t *testing.T) {
+	cfg, err := loadConfigForTest(t, map[string]string{
+		"EMULATOR_SECRET_KEY":     testKeyHex(1),
+		"EMULATOR_ARKD_URL":       "http://arkd:7070",
+		"EMULATOR_COMPUTE_LIMITS": "OP_ECPAIRING=8",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 8, cfg.ComputeLimits[arkade.OP_ECPAIRING])
+}
+
+func TestLoadConfigDefaultsComputeLimitsWhenUnset(t *testing.T) {
+	cfg, err := loadConfigForTest(t, map[string]string{
+		"EMULATOR_SECRET_KEY": testKeyHex(1),
+		"EMULATOR_ARKD_URL":   "http://arkd:7070",
+	})
+	require.NoError(t, err)
+	require.Equal(t, arkade.DefaultComputeLimits(), cfg.ComputeLimits)
 }

--- a/pkg/arkade/compute_limits.go
+++ b/pkg/arkade/compute_limits.go
@@ -27,6 +27,11 @@ func (c ComputeLimits) Validate() error {
 // single-threaded) to bound worst-case per-input CPU well below the
 // multi-second cases an unbounded script could reach.
 func DefaultComputeLimits() ComputeLimits {
+	// Aggregate-cost note: this table is deliberately a simple per-opcode
+	// lookup, not a grouped or weighted budget. If every listed opcode is pushed
+	// to its independent cap, the measured heavy-opcode aggregate is ~37 ms per
+	// input on an Apple M4 Pro. That is looser than the ~24 ms grouped design,
+	// but keeps the policy easy to read, configure, and reason about for now.
 	return ComputeLimits{
 		// Schnorr-class signature verification, ~84 µs each.
 		OP_CHECKSIG:          50,
@@ -42,7 +47,3 @@ func DefaultComputeLimits() ComputeLimits {
 		OP_MODEXP:            64,   // ~60 µs at the 64-byte operand cap
 	}
 }
-
-// defaultComputeLimits is the shared, read-only default applied by NewEngine to
-// every engine that does not override it via WithComputeLimits.
-var defaultComputeLimits = DefaultComputeLimits()

--- a/pkg/arkade/compute_limits.go
+++ b/pkg/arkade/compute_limits.go
@@ -47,3 +47,14 @@ func DefaultComputeLimits() ComputeLimits {
 		OP_MODEXP:            64,   // ~60 µs at the 64-byte operand cap
 	}
 }
+
+func cloneComputeLimits(c ComputeLimits) ComputeLimits {
+	if c == nil {
+		return nil
+	}
+	clone := make(ComputeLimits, len(c))
+	for op, limit := range c {
+		clone[op] = limit
+	}
+	return clone
+}

--- a/pkg/arkade/compute_limits.go
+++ b/pkg/arkade/compute_limits.go
@@ -2,108 +2,47 @@ package arkade
 
 import "fmt"
 
-// OpcodeGroup is a named set of opcodes that share a single per-input
-// execution-count limit. Each time any member opcode executes, the group's
-// remaining count is decremented; execution fails once a group would go below
-// zero.
-type OpcodeGroup struct {
-	Name    string
-	Opcodes []byte
-	Limit   int
-}
-
-// ComputeLimits is the declarative compute brake: a set of opcode groups, each
-// with its own per-input execution-count cap. Opcodes that belong to no group
-// are unlimited, matching tapscript's lack of an op-count limit for the cheap
+// ComputeLimits maps an opcode to the maximum number of times it may execute
+// during a single input's script evaluation. Opcodes absent from the map are
+// unlimited, matching tapscript's lack of an op-count limit for the cheap
 // opcodes whose per-call cost is negligible.
-type ComputeLimits struct {
-	Groups []OpcodeGroup
-}
+type ComputeLimits map[byte]int
 
-// compiledComputeLimits is the hot-path form of a ComputeLimits: a constant-time
-// opcode→group lookup plus per-group metadata addressed by group index.
-type compiledComputeLimits struct {
-	groupOf [256]int // opcode byte -> group index, -1 if ungrouped
-	limits  []int    // per-group execution-count limit
-	names   []string // per-group name, for error messages
-}
-
-// Validate reports whether the configuration is well formed: every limit must
-// be non-negative and no opcode may appear in more than one group.
+// Validate reports whether every configured limit is non-negative.
 func (c ComputeLimits) Validate() error {
-	var seen [256]bool
-	for _, g := range c.Groups {
-		if g.Limit < 0 {
-			return fmt.Errorf("compute limits: group %q has negative limit %d",
-				g.Name, g.Limit)
-		}
-		for _, op := range g.Opcodes {
-			if seen[op] {
-				return fmt.Errorf("compute limits: opcode 0x%02x appears in "+
-					"more than one group", op)
-			}
-			seen[op] = true
+	for op, limit := range c {
+		if limit < 0 {
+			return fmt.Errorf("compute limit for %s is negative: %d",
+				opcodeArray[op].name, limit)
 		}
 	}
 	return nil
 }
 
-// compile builds the lookup form. It panics on an invalid configuration: a
-// malformed ComputeLimits is always a programmer error, never runtime input.
-// Use Validate to check a configuration without panicking.
-func (c ComputeLimits) compile() *compiledComputeLimits {
-	if err := c.Validate(); err != nil {
-		panic(err)
-	}
-	cl := &compiledComputeLimits{
-		limits: make([]int, len(c.Groups)),
-		names:  make([]string, len(c.Groups)),
-	}
-	for i := range cl.groupOf {
-		cl.groupOf[i] = -1
-	}
-	for gi, g := range c.Groups {
-		cl.limits[gi] = g.Limit
-		cl.names[gi] = g.Name
-		for _, op := range g.Opcodes {
-			cl.groupOf[op] = gi
-		}
-	}
-	return cl
-}
-
-// DefaultComputeLimits returns the canonical per-input compute brake. It is a
-// function rather than an exported variable so the production policy cannot be
-// mutated through a shared slice-backed global: each call builds fresh slices,
-// so callers may freely modify the returned value (e.g. to relax a limit for an
-// experiment) without affecting the engine default.
+// DefaultComputeLimits returns the canonical per-input execution caps for the
+// heavy opcodes. It returns a fresh map so callers may modify their copy
+// without affecting the engine default.
 //
 // Limits are calibrated from the issue #81 benchmark table (Apple Silicon,
-// single-threaded) so the worst-case per-input CPU summed across all groups —
-// Σ(limit × worst-call-cost) — is roughly 20-25 ms, well below the multi-second
-// adversarial cases an unbounded script could reach.
+// single-threaded) to bound worst-case per-input CPU well below the
+// multi-second cases an unbounded script could reach.
 func DefaultComputeLimits() ComputeLimits {
-	return ComputeLimits{Groups: []OpcodeGroup{
-		// Schnorr verify ≈ 84 µs/call; 50 → ≈ 4.2 ms.
-		{Name: "sig", Limit: 50, Opcodes: []byte{
-			OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKSIGADD,
-		}},
-		// ≈ 3.7 µs/call; 1000 → ≈ 3.7 ms.
-		{Name: "ec-add", Limit: 1000, Opcodes: []byte{OP_ECADD}},
-		// ≈ 84 µs/call; 50 → ≈ 4.2 ms.
-		{Name: "ec-scalarmul", Limit: 50, Opcodes: []byte{
-			OP_ECMUL, OP_ECMULSCALARVERIFY, OP_TWEAKVERIFY,
-		}},
-		// CHECKSIGFROMSTACK ≈ 84 µs/call; 50 → ≈ 4.2 ms.
-		{Name: "ec-sig", Limit: 50, Opcodes: []byte{OP_CHECKSIGFROMSTACK}},
-		// ≈ 2.04 ms/call at the 16-pair cap; 2 → ≈ 4.1 ms.
-		{Name: "ec-pairing", Limit: 2, Opcodes: []byte{OP_ECPAIRING}},
-		// ≈ 60 µs/call at the 64-byte operand cap; 64 → ≈ 3.8 ms.
-		{Name: "modexp", Limit: 64, Opcodes: []byte{OP_MODEXP}},
-	}}
+	return ComputeLimits{
+		// Schnorr-class signature verification, ~84 µs each.
+		OP_CHECKSIG:          50,
+		OP_CHECKSIGVERIFY:    50,
+		OP_CHECKSIGADD:       50,
+		OP_CHECKSIGFROMSTACK: 50,
+		// Elliptic-curve point operations.
+		OP_ECADD:             1000, // ~3.7 µs
+		OP_ECMUL:             50,   // ~84 µs
+		OP_ECMULSCALARVERIFY: 50,   // ~84 µs
+		OP_TWEAKVERIFY:       50,   // ~84 µs
+		OP_ECPAIRING:         2,    // ~2.04 ms at the 16-pair cap
+		OP_MODEXP:            64,   // ~60 µs at the 64-byte operand cap
+	}
 }
 
-// defaultCompiledLimits is the compiled canonical brake, built once at package
-// init and shared read-only by every engine that does not override it via
-// WithComputeLimits.
-var defaultCompiledLimits = DefaultComputeLimits().compile()
+// defaultComputeLimits is the shared, read-only default applied by NewEngine to
+// every engine that does not override it via WithComputeLimits.
+var defaultComputeLimits = DefaultComputeLimits()

--- a/pkg/arkade/compute_limits.go
+++ b/pkg/arkade/compute_limits.go
@@ -22,10 +22,6 @@ func (c ComputeLimits) Validate() error {
 // DefaultComputeLimits returns the canonical per-input execution caps for the
 // heavy opcodes. It returns a fresh map so callers may modify their copy
 // without affecting the engine default.
-//
-// Limits are calibrated from the issue #81 benchmark table (Apple Silicon,
-// single-threaded) to bound worst-case per-input CPU well below the
-// multi-second cases an unbounded script could reach.
 func DefaultComputeLimits() ComputeLimits {
 	// Aggregate-cost note: this table is deliberately a simple per-opcode
 	// lookup, not a grouped or weighted budget. If every listed opcode is pushed

--- a/pkg/arkade/compute_limits.go
+++ b/pkg/arkade/compute_limits.go
@@ -1,0 +1,109 @@
+package arkade
+
+import "fmt"
+
+// OpcodeGroup is a named set of opcodes that share a single per-input
+// execution-count limit. Each time any member opcode executes, the group's
+// remaining count is decremented; execution fails once a group would go below
+// zero.
+type OpcodeGroup struct {
+	Name    string
+	Opcodes []byte
+	Limit   int
+}
+
+// ComputeLimits is the declarative compute brake: a set of opcode groups, each
+// with its own per-input execution-count cap. Opcodes that belong to no group
+// are unlimited, matching tapscript's lack of an op-count limit for the cheap
+// opcodes whose per-call cost is negligible.
+type ComputeLimits struct {
+	Groups []OpcodeGroup
+}
+
+// compiledComputeLimits is the hot-path form of a ComputeLimits: a constant-time
+// opcode→group lookup plus per-group metadata addressed by group index.
+type compiledComputeLimits struct {
+	groupOf [256]int // opcode byte -> group index, -1 if ungrouped
+	limits  []int    // per-group execution-count limit
+	names   []string // per-group name, for error messages
+}
+
+// Validate reports whether the configuration is well formed: every limit must
+// be non-negative and no opcode may appear in more than one group.
+func (c ComputeLimits) Validate() error {
+	var seen [256]bool
+	for _, g := range c.Groups {
+		if g.Limit < 0 {
+			return fmt.Errorf("compute limits: group %q has negative limit %d",
+				g.Name, g.Limit)
+		}
+		for _, op := range g.Opcodes {
+			if seen[op] {
+				return fmt.Errorf("compute limits: opcode 0x%02x appears in "+
+					"more than one group", op)
+			}
+			seen[op] = true
+		}
+	}
+	return nil
+}
+
+// compile builds the lookup form. It panics on an invalid configuration: a
+// malformed ComputeLimits is always a programmer error, never runtime input.
+// Use Validate to check a configuration without panicking.
+func (c ComputeLimits) compile() *compiledComputeLimits {
+	if err := c.Validate(); err != nil {
+		panic(err)
+	}
+	cl := &compiledComputeLimits{
+		limits: make([]int, len(c.Groups)),
+		names:  make([]string, len(c.Groups)),
+	}
+	for i := range cl.groupOf {
+		cl.groupOf[i] = -1
+	}
+	for gi, g := range c.Groups {
+		cl.limits[gi] = g.Limit
+		cl.names[gi] = g.Name
+		for _, op := range g.Opcodes {
+			cl.groupOf[op] = gi
+		}
+	}
+	return cl
+}
+
+// DefaultComputeLimits returns the canonical per-input compute brake. It is a
+// function rather than an exported variable so the production policy cannot be
+// mutated through a shared slice-backed global: each call builds fresh slices,
+// so callers may freely modify the returned value (e.g. to relax a limit for an
+// experiment) without affecting the engine default.
+//
+// Limits are calibrated from the issue #81 benchmark table (Apple Silicon,
+// single-threaded) so the worst-case per-input CPU summed across all groups —
+// Σ(limit × worst-call-cost) — is roughly 20-25 ms, well below the multi-second
+// adversarial cases an unbounded script could reach.
+func DefaultComputeLimits() ComputeLimits {
+	return ComputeLimits{Groups: []OpcodeGroup{
+		// Schnorr verify ≈ 84 µs/call; 50 → ≈ 4.2 ms.
+		{Name: "sig", Limit: 50, Opcodes: []byte{
+			OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKSIGADD,
+		}},
+		// ≈ 3.7 µs/call; 1000 → ≈ 3.7 ms.
+		{Name: "ec-add", Limit: 1000, Opcodes: []byte{OP_ECADD}},
+		// ≈ 84 µs/call; 50 → ≈ 4.2 ms.
+		{Name: "ec-scalarmul", Limit: 50, Opcodes: []byte{
+			OP_ECMUL, OP_ECMULSCALARVERIFY, OP_TWEAKVERIFY,
+		}},
+		// CHECKSIGFROMSTACK ≈ 84 µs/call; 50 → ≈ 4.2 ms.
+		{Name: "ec-sig", Limit: 50, Opcodes: []byte{OP_CHECKSIGFROMSTACK}},
+		// ≈ 2.04 ms/call at the 16-pair cap; 2 → ≈ 4.1 ms.
+		{Name: "ec-pairing", Limit: 2, Opcodes: []byte{OP_ECPAIRING}},
+		// ≈ 60 µs/call at the 64-byte operand cap; 64 → ≈ 3.8 ms.
+		{Name: "modexp", Limit: 64, Opcodes: []byte{OP_MODEXP}},
+	}}
+}
+
+// defaultCompiledLimits is the compiled canonical brake, built once at package
+// init and shared read-only by every engine that does not override it via
+// WithComputeLimits.
+var defaultCompiledLimits = DefaultComputeLimits().compile()

--- a/pkg/arkade/compute_limits_engine_test.go
+++ b/pkg/arkade/compute_limits_engine_test.go
@@ -122,6 +122,44 @@ func TestWithComputeLimitsOverridesDefault(t *testing.T) {
 		txscript.ErrScriptTooBig)
 }
 
+func TestWithComputeLimitsMergesWithDefaults(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+
+	WithComputeLimits(ComputeLimits{OP_ECPAIRING: 8})(vm)
+
+	pubkey := make([]byte, 32)
+	pushSig := func() { vm.SetStack([][]byte{{}, pubkey}) }
+	for range 50 {
+		pushSig()
+		require.NoError(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm))
+	}
+	pushSig()
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+func TestWithExactComputeLimitsCanRemoveDefaultLimit(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+	limits := DefaultComputeLimits()
+	delete(limits, OP_CHECKSIG)
+
+	WithExactComputeLimits(limits)(vm)
+
+	pubkey := make([]byte, 32)
+	for range 100 {
+		vm.SetStack([][]byte{{}, pubkey})
+		require.NoError(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm))
+	}
+}
+
 func TestWithComputeLimitsNilKeepsDefaultLimits(t *testing.T) {
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)

--- a/pkg/arkade/compute_limits_engine_test.go
+++ b/pkg/arkade/compute_limits_engine_test.go
@@ -122,6 +122,40 @@ func TestWithComputeLimitsOverridesDefault(t *testing.T) {
 		txscript.ErrScriptTooBig)
 }
 
+func TestWithComputeLimitsNilKeepsDefaultLimits(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+
+	WithComputeLimits(nil)(vm)
+
+	pubkey := make([]byte, 32)
+	pushSig := func() { vm.SetStack([][]byte{{}, pubkey}) }
+	for range 50 {
+		pushSig()
+		require.NoError(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm))
+	}
+	pushSig()
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+func TestNewEngineDefaultLimitsAreIndependent(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.limits[OP_1] = 0
+
+	next, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	next.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+
+	require.NoError(t, invokeOpcodeWithData(OP_1, nil, next))
+}
+
 func TestChargeOpcodeNoTaprootContextIsUnlimited(t *testing.T) {
 	// With no tapscript context there is no per-input budget, even for an
 	// opcode that would otherwise be limited to zero executions.

--- a/pkg/arkade/compute_limits_engine_test.go
+++ b/pkg/arkade/compute_limits_engine_test.go
@@ -7,20 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// limitOnlyOp1 builds an engine whose only compute group is OP_1 with the given
-// limit, with a tapscript execution context active so charges take effect.
+// limitOnlyOp1 builds an engine whose only compute limit is OP_1, with a
+// tapscript execution context active so charges take effect.
 func limitOnlyOp1(t *testing.T, limit int) *Engine {
 	t.Helper()
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)
 	vm.taprootCtx = &taprootExecutionCtx{}
-	vm.limits = ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "test", Limit: limit, Opcodes: []byte{OP_1}},
-	}}.compile()
+	vm.limits = ComputeLimits{OP_1: limit}
 	return vm
 }
 
-func TestChargeOpcodeEnforcesGroupLimit(t *testing.T) {
+func TestChargeOpcodeEnforcesLimit(t *testing.T) {
 	vm := limitOnlyOp1(t, 2)
 
 	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
@@ -47,14 +45,12 @@ func TestChargeOpcodeIgnoresDeadBranch(t *testing.T) {
 		txscript.ErrScriptTooBig)
 }
 
-func TestChargeOpcodeUngroupedIsUnlimited(t *testing.T) {
-	// OP_1 is not in any group here, so it is never charged.
+func TestChargeOpcodeUnlistedIsUnlimited(t *testing.T) {
+	// OP_1 has no limit here, so it is never charged.
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)
 	vm.taprootCtx = &taprootExecutionCtx{}
-	vm.limits = ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "test", Limit: 0, Opcodes: []byte{OP_ECADD}},
-	}}.compile()
+	vm.limits = ComputeLimits{OP_ECADD: 0}
 
 	for range 100 {
 		require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
@@ -63,8 +59,8 @@ func TestChargeOpcodeUngroupedIsUnlimited(t *testing.T) {
 
 // TestComputeLimitPairingTripsBeforePerCallCap is the acceptance-criterion
 // test: a script that repeats OP_ECPAIRING with each call well within the
-// per-call pair cap (maxECPairingCount) still fails once the group's call-count
-// limit is exhausted, under the default limits.
+// per-call pair cap (maxECPairingCount) still fails once OP_ECPAIRING's
+// execution limit is exhausted, under the default limits.
 func TestComputeLimitPairingTripsBeforePerCallCap(t *testing.T) {
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)
@@ -72,8 +68,8 @@ func TestComputeLimitPairingTripsBeforePerCallCap(t *testing.T) {
 		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
 	)
 
-	// Default ec-pairing limit is 2. Each call uses a single pair — far below
-	// the 16-pair per-call cap — so only the count limit can stop it.
+	// Default OP_ECPAIRING limit is 2. Each call uses a single pair — far below
+	// the 16-pair per-call cap — so only the execution limit can stop it.
 	for range 2 {
 		vm.SetStack(pairingFalseVectors())
 		require.NoError(t, invokeOpcodeWithData(OP_ECPAIRING, nil, vm))
@@ -83,10 +79,10 @@ func TestComputeLimitPairingTripsBeforePerCallCap(t *testing.T) {
 		txscript.ErrScriptTooBig)
 }
 
-// TestComputeLimitSigGroupCountsEveryExecution locks in the post-sigops
-// behavior: the sig group counts every CHECKSIG execution, including
-// empty-signature calls that BIP-342 used to exempt.
-func TestComputeLimitSigGroupCountsEveryExecution(t *testing.T) {
+// TestComputeLimitSigCountsEveryExecution locks in the post-sigops behavior:
+// CHECKSIG is counted on every execution, including empty-signature calls that
+// BIP-342 used to exempt.
+func TestComputeLimitSigCountsEveryExecution(t *testing.T) {
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)
 	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
@@ -98,7 +94,7 @@ func TestComputeLimitSigGroupCountsEveryExecution(t *testing.T) {
 	pubkey := make([]byte, 32)
 	pushSig := func() { vm.SetStack([][]byte{{}, pubkey}) }
 
-	// Default sig limit is 50.
+	// Default OP_CHECKSIG limit is 50.
 	for range 50 {
 		pushSig()
 		require.NoError(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm))
@@ -110,7 +106,7 @@ func TestComputeLimitSigGroupCountsEveryExecution(t *testing.T) {
 
 // TestWithComputeLimitsOverridesDefault verifies the override applies even
 // though it runs after the taproot context was created (as it does in
-// ArkadeScript.Execute), thanks to lazy budget initialization.
+// ArkadeScript.Execute).
 func TestWithComputeLimitsOverridesDefault(t *testing.T) {
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)
@@ -118,10 +114,8 @@ func TestWithComputeLimitsOverridesDefault(t *testing.T) {
 		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
 	)
 
-	// OP_1 is unlimited under the default config; the override caps it at 1.
-	WithComputeLimits(ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "test", Limit: 1, Opcodes: []byte{OP_1}},
-	}})(vm)
+	// OP_1 is unlimited by default; the override caps it at 1.
+	WithComputeLimits(ComputeLimits{OP_1: 1})(vm)
 
 	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
 	requireScriptErrorCode(t, invokeOpcodeWithData(OP_1, nil, vm),
@@ -134,9 +128,7 @@ func TestChargeOpcodeNoTaprootContextIsUnlimited(t *testing.T) {
 	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
 	require.NoError(t, err)
 	vm.taprootCtx = nil
-	vm.limits = ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "test", Limit: 0, Opcodes: []byte{OP_1}},
-	}}.compile()
+	vm.limits = ComputeLimits{OP_1: 0}
 
 	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
 }

--- a/pkg/arkade/compute_limits_engine_test.go
+++ b/pkg/arkade/compute_limits_engine_test.go
@@ -7,17 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// limitOnlyOp1 builds an engine whose only compute limit is OP_1, with a
-// tapscript execution context active so charges take effect.
-func limitOnlyOp1(t *testing.T, limit int) *Engine {
-	t.Helper()
-	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
-	require.NoError(t, err)
-	vm.taprootCtx = &taprootExecutionCtx{}
-	vm.limits = ComputeLimits{OP_1: limit}
-	return vm
-}
-
 func TestChargeOpcodeEnforcesLimit(t *testing.T) {
 	vm := limitOnlyOp1(t, 2)
 
@@ -203,4 +192,15 @@ func TestChargeOpcodeNoTaprootContextIsUnlimited(t *testing.T) {
 	vm.limits = ComputeLimits{OP_1: 0}
 
 	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+}
+
+// limitOnlyOp1 builds an engine whose only compute limit is OP_1, with a
+// tapscript execution context active so charges take effect.
+func limitOnlyOp1(t *testing.T, limit int) *Engine {
+	t.Helper()
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = &taprootExecutionCtx{}
+	vm.limits = ComputeLimits{OP_1: limit}
+	return vm
 }

--- a/pkg/arkade/compute_limits_engine_test.go
+++ b/pkg/arkade/compute_limits_engine_test.go
@@ -1,0 +1,142 @@
+package arkade
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// limitOnlyOp1 builds an engine whose only compute group is OP_1 with the given
+// limit, with a tapscript execution context active so charges take effect.
+func limitOnlyOp1(t *testing.T, limit int) *Engine {
+	t.Helper()
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = &taprootExecutionCtx{}
+	vm.limits = ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "test", Limit: limit, Opcodes: []byte{OP_1}},
+	}}.compile()
+	return vm
+}
+
+func TestChargeOpcodeEnforcesGroupLimit(t *testing.T) {
+	vm := limitOnlyOp1(t, 2)
+
+	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_1, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+func TestChargeOpcodeIgnoresDeadBranch(t *testing.T) {
+	vm := limitOnlyOp1(t, 1)
+
+	// Inside a non-executed conditional branch, executions must not count.
+	vm.condStack = []int{OpCondFalse}
+	for range 5 {
+		require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+	}
+
+	// Back in an executing branch the full budget is still available: one
+	// charge succeeds, the next exhausts it — proving the dead-branch
+	// executions consumed nothing.
+	vm.condStack = nil
+	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_1, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+func TestChargeOpcodeUngroupedIsUnlimited(t *testing.T) {
+	// OP_1 is not in any group here, so it is never charged.
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = &taprootExecutionCtx{}
+	vm.limits = ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "test", Limit: 0, Opcodes: []byte{OP_ECADD}},
+	}}.compile()
+
+	for range 100 {
+		require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+	}
+}
+
+// TestComputeLimitPairingTripsBeforePerCallCap is the acceptance-criterion
+// test: a script that repeats OP_ECPAIRING with each call well within the
+// per-call pair cap (maxECPairingCount) still fails once the group's call-count
+// limit is exhausted, under the default limits.
+func TestComputeLimitPairingTripsBeforePerCallCap(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+
+	// Default ec-pairing limit is 2. Each call uses a single pair — far below
+	// the 16-pair per-call cap — so only the count limit can stop it.
+	for range 2 {
+		vm.SetStack(pairingFalseVectors())
+		require.NoError(t, invokeOpcodeWithData(OP_ECPAIRING, nil, vm))
+	}
+	vm.SetStack(pairingFalseVectors())
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_ECPAIRING, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+// TestComputeLimitSigGroupCountsEveryExecution locks in the post-sigops
+// behavior: the sig group counts every CHECKSIG execution, including
+// empty-signature calls that BIP-342 used to exempt.
+func TestComputeLimitSigGroupCountsEveryExecution(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+
+	// An empty signature short-circuits before any verification; a non-empty
+	// pubkey is all opcodeCheckSig requires to reach that path.
+	pubkey := make([]byte, 32)
+	pushSig := func() { vm.SetStack([][]byte{{}, pubkey}) }
+
+	// Default sig limit is 50.
+	for range 50 {
+		pushSig()
+		require.NoError(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm))
+	}
+	pushSig()
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_CHECKSIG, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+// TestWithComputeLimitsOverridesDefault verifies the override applies even
+// though it runs after the taproot context was created (as it does in
+// ArkadeScript.Execute), thanks to lazy budget initialization.
+func TestWithComputeLimitsOverridesDefault(t *testing.T) {
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
+		txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	)
+
+	// OP_1 is unlimited under the default config; the override caps it at 1.
+	WithComputeLimits(ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "test", Limit: 1, Opcodes: []byte{OP_1}},
+	}})(vm)
+
+	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_1, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
+func TestChargeOpcodeNoTaprootContextIsUnlimited(t *testing.T) {
+	// With no tapscript context there is no per-input budget, even for an
+	// opcode that would otherwise be limited to zero executions.
+	vm, err := newOpcodeEngine(buildOpcodeWorld(), 0)
+	require.NoError(t, err)
+	vm.taprootCtx = nil
+	vm.limits = ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "test", Limit: 0, Opcodes: []byte{OP_1}},
+	}}.compile()
+
+	require.NoError(t, invokeOpcodeWithData(OP_1, nil, vm))
+}

--- a/pkg/arkade/compute_limits_engine_test.go
+++ b/pkg/arkade/compute_limits_engine_test.go
@@ -16,6 +16,15 @@ func TestChargeOpcodeEnforcesLimit(t *testing.T) {
 		txscript.ErrScriptTooBig)
 }
 
+func TestChargeOpcodeZeroLimitForbidsExecution(t *testing.T) {
+	vm := limitOnlyOp1(t, 0)
+
+	// A limit of 0 disables the opcode entirely: the very first execution
+	// already exceeds the budget.
+	requireScriptErrorCode(t, invokeOpcodeWithData(OP_1, nil, vm),
+		txscript.ErrScriptTooBig)
+}
+
 func TestChargeOpcodeIgnoresDeadBranch(t *testing.T) {
 	vm := limitOnlyOp1(t, 1)
 

--- a/pkg/arkade/compute_limits_test.go
+++ b/pkg/arkade/compute_limits_test.go
@@ -14,15 +14,6 @@ func TestComputeLimitsValidateAcceptsDefault(t *testing.T) {
 	require.NoError(t, DefaultComputeLimits().Validate())
 }
 
-func TestDefaultComputeLimitsIsIndependentCopy(t *testing.T) {
-	c1 := DefaultComputeLimits()
-	c1[OP_ECPAIRING] = 99999
-
-	c2 := DefaultComputeLimits()
-	require.NotEqual(t, 99999, c2[OP_ECPAIRING],
-		"mutating a returned copy must not affect later calls")
-}
-
 func TestDefaultComputeLimitsCoversHeavyOpcodes(t *testing.T) {
 	heavy := []byte{
 		OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKSIGADD,

--- a/pkg/arkade/compute_limits_test.go
+++ b/pkg/arkade/compute_limits_test.go
@@ -1,0 +1,77 @@
+package arkade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeLimitsCompileLookup(t *testing.T) {
+	c := ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "first", Limit: 3, Opcodes: []byte{OP_ECADD, OP_ECMUL}},
+		{Name: "second", Limit: 7, Opcodes: []byte{OP_MODEXP}},
+	}}
+	compiled := c.compile()
+
+	require.Equal(t, 0, compiled.groupOf[OP_ECADD])
+	require.Equal(t, 0, compiled.groupOf[OP_ECMUL])
+	require.Equal(t, 1, compiled.groupOf[OP_MODEXP])
+	// Ungrouped opcodes map to -1.
+	require.Equal(t, -1, compiled.groupOf[OP_DUP])
+
+	require.Equal(t, []int{3, 7}, compiled.limits)
+	require.Equal(t, []string{"first", "second"}, compiled.names)
+}
+
+func TestComputeLimitsValidateRejectsDuplicateOpcode(t *testing.T) {
+	c := ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "a", Limit: 1, Opcodes: []byte{OP_ECADD}},
+		{Name: "b", Limit: 1, Opcodes: []byte{OP_ECADD}},
+	}}
+	require.Error(t, c.Validate())
+}
+
+func TestComputeLimitsValidateRejectsNegativeLimit(t *testing.T) {
+	c := ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "a", Limit: -1, Opcodes: []byte{OP_ECADD}},
+	}}
+	require.Error(t, c.Validate())
+}
+
+func TestComputeLimitsValidateAcceptsWellFormed(t *testing.T) {
+	require.NoError(t, DefaultComputeLimits().Validate())
+}
+
+func TestComputeLimitsCompilePanicsOnInvalid(t *testing.T) {
+	c := ComputeLimits{Groups: []OpcodeGroup{
+		{Name: "a", Limit: 1, Opcodes: []byte{OP_ECADD}},
+		{Name: "b", Limit: 1, Opcodes: []byte{OP_ECADD}},
+	}}
+	require.Panics(t, func() { _ = c.compile() })
+}
+
+func TestDefaultComputeLimitsIsIndependentCopy(t *testing.T) {
+	c1 := DefaultComputeLimits()
+	c1.Groups[0].Limit = 99999
+	c1.Groups[0].Opcodes[0] = OP_NOP
+
+	c2 := DefaultComputeLimits()
+	require.NotEqual(t, 99999, c2.Groups[0].Limit,
+		"mutating a returned copy must not affect later calls")
+	require.NotEqual(t, byte(OP_NOP), c2.Groups[0].Opcodes[0],
+		"opcode slices must be deep-copied")
+}
+
+func TestDefaultCompiledLimitsCoversHeavyOpcodes(t *testing.T) {
+	heavy := []byte{
+		OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKSIGADD,
+		OP_CHECKSIGFROMSTACK,
+		OP_ECADD, OP_ECMUL, OP_ECPAIRING,
+		OP_ECMULSCALARVERIFY, OP_TWEAKVERIFY,
+		OP_MODEXP,
+	}
+	for _, op := range heavy {
+		require.GreaterOrEqualf(t, defaultCompiledLimits.groupOf[op], 0,
+			"opcode 0x%02x must belong to a compute-limit group", op)
+	}
+}

--- a/pkg/arkade/compute_limits_test.go
+++ b/pkg/arkade/compute_limits_test.go
@@ -6,63 +6,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestComputeLimitsCompileLookup(t *testing.T) {
-	c := ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "first", Limit: 3, Opcodes: []byte{OP_ECADD, OP_ECMUL}},
-		{Name: "second", Limit: 7, Opcodes: []byte{OP_MODEXP}},
-	}}
-	compiled := c.compile()
-
-	require.Equal(t, 0, compiled.groupOf[OP_ECADD])
-	require.Equal(t, 0, compiled.groupOf[OP_ECMUL])
-	require.Equal(t, 1, compiled.groupOf[OP_MODEXP])
-	// Ungrouped opcodes map to -1.
-	require.Equal(t, -1, compiled.groupOf[OP_DUP])
-
-	require.Equal(t, []int{3, 7}, compiled.limits)
-	require.Equal(t, []string{"first", "second"}, compiled.names)
+func TestComputeLimitsValidateRejectsNegative(t *testing.T) {
+	require.Error(t, ComputeLimits{OP_ECADD: -1}.Validate())
 }
 
-func TestComputeLimitsValidateRejectsDuplicateOpcode(t *testing.T) {
-	c := ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "a", Limit: 1, Opcodes: []byte{OP_ECADD}},
-		{Name: "b", Limit: 1, Opcodes: []byte{OP_ECADD}},
-	}}
-	require.Error(t, c.Validate())
-}
-
-func TestComputeLimitsValidateRejectsNegativeLimit(t *testing.T) {
-	c := ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "a", Limit: -1, Opcodes: []byte{OP_ECADD}},
-	}}
-	require.Error(t, c.Validate())
-}
-
-func TestComputeLimitsValidateAcceptsWellFormed(t *testing.T) {
+func TestComputeLimitsValidateAcceptsDefault(t *testing.T) {
 	require.NoError(t, DefaultComputeLimits().Validate())
-}
-
-func TestComputeLimitsCompilePanicsOnInvalid(t *testing.T) {
-	c := ComputeLimits{Groups: []OpcodeGroup{
-		{Name: "a", Limit: 1, Opcodes: []byte{OP_ECADD}},
-		{Name: "b", Limit: 1, Opcodes: []byte{OP_ECADD}},
-	}}
-	require.Panics(t, func() { _ = c.compile() })
 }
 
 func TestDefaultComputeLimitsIsIndependentCopy(t *testing.T) {
 	c1 := DefaultComputeLimits()
-	c1.Groups[0].Limit = 99999
-	c1.Groups[0].Opcodes[0] = OP_NOP
+	c1[OP_ECPAIRING] = 99999
 
 	c2 := DefaultComputeLimits()
-	require.NotEqual(t, 99999, c2.Groups[0].Limit,
+	require.NotEqual(t, 99999, c2[OP_ECPAIRING],
 		"mutating a returned copy must not affect later calls")
-	require.NotEqual(t, byte(OP_NOP), c2.Groups[0].Opcodes[0],
-		"opcode slices must be deep-copied")
 }
 
-func TestDefaultCompiledLimitsCoversHeavyOpcodes(t *testing.T) {
+func TestDefaultComputeLimitsCoversHeavyOpcodes(t *testing.T) {
 	heavy := []byte{
 		OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKSIGADD,
 		OP_CHECKSIGFROMSTACK,
@@ -70,8 +31,9 @@ func TestDefaultCompiledLimitsCoversHeavyOpcodes(t *testing.T) {
 		OP_ECMULSCALARVERIFY, OP_TWEAKVERIFY,
 		OP_MODEXP,
 	}
+	limits := DefaultComputeLimits()
 	for _, op := range heavy {
-		require.GreaterOrEqualf(t, defaultCompiledLimits.groupOf[op], 0,
-			"opcode 0x%02x must belong to a compute-limit group", op)
+		_, ok := limits[op]
+		require.Truef(t, ok, "opcode %s must have a compute limit", opcodeArray[op].name)
 	}
 }

--- a/pkg/arkade/engine.go
+++ b/pkg/arkade/engine.go
@@ -46,12 +46,9 @@ type taprootExecutionCtx struct {
 	tapLeaf     txscript.TapLeaf
 	tapLeafHash chainhash.Hash
 
-	// opGroupRemaining holds the remaining per-input execution count for each
-	// opcode group in the active ComputeLimits, indexed by group index. It is
-	// initialized lazily on the first charge so the limits in effect at
-	// execution time (possibly overridden after this context was created) are
-	// the ones applied.
-	opGroupRemaining []int
+	// opCounts tracks how many times each limited opcode has executed for this
+	// input. It is allocated lazily on the first charge.
+	opCounts map[byte]int
 
 	mustSucceed bool
 
@@ -151,10 +148,10 @@ type Engine struct {
 	inputAmount    int64
 	taprootCtx     *taprootExecutionCtx
 
-	// limits is the per-input opcode-execution compute brake. It is set to the
-	// compiled DefaultComputeLimits by NewEngine and may be replaced before
-	// execution via WithComputeLimits.
-	limits *compiledComputeLimits
+	// limits is the per-input opcode-execution compute brake. NewEngine sets it
+	// to DefaultComputeLimits; it may be replaced before execution via
+	// WithComputeLimits.
+	limits ComputeLimits
 
 	// stepCallback is an optional function that will be called every time
 	// a step has been performed during script execution.
@@ -323,27 +320,25 @@ func (vm *Engine) executeOpcode(op *opcode, data []byte) error {
 	return op.opfunc(op, data, vm)
 }
 
-// chargeOpcode decrements the per-input execution budget for the group that op
-// belongs to, if any. It returns an error once a group's budget is exhausted.
-// Ungrouped opcodes, executions outside a tapscript context, and engines with
-// no compute limits configured are never charged. Group budgets are seeded
-// lazily on first charge from the active limits.
+// chargeOpcode counts one execution of op and returns an error once op exceeds
+// its configured per-input limit. Opcodes with no limit, and executions outside
+// a tapscript context, are never charged.
 func (vm *Engine) chargeOpcode(op byte) error {
-	if vm.taprootCtx == nil || vm.limits == nil {
+	if vm.taprootCtx == nil {
 		return nil
 	}
-	g := vm.limits.groupOf[op]
-	if g < 0 {
+	limit, ok := vm.limits[op]
+	if !ok {
 		return nil
 	}
-	if vm.taprootCtx.opGroupRemaining == nil {
-		vm.taprootCtx.opGroupRemaining = append([]int(nil), vm.limits.limits...)
+	if vm.taprootCtx.opCounts == nil {
+		vm.taprootCtx.opCounts = make(map[byte]int)
 	}
-	vm.taprootCtx.opGroupRemaining[g]--
-	if vm.taprootCtx.opGroupRemaining[g] < 0 {
+	vm.taprootCtx.opCounts[op]++
+	if vm.taprootCtx.opCounts[op] > limit {
 		return scriptError(txscript.ErrScriptTooBig,
-			fmt.Sprintf("opcode group %q exceeded execution limit of %d",
-				vm.limits.names[g], vm.limits.limits[g]))
+			fmt.Sprintf("opcode %s exceeded execution limit of %d",
+				opcodeArray[op].name, limit))
 	}
 	return nil
 }
@@ -840,7 +835,7 @@ func NewEngine(scriptPubKey []byte, tx *wire.MsgTx, txIdx int,
 		hashCache:      hashCache,
 		inputAmount:    inputAmount,
 		prevOutFetcher: prevOutFetcher,
-		limits:         defaultCompiledLimits,
+		limits:         defaultComputeLimits,
 	}
 
 	// The signature script must only contain data pushes.

--- a/pkg/arkade/engine.go
+++ b/pkg/arkade/engine.go
@@ -835,7 +835,7 @@ func NewEngine(scriptPubKey []byte, tx *wire.MsgTx, txIdx int,
 		hashCache:      hashCache,
 		inputAmount:    inputAmount,
 		prevOutFetcher: prevOutFetcher,
-		limits:         defaultComputeLimits,
+		limits:         DefaultComputeLimits(),
 	}
 
 	// The signature script must only contain data pushes.

--- a/pkg/arkade/engine.go
+++ b/pkg/arkade/engine.go
@@ -36,8 +36,8 @@ const (
 )
 
 // taprootExecutionCtx houses the special context-specific information we need
-// to validate a taproot script spend. This includes the annex, the running sig
-// op count tally, and other relevant information.
+// to validate a taproot script spend. This includes the annex, the per-input
+// opcode-group execution budgets, and other relevant information.
 type taprootExecutionCtx struct {
 	annex []byte
 
@@ -46,47 +46,31 @@ type taprootExecutionCtx struct {
 	tapLeaf     txscript.TapLeaf
 	tapLeafHash chainhash.Hash
 
-	sigOpsBudget int32
+	// opGroupRemaining holds the remaining per-input execution count for each
+	// opcode group in the active ComputeLimits, indexed by group index. It is
+	// initialized lazily on the first charge so the limits in effect at
+	// execution time (possibly overridden after this context was created) are
+	// the ones applied.
+	opGroupRemaining []int
 
 	mustSucceed bool
 
 	trackCodeSep bool
 }
 
-// sigOpsDelta is both the starting budget for sig ops for tapscript
-// verification, as well as the decrease in the total budget when we encounter
-// a signature.
-const sigOpsDelta = 50
-
-// tallysigOp attempts to decrease the current sig ops budget by sigOpsDelta.
-// An error is returned if after subtracting the delta, the budget is below
-// zero.
-func (t *taprootExecutionCtx) tallysigOp() error {
-	t.sigOpsBudget -= sigOpsDelta
-
-	if t.sigOpsBudget < 0 {
-		return scriptError(txscript.ErrTaprootMaxSigOps, "")
-	}
-
-	return nil
-}
-
 // newTaprootExecutionCtx returns a fresh instance of the taproot execution
 // context.
-func newTaprootExecutionCtx(inputWitnessSize int32) *taprootExecutionCtx {
+func newTaprootExecutionCtx() *taprootExecutionCtx {
 	return &taprootExecutionCtx{
 		codeSepPos:   blankCodeSepValue,
-		sigOpsBudget: sigOpsDelta + inputWitnessSize,
 		trackCodeSep: true,
 	}
 }
 
 // newTaprootExecutionCtxForLeaf returns a fresh taproot execution context for
 // the given tapscript leaf.
-func newTaprootExecutionCtxForLeaf(
-	tapLeaf txscript.TapLeaf, inputWitnessSize int32,
-) *taprootExecutionCtx {
-	ctx := newTaprootExecutionCtx(inputWitnessSize)
+func newTaprootExecutionCtxForLeaf(tapLeaf txscript.TapLeaf) *taprootExecutionCtx {
+	ctx := newTaprootExecutionCtx()
 	ctx.tapLeaf = tapLeaf
 	ctx.tapLeafHash = tapLeaf.TapHash()
 	return ctx
@@ -166,6 +150,11 @@ type Engine struct {
 	witnessProgram []byte
 	inputAmount    int64
 	taprootCtx     *taprootExecutionCtx
+
+	// limits is the per-input opcode-execution compute brake. It is set to the
+	// compiled DefaultComputeLimits by NewEngine and may be replaced before
+	// execution via WithComputeLimits.
+	limits *compiledComputeLimits
 
 	// stepCallback is an optional function that will be called every time
 	// a step has been performed during script execution.
@@ -327,7 +316,36 @@ func (vm *Engine) executeOpcode(op *opcode, data []byte) error {
 		}
 	}
 
+	if err := vm.chargeOpcode(op.value); err != nil {
+		return err
+	}
+
 	return op.opfunc(op, data, vm)
+}
+
+// chargeOpcode decrements the per-input execution budget for the group that op
+// belongs to, if any. It returns an error once a group's budget is exhausted.
+// Ungrouped opcodes, executions outside a tapscript context, and engines with
+// no compute limits configured are never charged. Group budgets are seeded
+// lazily on first charge from the active limits.
+func (vm *Engine) chargeOpcode(op byte) error {
+	if vm.taprootCtx == nil || vm.limits == nil {
+		return nil
+	}
+	g := vm.limits.groupOf[op]
+	if g < 0 {
+		return nil
+	}
+	if vm.taprootCtx.opGroupRemaining == nil {
+		vm.taprootCtx.opGroupRemaining = append([]int(nil), vm.limits.limits...)
+	}
+	vm.taprootCtx.opGroupRemaining[g]--
+	if vm.taprootCtx.opGroupRemaining[g] < 0 {
+		return scriptError(txscript.ErrScriptTooBig,
+			fmt.Sprintf("opcode group %q exceeded execution limit of %d",
+				vm.limits.names[g], vm.limits.limits[g]))
+	}
+	return nil
 }
 
 // checkValidPC returns an error if the current script position is not valid for
@@ -365,9 +383,7 @@ func (vm *Engine) verifyWitnessProgram(witness wire.TxWitness) error {
 
 	// At this point, we know taproot is active, so we'll populate
 	// the taproot execution context.
-	vm.taprootCtx = newTaprootExecutionCtx(
-		int32(witness.SerializeSize()),
-	)
+	vm.taprootCtx = newTaprootExecutionCtx()
 
 	// If we can detect the annex, then drop that off the stack,
 	// we'll only need it to compute the sighash later.
@@ -824,6 +840,7 @@ func NewEngine(scriptPubKey []byte, tx *wire.MsgTx, txIdx int,
 		hashCache:      hashCache,
 		inputAmount:    inputAmount,
 		prevOutFetcher: prevOutFetcher,
+		limits:         defaultCompiledLimits,
 	}
 
 	// The signature script must only contain data pushes.

--- a/pkg/arkade/engine_test.go
+++ b/pkg/arkade/engine_test.go
@@ -2463,7 +2463,7 @@ func arkadeDigest(
 		hashCache:      txscript.NewTxSigHashes(tx, fetcher),
 		prevOutFetcher: fetcher,
 		taprootCtx: newTaprootExecutionCtxForLeaf(
-			txscript.NewBaseTapLeaf(leafScript), 0,
+			txscript.NewBaseTapLeaf(leafScript),
 		),
 	}
 	digest, err := computeArkadeSighash(vm, hashType)
@@ -2819,7 +2819,7 @@ func TestArkadeSighashSingleMasksExtensionOutput(t *testing.T) {
 					hashCache:      txscript.NewTxSigHashes(baseTx, fetcher),
 					prevOutFetcher: fetcher,
 					taprootCtx: newTaprootExecutionCtxForLeaf(
-						txscript.NewBaseTapLeaf(leafScript), 0,
+						txscript.NewBaseTapLeaf(leafScript),
 					),
 				}
 				arkadeSigMsg, err := buildArkadeSigMsg(vm, f.flag)
@@ -2887,7 +2887,7 @@ func TestArkadeSighashByteLayoutMatchesBIP342(t *testing.T) {
 				hashCache:      txscript.NewTxSigHashes(tx, fetcher),
 				prevOutFetcher: fetcher,
 				taprootCtx: newTaprootExecutionCtxForLeaf(
-					txscript.NewBaseTapLeaf(leafScript), 0,
+					txscript.NewBaseTapLeaf(leafScript),
 				),
 			}
 
@@ -2940,7 +2940,7 @@ func TestArkadeSighashByteLayoutMatchesBIP342WithAnnexAndCodeSep(t *testing.T) {
 	const codeSepPos = uint32(1)
 	const flag = txscript.SigHashAll
 	taprootCtx := newTaprootExecutionCtxForLeaf(
-		txscript.NewBaseTapLeaf(leafScript), 0,
+		txscript.NewBaseTapLeaf(leafScript),
 	)
 	taprootCtx.annex = annex
 	taprootCtx.codeSepPos = codeSepPos

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -1801,14 +1801,6 @@ func opcodeCheckSig(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	// Account for changes in the sig ops budget after this
-	// execution, but only for non-empty signatures.
-	if len(fullSigBytes) > 0 {
-		if err := vm.taprootCtx.tallysigOp(); err != nil {
-			return err
-		}
-	}
-
 	// Empty public keys immediately cause execution to fail.
 	if len(pkBytes) == 0 {
 		return scriptError(txscript.ErrTaprootPubkeyIsEmpty, "")
@@ -1884,15 +1876,6 @@ func opcodeCheckSigAdd(op *opcode, data []byte, vm *Engine) error {
 	sigBytes, err := vm.dstack.PopByteArray()
 	if err != nil {
 		return err
-	}
-
-	// Only non-empty signatures count towards the total tapscript sig op
-	// limit.
-	if len(sigBytes) != 0 {
-		// Account for changes in the sig ops budget after this execution.
-		if err := vm.taprootCtx.tallysigOp(); err != nil {
-			return err
-		}
 	}
 
 	// Empty public keys immediately cause execution to fail.

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -4088,7 +4088,7 @@ func installSighashTapContext(vm *Engine, annex []byte) {
 		vm.hashCache = txscript.NewTxSigHashes(&vm.tx, vm.prevOutFetcher)
 	}
 	vm.taprootCtx = newTaprootExecutionCtxForLeaf(
-		txscript.NewBaseTapLeaf(sighashTestLeafScript), 0,
+		txscript.NewBaseTapLeaf(sighashTestLeafScript),
 	)
 	if len(annex) > 0 {
 		vm.taprootCtx.annex = append([]byte(nil), annex...)

--- a/pkg/arkade/script.go
+++ b/pkg/arkade/script.go
@@ -36,13 +36,10 @@ func WithDebugCallback(callback func(*StepInfo, *Engine) error) ExecuteOption {
 }
 
 // WithComputeLimits overrides the per-input opcode-execution compute brake for
-// this execution. Without it the engine uses DefaultComputeLimits. It panics on
-// an invalid configuration (see ComputeLimits.Validate); callers handling
-// untrusted configs should validate before constructing the option.
+// this execution. Without it the engine uses DefaultComputeLimits.
 func WithComputeLimits(c ComputeLimits) ExecuteOption {
-	compiled := c.compile()
 	return func(engine *Engine) {
-		engine.limits = compiled
+		engine.limits = c
 	}
 }
 

--- a/pkg/arkade/script.go
+++ b/pkg/arkade/script.go
@@ -36,9 +36,12 @@ func WithDebugCallback(callback func(*StepInfo, *Engine) error) ExecuteOption {
 }
 
 // WithComputeLimits overrides the per-input opcode-execution compute brake for
-// this execution. Without it the engine uses DefaultComputeLimits.
+// this execution. A nil map means no override; the engine keeps its default.
 func WithComputeLimits(c ComputeLimits) ExecuteOption {
 	return func(engine *Engine) {
+		if c == nil {
+			return
+		}
 		engine.limits = c
 	}
 }

--- a/pkg/arkade/script.go
+++ b/pkg/arkade/script.go
@@ -35,14 +35,33 @@ func WithDebugCallback(callback func(*StepInfo, *Engine) error) ExecuteOption {
 	}
 }
 
-// WithComputeLimits overrides the per-input opcode-execution compute brake for
-// this execution. A nil map means no override; the engine keeps its default.
+// WithComputeLimits applies partial per-input opcode-execution compute-limit
+// overrides for this execution. The overrides are applied on top of
+// DefaultComputeLimits, so opcodes absent from c keep their defaults. A nil map
+// means no override; the engine keeps its current limits.
 func WithComputeLimits(c ComputeLimits) ExecuteOption {
 	return func(engine *Engine) {
 		if c == nil {
 			return
 		}
-		engine.limits = c
+		limits := DefaultComputeLimits()
+		for op, limit := range c {
+			limits[op] = limit
+		}
+		engine.limits = limits
+	}
+}
+
+// WithExactComputeLimits replaces the compute-limit table exactly. Opcodes
+// absent from c are unlimited. This is intended for already-resolved
+// configuration tables; most callers should use WithComputeLimits for partial
+// overrides.
+func WithExactComputeLimits(c ComputeLimits) ExecuteOption {
+	return func(engine *Engine) {
+		if c == nil {
+			return
+		}
+		engine.limits = cloneComputeLimits(c)
 	}
 }
 

--- a/pkg/arkade/script.go
+++ b/pkg/arkade/script.go
@@ -35,6 +35,17 @@ func WithDebugCallback(callback func(*StepInfo, *Engine) error) ExecuteOption {
 	}
 }
 
+// WithComputeLimits overrides the per-input opcode-execution compute brake for
+// this execution. Without it the engine uses DefaultComputeLimits. It panics on
+// an invalid configuration (see ComputeLimits.Validate); callers handling
+// untrusted configs should validate before constructing the option.
+func WithComputeLimits(c ComputeLimits) ExecuteOption {
+	compiled := c.compile()
+	return func(engine *Engine) {
+		engine.limits = compiled
+	}
+}
+
 // ArkPrevOutFetcher extends txscript.PrevOutputFetcher with the ability to
 // look up previous ark transactions by outpoint. Both methods are keyed by
 // the spending input's outpoint but serve different purposes:
@@ -148,9 +159,7 @@ func (s *ArkadeScript) Execute(spendingTx *wire.MsgTx, prevOutFetcher ArkPrevOut
 		return fmt.Errorf("failed to create engine: %w", err)
 	}
 
-	engine.taprootCtx = newTaprootExecutionCtxForLeaf(
-		s.spendingTapLeaf, int32(s.witness.SerializeSize()),
-	)
+	engine.taprootCtx = newTaprootExecutionCtxForLeaf(s.spendingTapLeaf)
 	// Arkade scripts execute from the emulator packet, not from the
 	// spending tapleaf whose hash the sighash commits to.
 	engine.taprootCtx.trackCodeSep = false

--- a/pkg/arkade/sigvalidate.go
+++ b/pkg/arkade/sigvalidate.go
@@ -102,7 +102,7 @@ func CalcTapscriptSignaturehash(
 		txIdx:          idx,
 		hashCache:      sigHashes,
 		prevOutFetcher: prevOutFetcher,
-		taprootCtx:     newTaprootExecutionCtxForLeaf(tapLeaf, 0),
+		taprootCtx:     newTaprootExecutionCtxForLeaf(tapLeaf),
 	}
 
 	return computeArkadeSighash(vm, hashType)


### PR DESCRIPTION
## Summary

Adds a per-input execution-count brake for the VM's heavy opcodes and removes the BIP-342 sigops budget, replacing both with one simple lookup table. This bounds worst-case single-input CPU and unblocks the heavy-opcode PRs (#79 EC ops, #80 OP_MODEXP), which add opcodes that are otherwise charged nothing and only limited by the 10 KB script-size cap.

## Motivation

The VM enforces script size and stack size but has no op-count limit. BIP-342 dropped it deliberately, which is fine for cheap opcodes.

Several Arkade opcodes (`OP_CHECKSIGFROMSTACK`, `OP_ECADD`, `OP_ECMUL`, `OP_ECPAIRING`, `OP_ECMULSCALARVERIFY`, `OP_TWEAKVERIFY`, `OP_MODEXP`) cost orders of magnitude more per call, so an adversarial 10 KB script could drive multi-second CPU per input. See #81.

## What changed

- Added `ComputeLimits` lookup table (`pkg/arkade/compute_limits.go`):
  - `type ComputeLimits map[byte]int`
  - Opcode → max executions per input
  - Absent opcode ⇒ unlimited
  - `DefaultComputeLimits()` returns a fresh copy

- Added engine charging (`engine.go`):
  - One `chargeOpcode` call in `executeOpcode`
  - Runs after the dead-branch return, so opcodes in unexecuted branches don't count
  - Runs before the handler
  - Per-input counts live on the tapscript context
  - Exhaustion returns `txscript.ErrScriptTooBig`, naming the opcode and limit

- Removed the BIP-342 sigops budget:
  - Deleted `sigOpsBudget`, `tallysigOp`, `sigOpsDelta`
  - Deleted witness-size scaling
  - Deleted both `tallysigOp` calls in the sig handlers
  - That budget models L1 block-weight/fee economics, which don't apply to the emulator
  - Sig opcodes are now entries in the same count-limit table

- Added admin override (`internal/config`):
  - Example: `EMULATOR_COMPUTE_LIMITS="OP_ECPAIRING=8,OP_MODEXP=128"`
  - Applied on top of defaults
  - Threaded via `WithComputeLimits` into the three `script.Execute` call sites
  - Unknown opcode, non-integer limit, or negative limit fails config load

- Retained existing per-call caps:
  - `maxECPairingCount = 16`
  - `maxModexpOperandLen = 64`
  - These bound a single call's cost
  - The count limit bounds the number of calls
  - They compose

## Default limits

| Opcode(s)                                                              | Limit   | ~cost/call |
| ---------------------------------------------------------------------- | ------- | ---------- |
| `OP_CHECKSIG`, `OP_CHECKSIGVERIFY`, `OP_CHECKSIGADD`, `OP_CHECKSIGFROMSTACK` | 50 each | 84 µs      |
| `OP_ECADD`                                                             | 1000    | 3.7 µs     |
| `OP_ECMUL`, `OP_ECMULSCALARVERIFY`, `OP_TWEAKVERIFY`                   | 50 each | 84 µs      |
| `OP_ECPAIRING`                                                         | 2       | 2.04 ms    |
| `OP_MODEXP`                                                            | 64      | 60 µs      |

## Behavior change

Dropping the sigops budget removes the BIP-342 empty-signature exemption: an empty-signature `OP_CHECKSIG` / `OP_CHECKSIGADD` in the unselected-branch multisig pattern now counts toward the opcode's limit.

This only over-counts cheap non-verifying calls. It never permits extra real verifications, and 50 is generous for realistic multisig.


---

Closing #81 