### PR TITLE
Make OP_CODESEPERATOR work in an arkade script context

### DIFF
--- a/pkg/arkade/engine.go
+++ b/pkg/arkade/engine.go
@@ -30,9 +30,9 @@ const (
 )
 
 const (
-	// blankCodeSepValue is the value of the code separator position in the
-	// tapscript sighash when no code separator was found in the script.
-	blankCodeSepValue = math.MaxUint32
+	// BlankCodeSepValue is the value of the code separator position in the
+	// tapscript sighash when no code separator was executed in the script.
+	BlankCodeSepValue uint32 = math.MaxUint32
 )
 
 // taprootExecutionCtx houses the special context-specific information we need
@@ -49,8 +49,6 @@ type taprootExecutionCtx struct {
 	sigOpsBudget int32
 
 	mustSucceed bool
-
-	trackCodeSep bool
 }
 
 // sigOpsDelta is both the starting budget for sig ops for tapscript
@@ -75,9 +73,8 @@ func (t *taprootExecutionCtx) tallysigOp() error {
 // context.
 func newTaprootExecutionCtx(inputWitnessSize int32) *taprootExecutionCtx {
 	return &taprootExecutionCtx{
-		codeSepPos:   blankCodeSepValue,
+		codeSepPos:   BlankCodeSepValue,
 		sigOpsBudget: sigOpsDelta + inputWitnessSize,
-		trackCodeSep: true,
 	}
 }
 
@@ -140,9 +137,6 @@ type Engine struct {
 	// the current program counter.  Note that it differs from the actual byte
 	// index into the script and is really only used for disassembly purposes.
 	//
-	// lastCodeSep specifies the position within the current script of the last
-	// OP_CODESEPARATOR.
-	//
 	// tokenizer provides the token stream of the current script being executed
 	// and doubles as state tracking for the program counter within the script.
 	//
@@ -157,7 +151,6 @@ type Engine struct {
 	scripts        [][]byte
 	scriptIdx      int
 	opcodeIdx      int
-	lastCodeSep    int
 	tokenizer      ScriptTokenizer
 	dstack         stack
 	astack         stack
@@ -660,7 +653,6 @@ func (vm *Engine) Step() (done bool, err error) {
 			vm.scriptIdx++
 		}
 
-		vm.lastCodeSep = 0
 		if vm.scriptIdx >= len(vm.scripts) {
 			return true, nil
 		}

--- a/pkg/arkade/engine.go
+++ b/pkg/arkade/engine.go
@@ -30,9 +30,9 @@ const (
 )
 
 const (
-	// BlankCodeSepValue is the value of the code separator position in the
+	// blankCodeSepValue is the value of the code separator position in the
 	// tapscript sighash when no code separator was executed in the script.
-	BlankCodeSepValue uint32 = math.MaxUint32
+	blankCodeSepValue uint32 = math.MaxUint32
 )
 
 // taprootExecutionCtx houses the special context-specific information we need
@@ -73,7 +73,7 @@ func (t *taprootExecutionCtx) tallysigOp() error {
 // context.
 func newTaprootExecutionCtx(inputWitnessSize int32) *taprootExecutionCtx {
 	return &taprootExecutionCtx{
-		codeSepPos:   BlankCodeSepValue,
+		codeSepPos:   blankCodeSepValue,
 		sigOpsBudget: sigOpsDelta + inputWitnessSize,
 	}
 }

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -1751,8 +1751,8 @@ func opcodeHash256(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeCodeSeparator stores the current script offset as the most recently
-// seen OP_CODESEPARATOR which is used during signature checking.
+// opcodeCodeSeparator stores the current opcode position as the most recently
+// executed OP_CODESEPARATOR for BIP342-style signature hashing.
 //
 // This opcode does not change the contents of the data stack.
 func opcodeCodeSeparator(op *opcode, data []byte, vm *Engine) error {
@@ -1762,10 +1762,7 @@ func opcodeCodeSeparator(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrReservedOpcode, str)
 	}
 
-	vm.lastCodeSep = int(vm.tokenizer.ByteIndex())
-	if vm.taprootCtx.trackCodeSep {
-		vm.taprootCtx.codeSepPos = uint32(vm.tokenizer.OpcodePosition())
-	}
+	vm.taprootCtx.codeSepPos = uint32(vm.tokenizer.OpcodePosition())
 
 	return nil
 }
@@ -1774,14 +1771,10 @@ func opcodeCodeSeparator(op *opcode, data []byte, vm *Engine) error {
 // signature and replaces them with a bool which indicates if the signature was
 // successfully verified.
 //
-// The process of verifying a signature requires calculating a signature hash in
-// the same way the transaction signer did.  It involves hashing portions of the
-// transaction based on the hash type byte (which is the final byte of the
-// signature) and the portion of the script starting from the most recent
-// OP_CODESEPARATOR (or the beginning of the script if there are none) to the
-// end of the script (with any other OP_CODESEPARATORs removed).  Once this
-// "script hash" is calculated, the signature is checked using standard
-// cryptographic methods against the provided public key.
+// The process of verifying a signature requires calculating the arkade
+// tapscript signature hash in the same way the transaction signer did.  The
+// digest commits to the spending tapleaf hash and the opcode position of the
+// last executed OP_CODESEPARATOR, or BlankCodeSepValue if none executed.
 //
 // Stack transformation: [... signature pubkey] -> [... bool]
 func opcodeCheckSig(op *opcode, data []byte, vm *Engine) error {

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -1774,7 +1774,7 @@ func opcodeCodeSeparator(op *opcode, data []byte, vm *Engine) error {
 // The process of verifying a signature requires calculating the arkade
 // tapscript signature hash in the same way the transaction signer did.  The
 // digest commits to the spending tapleaf hash and the opcode position of the
-// last executed OP_CODESEPARATOR, or BlankCodeSepValue if none executed.
+// last executed OP_CODESEPARATOR, or math.MaxUint32 if none executed.
 //
 // Stack transformation: [... signature pubkey] -> [... bool]
 func opcodeCheckSig(op *opcode, data []byte, vm *Engine) error {

--- a/pkg/arkade/script.go
+++ b/pkg/arkade/script.go
@@ -151,9 +151,6 @@ func (s *ArkadeScript) Execute(spendingTx *wire.MsgTx, prevOutFetcher ArkPrevOut
 	engine.taprootCtx = newTaprootExecutionCtxForLeaf(
 		s.spendingTapLeaf, int32(s.witness.SerializeSize()),
 	)
-	// Arkade scripts execute from the emulator packet, not from the
-	// spending tapleaf whose hash the sighash commits to.
-	engine.taprootCtx.trackCodeSep = false
 
 	for _, opt := range opts {
 		opt(engine)

--- a/pkg/arkade/script_test.go
+++ b/pkg/arkade/script_test.go
@@ -59,7 +59,7 @@ func TestArkadeScriptExecuteUsesSpendingTapLeafForSighash(t *testing.T) {
 	sighashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
 	digest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		closureTapLeaf, blankCodeSepValue,
+		closureTapLeaf,
 	)
 	require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestArkadeScriptExecuteUsesCodeSeparatorForSighash(t *testing.T) {
 	// verify.
 	digest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf, codeSepPos,
+		spendingTapLeaf, WithCodeSepPosition(codeSepPos),
 	)
 	require.NoError(t, err)
 	sig, err := schnorr.Sign(signingKey, digest)
@@ -138,7 +138,7 @@ func TestArkadeScriptExecuteUsesCodeSeparatorForSighash(t *testing.T) {
 	// pre-BIP342 behavior) must now be rejected.
 	staleDigest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf, blankCodeSepValue,
+		spendingTapLeaf,
 	)
 	require.NoError(t, err)
 	staleSig, err := schnorr.Sign(signingKey, staleDigest)
@@ -227,12 +227,12 @@ func TestArkadeScriptExecuteOpSighashUsesCodeSeparatorPosition(t *testing.T) {
 
 	expectedDigest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf, 0,
+		spendingTapLeaf, WithCodeSepPosition(0),
 	)
 	require.NoError(t, err)
 	blankDigest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf, blankCodeSepValue,
+		spendingTapLeaf,
 	)
 	require.NoError(t, err)
 	require.NotEqual(t, blankDigest, expectedDigest,
@@ -389,7 +389,7 @@ func TestArkadeScriptExecuteCodeSepInUnexecutedBranchIgnored(t *testing.T) {
 		t.Helper()
 		digest, err := CalcArkadeScriptSignatureHash(
 			sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-			spendingTapLeaf, codeSepPos,
+			spendingTapLeaf, WithCodeSepPosition(codeSepPos),
 		)
 		require.NoError(t, err)
 		sig, err := schnorr.Sign(signingKey, digest)

--- a/pkg/arkade/script_test.go
+++ b/pkg/arkade/script_test.go
@@ -59,7 +59,7 @@ func TestArkadeScriptExecuteUsesSpendingTapLeafForSighash(t *testing.T) {
 	sighashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
 	digest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		closureTapLeaf, BlankCodeSepValue,
+		closureTapLeaf, blankCodeSepValue,
 	)
 	require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestArkadeScriptExecuteUsesCodeSeparatorForSighash(t *testing.T) {
 	// pre-BIP342 behavior) must now be rejected.
 	staleDigest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf, BlankCodeSepValue,
+		spendingTapLeaf, blankCodeSepValue,
 	)
 	require.NoError(t, err)
 	staleSig, err := schnorr.Sign(signingKey, staleDigest)
@@ -194,7 +194,7 @@ func TestArkadeScriptExecuteUpdatesCodeSepPosOnCodeSeparator(t *testing.T) {
 
 	// The callback fires once for the initial state, then after each step.
 	require.GreaterOrEqual(t, len(seen), 2)
-	require.Equal(t, BlankCodeSepValue, seen[0],
+	require.Equal(t, blankCodeSepValue, seen[0],
 		"codesep_pos must start at the blank sentinel")
 	require.Equal(t, uint32(0), seen[1],
 		"codesep_pos must equal the OP_CODESEPARATOR opcode position after it executes")
@@ -232,7 +232,7 @@ func TestArkadeScriptExecuteOpSighashUsesCodeSeparatorPosition(t *testing.T) {
 	require.NoError(t, err)
 	blankDigest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf, BlankCodeSepValue,
+		spendingTapLeaf, blankCodeSepValue,
 	)
 	require.NoError(t, err)
 	require.NotEqual(t, blankDigest, expectedDigest,

--- a/pkg/arkade/script_test.go
+++ b/pkg/arkade/script_test.go
@@ -57,9 +57,9 @@ func TestArkadeScriptExecuteUsesSpendingTapLeafForSighash(t *testing.T) {
 		txscript.NewMultiPrevOutFetcher(prevOuts), nil, nil,
 	)
 	sighashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
-	digest, err := CalcTapscriptSignaturehash(
+	digest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		closureTapLeaf,
+		closureTapLeaf, BlankCodeSepValue,
 	)
 	require.NoError(t, err)
 
@@ -74,7 +74,7 @@ func TestArkadeScriptExecuteUsesSpendingTapLeafForSighash(t *testing.T) {
 	require.NoError(t, script.Execute(tx, prevOutFetcher, 0))
 }
 
-func TestArkadeScriptExecuteDoesNotUsePacketCodeSeparatorForSighash(t *testing.T) {
+func TestArkadeScriptExecuteUsesCodeSeparatorForSighash(t *testing.T) {
 	t.Parallel()
 
 	signingKey, _ := btcec.PrivKeyFromBytes([]byte{
@@ -84,6 +84,9 @@ func TestArkadeScriptExecuteDoesNotUsePacketCodeSeparatorForSighash(t *testing.T
 		0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
 	})
 	pubKeyX := schnorr.SerializePubKey(signingKey.PubKey())
+	// OP_CODESEPARATOR is the first opcode (position 0). Per BIP342 it sets
+	// codesep_pos to its own opcode position, which the following OP_CHECKSIG
+	// must commit to.
 	arkadeScript, err := txscript.NewScriptBuilder().
 		AddOp(OP_CODESEPARATOR).
 		AddData(pubKeyX).
@@ -111,21 +114,145 @@ func TestArkadeScriptExecuteDoesNotUsePacketCodeSeparatorForSighash(t *testing.T
 		txscript.NewMultiPrevOutFetcher(prevOuts), nil, nil,
 	)
 	sighashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
-	digest, err := CalcTapscriptSignaturehash(
+
+	const codeSepPos = uint32(0) // OP_CODESEPARATOR is opcode 0 in the script.
+
+	// A signature that commits to the executed code-separator position must
+	// verify.
+	digest, err := CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
-		spendingTapLeaf,
+		spendingTapLeaf, codeSepPos,
 	)
 	require.NoError(t, err)
-
 	sig, err := schnorr.Sign(signingKey, digest)
 	require.NoError(t, err)
-
 	script := &ArkadeScript{
 		script:          arkadeScript,
 		witness:         wire.TxWitness{sig.Serialize()},
 		spendingTapLeaf: spendingTapLeaf,
 	}
-	require.NoError(t, script.Execute(tx, prevOutFetcher, 0))
+	require.NoError(t, script.Execute(tx, prevOutFetcher, 0),
+		"signature committing to the executed codesep position must verify")
+
+	// A signature that ignores the code separator (blank codesep_pos, the
+	// pre-BIP342 behavior) must now be rejected.
+	staleDigest, err := CalcArkadeScriptSignatureHash(
+		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
+		spendingTapLeaf, BlankCodeSepValue,
+	)
+	require.NoError(t, err)
+	staleSig, err := schnorr.Sign(signingKey, staleDigest)
+	require.NoError(t, err)
+	staleScript := &ArkadeScript{
+		script:          arkadeScript,
+		witness:         wire.TxWitness{staleSig.Serialize()},
+		spendingTapLeaf: spendingTapLeaf,
+	}
+	require.Error(t, staleScript.Execute(tx, prevOutFetcher, 0),
+		"signature ignoring the code separator must fail")
+}
+
+func TestArkadeScriptExecuteUpdatesCodeSepPosOnCodeSeparator(t *testing.T) {
+	t.Parallel()
+
+	// OP_CODESEPARATOR is opcode 0; OP_TRUE leaves a truthy stack so execution
+	// completes successfully and we can observe codesep_pos at each step.
+	arkadeScript := []byte{OP_CODESEPARATOR, OP_TRUE}
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x04}, Index: 0}
+	tx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: outpoint,
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    900,
+			PkScript: []byte{OP_TRUE},
+		}},
+	}
+	prevOuts := map[wire.OutPoint]*wire.TxOut{
+		outpoint: {Value: 1_000, PkScript: []byte{OP_1, 0x20}},
+	}
+	prevOutFetcher := newTestArkPrevOutFetcher(
+		txscript.NewMultiPrevOutFetcher(prevOuts), nil, nil,
+	)
+
+	script := &ArkadeScript{
+		script:          arkadeScript,
+		spendingTapLeaf: txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	}
+
+	var seen []uint32
+	err := script.Execute(tx, prevOutFetcher, 0,
+		WithDebugCallback(func(_ *StepInfo, e *Engine) error {
+			seen = append(seen, e.taprootCtx.codeSepPos)
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+
+	// The callback fires once for the initial state, then after each step.
+	require.GreaterOrEqual(t, len(seen), 2)
+	require.Equal(t, BlankCodeSepValue, seen[0],
+		"codesep_pos must start at the blank sentinel")
+	require.Equal(t, uint32(0), seen[1],
+		"codesep_pos must equal the OP_CODESEPARATOR opcode position after it executes")
+}
+
+func TestArkadeScriptExecuteOpSighashUsesCodeSeparatorPosition(t *testing.T) {
+	t.Parallel()
+
+	spendingTapLeaf := txscript.NewBaseTapLeaf([]byte{OP_TRUE})
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x05}, Index: 0}
+	tx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: outpoint,
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    900,
+			PkScript: []byte{OP_TRUE},
+		}},
+	}
+	prevOuts := map[wire.OutPoint]*wire.TxOut{
+		outpoint: {Value: 1_000, PkScript: []byte{OP_1, 0x20}},
+	}
+	prevOutFetcher := newTestArkPrevOutFetcher(
+		txscript.NewMultiPrevOutFetcher(prevOuts), nil, nil,
+	)
+	sighashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+	expectedDigest, err := CalcArkadeScriptSignatureHash(
+		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
+		spendingTapLeaf, 0,
+	)
+	require.NoError(t, err)
+	blankDigest, err := CalcArkadeScriptSignatureHash(
+		sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
+		spendingTapLeaf, BlankCodeSepValue,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, blankDigest, expectedDigest,
+		"test requires the code separator position to affect OP_SIGHASH")
+
+	arkadeScript, err := txscript.NewScriptBuilder().
+		AddOp(OP_CODESEPARATOR).
+		AddOp(OP_0).
+		AddOp(OP_SIGHASH).
+		AddData(expectedDigest).
+		AddOp(OP_EQUAL).
+		Script()
+	require.NoError(t, err)
+
+	script := &ArkadeScript{
+		script:          arkadeScript,
+		spendingTapLeaf: spendingTapLeaf,
+	}
+	require.NoError(t, script.Execute(tx, prevOutFetcher, 0),
+		"OP_SIGHASH must include the last executed OP_CODESEPARATOR position")
 }
 
 func TestReadArkadeScriptRejectsNonBaseSpendingTapLeafVersion(t *testing.T) {

--- a/pkg/arkade/script_test.go
+++ b/pkg/arkade/script_test.go
@@ -255,6 +255,187 @@ func TestArkadeScriptExecuteOpSighashUsesCodeSeparatorPosition(t *testing.T) {
 		"OP_SIGHASH must include the last executed OP_CODESEPARATOR position")
 }
 
+// TestArkadeScriptExecuteCodeSepPosCountsUnexecutedBranchOpcodes locks in the
+// BIP342 rule that the committed codesep_pos is the opcode position of the
+// last *executed* OP_CODESEPARATOR, while opcodes in parsed-but-unexecuted
+// branches still advance the opcode position counter.
+//
+//	OP_FALSE         // pos 0 -> take the OP_ELSE branch
+//	OP_IF            // pos 1
+//	  OP_FALSE       // pos 2 (parsed but not executed)
+//	OP_ELSE          // pos 3
+//	  OP_CODESEPARATOR // pos 4 -> executed, codesep_pos = 4
+//	OP_ENDIF         // pos 5
+//	OP_CODESEPARATOR // pos 6 -> executed, codesep_pos = 6
+//	OP_TRUE          // pos 7 -> leave a truthy stack
+//
+// The opcode at position 2 lives in the unexecuted true branch; if it did not
+// count toward opcode positions the two code separators would land at
+// positions 3 and 5 instead. The final codesep_pos must equal 6.
+func TestArkadeScriptExecuteCodeSepPosCountsUnexecutedBranchOpcodes(t *testing.T) {
+	t.Parallel()
+
+	arkadeScript := []byte{
+		OP_FALSE,
+		OP_IF,
+		OP_FALSE,
+		OP_ELSE,
+		OP_CODESEPARATOR,
+		OP_ENDIF,
+		OP_CODESEPARATOR,
+		OP_TRUE,
+	}
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x06}, Index: 0}
+	tx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: outpoint,
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    900,
+			PkScript: []byte{OP_TRUE},
+		}},
+	}
+	prevOuts := map[wire.OutPoint]*wire.TxOut{
+		outpoint: {Value: 1_000, PkScript: []byte{OP_1, 0x20}},
+	}
+	prevOutFetcher := newTestArkPrevOutFetcher(
+		txscript.NewMultiPrevOutFetcher(prevOuts), nil, nil,
+	)
+
+	script := &ArkadeScript{
+		script:          arkadeScript,
+		spendingTapLeaf: txscript.NewBaseTapLeaf([]byte{OP_TRUE}),
+	}
+
+	var seen []uint32
+	err := script.Execute(tx, prevOutFetcher, 0,
+		WithDebugCallback(func(_ *StepInfo, e *Engine) error {
+			seen = append(seen, e.taprootCtx.codeSepPos)
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, seen)
+	require.Equal(t, uint32(6), seen[len(seen)-1],
+		"final codesep_pos must be the last executed OP_CODESEPARATOR position, "+
+			"counting opcodes in unexecuted branches")
+}
+
+// TestArkadeScriptExecuteCodeSepInUnexecutedBranchIgnored locks in the BIP342
+// rule that an OP_CODESEPARATOR sitting in an unexecuted branch must not
+// become the committed codesep_pos.
+//
+//	OP_IF              // pos 0 (selector from witness)
+//	  OP_CODESEPARATOR // pos 1 -> sets codesep_pos = 1 only when executed
+//	  <pubkey> OP_CHECKSIG
+//	OP_ELSE
+//	  <pubkey> OP_CHECKSIG // no code separator -> blankCodeSepValue
+//	OP_ENDIF
+//
+// Spent with a truthy selector the OP_CHECKSIG commits to codesep_pos == 1;
+// spent with a falsy selector it commits to blankCodeSepValue. A signature
+// computed for the wrong codesep_pos must be rejected.
+func TestArkadeScriptExecuteCodeSepInUnexecutedBranchIgnored(t *testing.T) {
+	t.Parallel()
+
+	signingKey, _ := btcec.PrivKeyFromBytes([]byte{
+		0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+		0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+		0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+		0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60,
+	})
+	pubKeyX := schnorr.SerializePubKey(signingKey.PubKey())
+
+	arkadeScript, err := txscript.NewScriptBuilder().
+		AddOp(OP_IF).
+		AddOp(OP_CODESEPARATOR).
+		AddData(pubKeyX).
+		AddOp(OP_CHECKSIG).
+		AddOp(OP_ELSE).
+		AddData(pubKeyX).
+		AddOp(OP_CHECKSIG).
+		AddOp(OP_ENDIF).
+		Script()
+	require.NoError(t, err)
+
+	spendingTapLeaf := txscript.NewBaseTapLeaf([]byte{OP_TRUE})
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x07}, Index: 0}
+	tx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: outpoint,
+			Sequence:         0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    900,
+			PkScript: []byte{OP_TRUE},
+		}},
+	}
+	prevOuts := map[wire.OutPoint]*wire.TxOut{
+		outpoint: {Value: 1_000, PkScript: []byte{OP_1, 0x20}},
+	}
+	prevOutFetcher := newTestArkPrevOutFetcher(
+		txscript.NewMultiPrevOutFetcher(prevOuts), nil, nil,
+	)
+	sighashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+	const trueBranchCodeSepPos = uint32(1) // OP_CODESEPARATOR is opcode 1.
+
+	sign := func(t *testing.T, codeSepPos uint32) []byte {
+		t.Helper()
+		digest, err := CalcArkadeScriptSignatureHash(
+			sighashes, txscript.SigHashDefault, tx, 0, prevOutFetcher,
+			spendingTapLeaf, codeSepPos,
+		)
+		require.NoError(t, err)
+		sig, err := schnorr.Sign(signingKey, digest)
+		require.NoError(t, err)
+		return sig.Serialize()
+	}
+
+	// Minimal-if selectors per BIP342: 0x01 selects the true branch, an empty
+	// byte array selects the false branch. The selector is the top witness item.
+	trueSelector := []byte{0x01}
+	falseSelector := []byte{}
+
+	// True branch: the executed OP_CODESEPARATOR commits codesep_pos == 1.
+	require.NoError(t,
+		(&ArkadeScript{
+			script:          arkadeScript,
+			witness:         wire.TxWitness{sign(t, trueBranchCodeSepPos), trueSelector},
+			spendingTapLeaf: spendingTapLeaf,
+		}).Execute(tx, prevOutFetcher, 0),
+		"true-branch signature must verify against the executed codesep position")
+	require.Error(t,
+		(&ArkadeScript{
+			script:          arkadeScript,
+			witness:         wire.TxWitness{sign(t, blankCodeSepValue), trueSelector},
+			spendingTapLeaf: spendingTapLeaf,
+		}).Execute(tx, prevOutFetcher, 0),
+		"true-branch signature must not verify against the blank codesep value")
+
+	// False branch: the OP_CODESEPARATOR is never executed, so codesep_pos
+	// stays at the blank sentinel.
+	require.NoError(t,
+		(&ArkadeScript{
+			script:          arkadeScript,
+			witness:         wire.TxWitness{sign(t, blankCodeSepValue), falseSelector},
+			spendingTapLeaf: spendingTapLeaf,
+		}).Execute(tx, prevOutFetcher, 0),
+		"false-branch signature must verify against the blank codesep value")
+	require.Error(t,
+		(&ArkadeScript{
+			script:          arkadeScript,
+			witness:         wire.TxWitness{sign(t, trueBranchCodeSepPos), falseSelector},
+			spendingTapLeaf: spendingTapLeaf,
+		}).Execute(tx, prevOutFetcher, 0),
+		"false-branch signature must not verify against the unexecuted codesep position")
+}
+
 func TestReadArkadeScriptRejectsNonBaseSpendingTapLeafVersion(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/arkade/sigvalidate.go
+++ b/pkg/arkade/sigvalidate.go
@@ -73,13 +73,42 @@ func computeArkadeSighash(vm *Engine,
 	return digest[:], nil
 }
 
+// arkadeSigHashOptions holds the optional parameters that modify the arkade
+// tapscript sighash digest.
+type arkadeSigHashOptions struct {
+	codeSepPos uint32
+}
+
+// defaultArkadeSigHashOptions returns the default sighash options, with the
+// code separator position blank (no OP_CODESEPARATOR executed).
+func defaultArkadeSigHashOptions() *arkadeSigHashOptions {
+	return &arkadeSigHashOptions{
+		codeSepPos: blankCodeSepValue,
+	}
+}
+
+// ArkadeSigHashOption defines a functional option that modifies the arkade
+// tapscript sighash digest.
+type ArkadeSigHashOption func(*arkadeSigHashOptions)
+
+// WithCodeSepPosition specifies the opcode position of the last
+// OP_CODESEPARATOR executed before the signature opcode. When omitted, the
+// position is blank (math.MaxUint32), matching the BIP342 default for scripts
+// that contain no OP_CODESEPARATOR.
+func WithCodeSepPosition(codeSepPos uint32) ArkadeSigHashOption {
+	return func(o *arkadeSigHashOptions) {
+		o.codeSepPos = codeSepPos
+	}
+}
+
 // CalcArkadeScriptSignatureHash returns the non-standard arkade tapscript
 // signature hash used by OP_CHECKSIG and OP_SIGHASH inside arkade scripts.
 //
 // The byte layout mirrors BIP342's tapscript sigMsg with arkade's witness
 // masking and "ArkadeTapSighash" final tag. Callers should pass the active
-// Bitcoin spending tapleaf whose hash the signature commits to. Pass
-// math.MaxUint32 when no OP_CODESEPARATOR executed before the signature opcode.
+// Bitcoin spending tapleaf whose hash the signature commits to. When an
+// OP_CODESEPARATOR executed before the signature opcode, supply its position
+// via WithCodeSepPosition; otherwise the position defaults to blank.
 func CalcArkadeScriptSignatureHash(
 	sigHashes *txscript.TxSigHashes,
 	hashType txscript.SigHashType,
@@ -87,7 +116,7 @@ func CalcArkadeScriptSignatureHash(
 	idx int,
 	prevOutFetcher ArkPrevOutFetcher,
 	tapLeaf txscript.TapLeaf,
-	codeSepPos uint32,
+	opts ...ArkadeSigHashOption,
 ) ([]byte, error) {
 	if sigHashes == nil {
 		return nil, fmt.Errorf("nil sighash cache")
@@ -99,8 +128,13 @@ func CalcArkadeScriptSignatureHash(
 		return nil, fmt.Errorf("nil prevout fetcher")
 	}
 
+	options := defaultArkadeSigHashOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	taprootCtx := newTaprootExecutionCtxForLeaf(tapLeaf, 0)
-	taprootCtx.codeSepPos = codeSepPos
+	taprootCtx.codeSepPos = options.codeSepPos
 
 	vm := &Engine{
 		tx:             *tx,

--- a/pkg/arkade/sigvalidate.go
+++ b/pkg/arkade/sigvalidate.go
@@ -79,8 +79,7 @@ func computeArkadeSighash(vm *Engine,
 // The byte layout mirrors BIP342's tapscript sigMsg with arkade's witness
 // masking and "ArkadeTapSighash" final tag. Callers should pass the active
 // Bitcoin spending tapleaf whose hash the signature commits to. Pass
-// BlankCodeSepValue when no OP_CODESEPARATOR executed before the signature
-// opcode.
+// math.MaxUint32 when no OP_CODESEPARATOR executed before the signature opcode.
 func CalcArkadeScriptSignatureHash(
 	sigHashes *txscript.TxSigHashes,
 	hashType txscript.SigHashType,

--- a/pkg/arkade/sigvalidate.go
+++ b/pkg/arkade/sigvalidate.go
@@ -73,19 +73,22 @@ func computeArkadeSighash(vm *Engine,
 	return digest[:], nil
 }
 
-// CalcTapscriptSignaturehash returns the non-standard arkade tapscript
+// CalcArkadeScriptSignatureHash returns the non-standard arkade tapscript
 // signature hash used by OP_CHECKSIG and OP_SIGHASH inside arkade scripts.
 //
 // The byte layout mirrors BIP342's tapscript sigMsg with arkade's witness
 // masking and "ArkadeTapSighash" final tag. Callers should pass the active
-// Bitcoin spending tapleaf whose hash the signature commits to.
-func CalcTapscriptSignaturehash(
+// Bitcoin spending tapleaf whose hash the signature commits to. Pass
+// BlankCodeSepValue when no OP_CODESEPARATOR executed before the signature
+// opcode.
+func CalcArkadeScriptSignatureHash(
 	sigHashes *txscript.TxSigHashes,
 	hashType txscript.SigHashType,
 	tx *wire.MsgTx,
 	idx int,
 	prevOutFetcher ArkPrevOutFetcher,
 	tapLeaf txscript.TapLeaf,
+	codeSepPos uint32,
 ) ([]byte, error) {
 	if sigHashes == nil {
 		return nil, fmt.Errorf("nil sighash cache")
@@ -97,12 +100,15 @@ func CalcTapscriptSignaturehash(
 		return nil, fmt.Errorf("nil prevout fetcher")
 	}
 
+	taprootCtx := newTaprootExecutionCtxForLeaf(tapLeaf, 0)
+	taprootCtx.codeSepPos = codeSepPos
+
 	vm := &Engine{
 		tx:             *tx,
 		txIdx:          idx,
 		hashCache:      sigHashes,
 		prevOutFetcher: prevOutFetcher,
-		taprootCtx:     newTaprootExecutionCtxForLeaf(tapLeaf, 0),
+		taprootCtx:     taprootCtx,
 	}
 
 	return computeArkadeSighash(vm, hashType)

--- a/test/signed_pay_to_output_test.go
+++ b/test/signed_pay_to_output_test.go
@@ -228,9 +228,9 @@ func signArkadeInput(
 		PrevOutputFetcher: txscript.NewMultiPrevOutFetcher(prevouts),
 	}
 	sighashes := txscript.NewTxSigHashes(ptx.UnsignedTx, prevOutFetcher)
-	message, err := arkade.CalcTapscriptSignaturehash(
+	message, err := arkade.CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, ptx.UnsignedTx,
-		inputIndex, prevOutFetcher, tapLeaf,
+		inputIndex, prevOutFetcher, tapLeaf, arkade.BlankCodeSepValue,
 	)
 	require.NoError(t, err)
 

--- a/test/signed_pay_to_output_test.go
+++ b/test/signed_pay_to_output_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"encoding/hex"
-	"math"
 	"strings"
 	"testing"
 
@@ -231,7 +230,7 @@ func signArkadeInput(
 	sighashes := txscript.NewTxSigHashes(ptx.UnsignedTx, prevOutFetcher)
 	message, err := arkade.CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, ptx.UnsignedTx,
-		inputIndex, prevOutFetcher, tapLeaf, math.MaxUint32,
+		inputIndex, prevOutFetcher, tapLeaf,
 	)
 	require.NoError(t, err)
 

--- a/test/signed_pay_to_output_test.go
+++ b/test/signed_pay_to_output_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"encoding/hex"
+	"math"
 	"strings"
 	"testing"
 
@@ -230,7 +231,7 @@ func signArkadeInput(
 	sighashes := txscript.NewTxSigHashes(ptx.UnsignedTx, prevOutFetcher)
 	message, err := arkade.CalcArkadeScriptSignatureHash(
 		sighashes, txscript.SigHashDefault, ptx.UnsignedTx,
-		inputIndex, prevOutFetcher, tapLeaf, arkade.BlankCodeSepValue,
+		inputIndex, prevOutFetcher, tapLeaf, math.MaxUint32,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Summary

`OP_CODESEPARATOR` was recognized and executed inside arkade scripts but had **no observable effect**: the opcode's update of the tapscript sighash's `codesep_pos` was gated behind a `trackCodeSep` flag that `ArkadeScript.Execute` set to `false`. As a result the code-separator position was never folded into the signature hash, diverging from BIP342.

This PR makes `OP_CODESEPARATOR` commit its opcode position into the arkade tapscript sighash, matching BIP342 semantics, and updates the signing helper so signers can produce matching digests.

### Changes

- **Engine (`opcode.go`, `engine.go`, `script.go`):** `opcodeCodeSeparator` now unconditionally records `vm.tokenizer.OpcodePosition()` into `taprootCtx.codeSepPos`. Removed the `trackCodeSep` flag and the line in `ArkadeScript.Execute` that disabled tracking. The position is tracked against the executing (emulator-packet) script per BIP342; the separately-committed spending-tapleaf hash is unaffected.
- **Signer helper (`sigvalidate.go`):** `CalcTapscriptSignaturehash` → renamed to `CalcArkadeScriptSignatureHash` and gained a `codeSepPos uint32` parameter so callers can compute the digest the engine will verify against. Exposed `BlankCodeSepValue` (the `0xffffffff` sentinel) for the common no-separator case. Updated repo call sites to the clearer Arkade-specific name.
- **Doc fixes (`opcode.go:1754`):** Updated the stale `OP_CHECKSIG` / `OP_CODESEPARATOR` comments that still described btcd's legacy script-subscript signing process; they now describe the arkade tapscript digest (spending-tapleaf hash + last executed separator position).
- **Dead-code removal (`engine.go`, `opcode.go`):** Removed the `lastCodeSep` field, its write, and its per-script reset. It was a vestige of btcd's legacy pre-segwit sighash (which subscripted the script from the last separator's *byte offset*); BIP341/342 replaced that mechanism with the `codesep_pos` opcode-position commitment this engine uses, leaving the field with zero readers.

### Tests

- `TestArkadeScriptExecuteUsesCodeSeparatorForSighash` — a signature committing to the executed codesep position verifies; one using the blank sentinel is now **rejected** (proves the position is actually committed).
- `TestArkadeScriptExecuteUpdatesCodeSepPosOnCodeSeparator` — observes `codesep_pos` through the real `Execute` path: blank initially, then the separator's opcode position after it runs.
- `TestArkadeScriptExecuteOpSighashUsesCodeSeparatorPosition` (`script_test.go:228`) — checks `OP_SIGHASH` (not just `OP_CHECKSIG`) uses the executed separator position and that it differs from the blank-sentinel path.
- Replaces the old `TestArkadeScriptExecuteDoesNotUsePacketCodeSeparatorForSighash`, which asserted the previous (disabled) behavior.