### PR TITLE
feat: Cashu nullifier-pool PoC (trust-minimized ecash exit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is achieved by signing any Arkade transaction (offchain or intent proof) ex
 
 - [`test/htlc_test.go`](test/htlc_test.go) — **Non-interactive HTLC.** A 2-of-2 (`arkd` + emulator-tweaked) VTXO with a claim path gated by HASH160(preimage) and a refund path gated by absolute timelock. Neither the receiver nor the sender ever signs — an arkade covenant enforcing destination + amount replaces both their signatures.
 - [`test/delegate_test.go`](test/delegate_test.go) — **Non-interactive delegate.** A 2-of-2 (`arkd` + emulator-tweaked) VTXO refreshed through batch settlement by any solver, with a CSV exit leaf reserved for the user. The arkade covenant is a self-send (preserves the input's scriptPubKey + value on output 0) gated to intent-proof transactions (`OP_INSPECTVERSION` == 2) so it cannot be drained via off-chain self-send loops.
+- [`pkg/arkade/cashupool_claim_script_test.go`](pkg/arkade/cashupool_claim_script_test.go) — **Trust-minimized Cashu ecash exit.** A shared fixed-denomination pool VTXO whose `ClaimScript` verifies a real Cashu token in-script (NUT-00 `hash_to_curve` + NUT-12 r-blinded DLEQ over the EC opcodes), proves the token's nullifier is unspent and inserts it into an Indexed Merkle Tree (positional Merkle walk), and a recursive covenant rolls the pool state forward via a `0x05` extension packet — no mint involvement. The no-SNARK sibling of the v1-zec shielded-pool design; off-chain reference in [`pkg/arkade/cashupool/`](pkg/arkade/cashupool/).
 
 ## API
 

--- a/pkg/arkade/cashupool/dleq.go
+++ b/pkg/arkade/cashupool/dleq.go
@@ -1,0 +1,112 @@
+package cashupool
+
+import (
+	"crypto/sha256"
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// --- EC helpers ---
+
+func baseMul(k *btcec.ModNScalar) *btcec.PublicKey {
+	var r btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(k, &r)
+	r.ToAffine()
+	return btcec.NewPublicKey(&r.X, &r.Y)
+}
+
+func mul(k *btcec.ModNScalar, p *btcec.PublicKey) *btcec.PublicKey {
+	var pj, r btcec.JacobianPoint
+	p.AsJacobian(&pj)
+	btcec.ScalarMultNonConst(k, &pj, &r)
+	r.ToAffine()
+	return btcec.NewPublicKey(&r.X, &r.Y)
+}
+
+func add(a, b *btcec.PublicKey) *btcec.PublicKey {
+	var aj, bj, r btcec.JacobianPoint
+	a.AsJacobian(&aj)
+	b.AsJacobian(&bj)
+	btcec.AddNonConst(&aj, &bj, &r)
+	r.ToAffine()
+	return btcec.NewPublicKey(&r.X, &r.Y)
+}
+
+// challenge computes e = SHA256(U(R1)||U(R2)||U(A)||U(Cp)) as a big-endian
+// scalar mod n. MUST match the in-script verifier byte-for-byte.
+//
+// Points are fed as uncompressed (65 bytes: 0x04 || X32 || Y32).
+func challenge(R1, R2, A, Cp *btcec.PublicKey) *btcec.ModNScalar {
+	pre := make([]byte, 0, 65*4)
+	pre = append(pre, R1.SerializeUncompressed()...)
+	pre = append(pre, R2.SerializeUncompressed()...)
+	pre = append(pre, A.SerializeUncompressed()...)
+	pre = append(pre, Cp.SerializeUncompressed()...)
+	d := sha256.Sum256(pre)
+	h := new(big.Int).SetBytes(d[:]) // big-endian
+	h.Mod(h, btcec.S256().N)
+	var sc btcec.ModNScalar
+	var b [32]byte
+	h.FillBytes(b[:])
+	sc.SetBytes(&b)
+	return &sc
+}
+
+// Sign is the mint's BDHKE signature C = k*Y.
+func Sign(k *btcec.PrivateKey, Y *btcec.PublicKey) *btcec.PublicKey { return mul(&k.Key, Y) }
+
+// ProveProofDLEQ produces a NUT-12 proof DLEQ (e, s) for token C=k*Y under
+// mint key A=k*G, given the wallet blinding factor r.
+//
+//	B' = Y + r*G ; C' = C + r*A
+//	p (nonce) = deterministic scalar ; R1 = p*G ; R2 = p*B'
+//	e = challenge(R1,R2,A,C') ; s = p + e*k
+//
+// The nonce p is derived deterministically as
+// SHA256("cashupool-dleq-nonce" || k || Y || C) to avoid nonce reuse.
+func ProveProofDLEQ(k *btcec.PrivateKey, Y, C *btcec.PublicKey, r *btcec.PrivateKey) (e, s *btcec.ModNScalar) {
+	A := k.PubKey()
+	Bp := add(Y, baseMul(&r.Key))
+	Cp := add(C, mul(&r.Key, A))
+
+	// Deterministic nonce p = SHA256("cashupool-dleq-nonce" || k || Y || C).
+	hh := sha256.New()
+	hh.Write([]byte("cashupool-dleq-nonce"))
+	kb := k.Key.Bytes()
+	hh.Write(kb[:])
+	hh.Write(Y.SerializeCompressed())
+	hh.Write(C.SerializeCompressed())
+	var pb [32]byte
+	copy(pb[:], hh.Sum(nil))
+	p := new(btcec.ModNScalar)
+	p.SetBytes(&pb)
+
+	R1 := baseMul(p)
+	R2 := mul(p, Bp)
+	e = challenge(R1, R2, A, Cp)
+
+	// s = p + e*k
+	ek := new(btcec.ModNScalar).Mul2(e, &k.Key)
+	s = new(btcec.ModNScalar).Add2(p, ek)
+	return e, s
+}
+
+// VerifyProofDLEQ checks a NUT-12 proof DLEQ. r is the revealed blinding
+// factor (the claim reveals r so the verifier can reconstruct B' and C').
+//
+//	B' = Y + r*G ; C' = C + r*A
+//	R1 = s*G - e*A ; R2 = s*B' - e*C'
+//	accept iff challenge(R1,R2,A,C') == e
+func VerifyProofDLEQ(A, Y, C *btcec.PublicKey, r *btcec.PrivateKey, e, s *btcec.ModNScalar) bool {
+	Bp := add(Y, baseMul(&r.Key))
+	Cp := add(C, mul(&r.Key, A))
+
+	negE := new(btcec.ModNScalar).Set(e)
+	negE.Negate()
+
+	R1 := add(baseMul(s), mul(negE, A))
+	R2 := add(mul(s, Bp), mul(negE, Cp))
+
+	return challenge(R1, R2, A, Cp).Equals(e)
+}

--- a/pkg/arkade/cashupool/dleq_test.go
+++ b/pkg/arkade/cashupool/dleq_test.go
@@ -1,0 +1,131 @@
+package cashupool
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProofDLEQ(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round_trip", func(t *testing.T) {
+		t.Parallel()
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		A := k.PubKey()
+
+		secret := GrindSecret("dleq", 4)
+		Y, _ := HashToCurve(secret)
+
+		r, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		C := Sign(k, Y)
+		e, s := ProveProofDLEQ(k, Y, C, r)
+
+		require.True(t, VerifyProofDLEQ(A, Y, C, r, e, s), "valid proof must verify")
+	})
+
+	t.Run("tampered_s_fails", func(t *testing.T) {
+		t.Parallel()
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		A := k.PubKey()
+
+		secret := GrindSecret("dleq-s", 4)
+		Y, _ := HashToCurve(secret)
+
+		r, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		C := Sign(k, Y)
+		e, s := ProveProofDLEQ(k, Y, C, r)
+
+		bad := new(btcec.ModNScalar).Set(s)
+		bad.Add(new(btcec.ModNScalar).SetInt(1))
+		require.False(t, VerifyProofDLEQ(A, Y, C, r, e, bad), "tampered s must not verify")
+	})
+
+	t.Run("tampered_e_fails", func(t *testing.T) {
+		t.Parallel()
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		A := k.PubKey()
+
+		secret := GrindSecret("dleq-e", 4)
+		Y, _ := HashToCurve(secret)
+
+		r, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		C := Sign(k, Y)
+		e, s := ProveProofDLEQ(k, Y, C, r)
+
+		badE := new(btcec.ModNScalar).Set(e)
+		badE.Add(new(btcec.ModNScalar).SetInt(1))
+		require.False(t, VerifyProofDLEQ(A, Y, C, r, badE, s), "tampered e must not verify")
+	})
+
+	t.Run("wrong_key_fails", func(t *testing.T) {
+		t.Parallel()
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		k2, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		A2 := k2.PubKey()
+
+		secret := GrindSecret("dleq-wk", 4)
+		Y, _ := HashToCurve(secret)
+
+		r, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		C := Sign(k, Y)
+		e, s := ProveProofDLEQ(k, Y, C, r)
+
+		require.False(t, VerifyProofDLEQ(A2, Y, C, r, e, s), "wrong mint key must not verify")
+	})
+
+	t.Run("wrong_r_fails", func(t *testing.T) {
+		t.Parallel()
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		A := k.PubKey()
+
+		secret := GrindSecret("dleq-wr", 4)
+		Y, _ := HashToCurve(secret)
+
+		r, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		r2, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		C := Sign(k, Y)
+		e, s := ProveProofDLEQ(k, Y, C, r)
+
+		require.False(t, VerifyProofDLEQ(A, Y, C, r2, e, s), "wrong blinding factor must not verify")
+	})
+
+	t.Run("determinism", func(t *testing.T) {
+		t.Parallel()
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		secret := GrindSecret("dleq-det", 4)
+		Y, _ := HashToCurve(secret)
+
+		r, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		C := Sign(k, Y)
+		e1, s1 := ProveProofDLEQ(k, Y, C, r)
+		e2, s2 := ProveProofDLEQ(k, Y, C, r)
+
+		require.True(t, e1.Equals(e2), "ProveProofDLEQ must be deterministic: e differs")
+		require.True(t, s1.Equals(s2), "ProveProofDLEQ must be deterministic: s differs")
+	})
+}

--- a/pkg/arkade/cashupool/hashtocurve.go
+++ b/pkg/arkade/cashupool/hashtocurve.go
@@ -1,0 +1,74 @@
+// Package cashupool is an off-chain Go reference library for the Cashu
+// nullifier-pool proof-of-concept.  It is the source of truth for the
+// in-script Cashu verifier implemented in Arkade Script.
+package cashupool
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// DomainSeparator is the NUT-00 hash_to_curve domain tag.
+var DomainSeparator = []byte("Secp256k1_HashToCurve_Cashu_")
+
+// HashToCurve maps a secret to a secp256k1 point per Cashu NUT-00, returning
+// the point and the winning counter.
+//
+// Algorithm (NUT-00):
+//
+//	msg  = SHA256(DomainSeparator || secret)
+//	for c = 0, 1, 2, …:
+//	    cand = SHA256(msg || uint32_little_endian(c))
+//	    try to parse 0x02||cand as a compressed secp256k1 point
+//	    if valid: return (point, c)
+//
+// The returned point always has an even Y coordinate (0x02 prefix) because
+// btcec.ParsePubKey with a 0x02 prefix selects the even-Y solution.
+func HashToCurve(secret []byte) (*btcec.PublicKey, uint32) {
+	// msg = SHA256(DomainSeparator || secret)
+	h := sha256.New()
+	h.Write(DomainSeparator)
+	h.Write(secret)
+	msg := h.Sum(nil)
+
+	// Scratch buffer: 4 bytes for little-endian counter.
+	var ctrBuf [4]byte
+
+	for c := uint32(0); ; c++ {
+		binary.LittleEndian.PutUint32(ctrBuf[:], c)
+
+		// cand = SHA256(msg || uint32_le(c))
+		h2 := sha256.New()
+		h2.Write(msg)
+		h2.Write(ctrBuf[:])
+		cand := h2.Sum(nil) // 32 bytes
+
+		// Build 33-byte compressed encoding: 0x02 || cand (even-Y lift_x).
+		compressed := make([]byte, 33)
+		compressed[0] = 0x02
+		copy(compressed[1:], cand)
+
+		Y, err := btcec.ParsePubKey(compressed)
+		if err != nil {
+			// cand is not a valid x-coordinate on secp256k1; try next counter.
+			continue
+		}
+		return Y, c
+	}
+}
+
+// GrindSecret returns a secret of the form "<prefix>-<i>" whose HashToCurve
+// winning counter is <= maxCounter.  It iterates i = 0, 1, 2, … until a
+// matching secret is found.  Used by tests to construct K-bounded test vectors.
+func GrindSecret(prefix string, maxCounter uint32) []byte {
+	for i := 0; ; i++ {
+		secret := []byte(fmt.Sprintf("%s-%d", prefix, i))
+		_, c := HashToCurve(secret)
+		if c <= maxCounter {
+			return secret
+		}
+	}
+}

--- a/pkg/arkade/cashupool/hashtocurve_test.go
+++ b/pkg/arkade/cashupool/hashtocurve_test.go
@@ -1,0 +1,66 @@
+package cashupool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHashToCurve exercises the Cashu NUT-00 hash_to_curve primitive.
+func TestHashToCurve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("determinism", func(t *testing.T) {
+		t.Parallel()
+		secret := []byte("test-secret")
+		Y1, c1 := HashToCurve(secret)
+		Y2, c2 := HashToCurve(secret)
+		require.Equal(t, c1, c2, "counter must be stable across calls")
+		require.Equal(
+			t,
+			Y1.SerializeCompressed(),
+			Y2.SerializeCompressed(),
+			"point must be stable across calls",
+		)
+	})
+
+	t.Run("even_y", func(t *testing.T) {
+		t.Parallel()
+		// NUT-00 lift_x always selects the even-Y solution (0x02 prefix).
+		Y, _ := HashToCurve([]byte("even-y-check"))
+		compressed := Y.SerializeCompressed()
+		require.Equal(t, byte(0x02), compressed[0], "compressed point must have 0x02 prefix (even Y)")
+	})
+
+	t.Run("on_curve", func(t *testing.T) {
+		t.Parallel()
+		Y, _ := HashToCurve([]byte("on-curve-check"))
+		require.True(t, Y.IsOnCurve(), "returned point must lie on secp256k1")
+	})
+
+	t.Run("different_secrets_give_different_points", func(t *testing.T) {
+		t.Parallel()
+		Y1, _ := HashToCurve([]byte("secret-alpha"))
+		Y2, _ := HashToCurve([]byte("secret-beta"))
+		require.NotEqual(
+			t,
+			Y1.SerializeCompressed(),
+			Y2.SerializeCompressed(),
+			"distinct secrets must produce distinct points",
+		)
+	})
+
+	t.Run("grind_counter_zero", func(t *testing.T) {
+		t.Parallel()
+		secret := GrindSecret("x", 0)
+		_, c := HashToCurve(secret)
+		require.Equal(t, uint32(0), c, "GrindSecret(\"x\", 0) must yield a secret with counter == 0")
+	})
+
+	t.Run("grind_counter_bounded", func(t *testing.T) {
+		t.Parallel()
+		secret := GrindSecret("y", 3)
+		_, c := HashToCurve(secret)
+		require.LessOrEqual(t, c, uint32(3), "GrindSecret(\"y\", 3) must yield a secret with counter <= 3")
+	})
+}

--- a/pkg/arkade/cashupool/imt.go
+++ b/pkg/arkade/cashupool/imt.go
@@ -1,0 +1,270 @@
+package cashupool
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"math/big"
+)
+
+// Leaf is one node in the sorted linked-list threaded through the IMT.
+// Value is the nullifier value; Next is the value of the next-larger occupied
+// leaf (Next == 0 means "+infinity": this leaf is the current maximum).
+type Leaf struct {
+	Value *big.Int
+	Next  *big.Int
+}
+
+// Hash returns SHA256(be32(Value) || be32(Next)) where be32 is the 32-byte
+// big-endian encoding.  This is the real-leaf hash used by both the off-chain
+// Go library and the in-script verifier — they must agree byte-for-byte.
+func (l Leaf) Hash() []byte {
+	var val, next [32]byte
+	l.Value.FillBytes(val[:])
+	l.Next.FillBytes(next[:])
+	h := sha256.Sum256(append(val[:], next[:]...))
+	return h[:]
+}
+
+// EmptyLeafHash returns the canonical empty-slot hash (32 zero bytes).
+// This is DISTINCT from the sentinel leaf (0,0).hash which is SHA256(64 zeros).
+func EmptyLeafHash() []byte {
+	return bytes.Repeat([]byte{0x00}, 32)
+}
+
+// RecomputeRoot walks depth levels from a leaf at index using siblings
+// (siblings[0] = sibling at the leaf level, i.e. level 0).
+// At each level the LSB-first bit of index selects child order:
+//
+//	bit == 0  =>  current is LEFT child:  SHA256(cur || sib)
+//	bit == 1  =>  current is RIGHT child: SHA256(sib || cur)
+//
+// This is the canonical positional walk that the in-script verifier replicates.
+func RecomputeRoot(depth int, index uint32, leafHash []byte, siblings [][]byte) []byte {
+	cur := leafHash
+	for i := 0; i < depth; i++ {
+		sib := siblings[i]
+		var comb []byte
+		if (index>>uint(i))&1 == 0 {
+			comb = append(append([]byte{}, cur...), sib...)
+		} else {
+			comb = append(append([]byte{}, sib...), cur...)
+		}
+		h := sha256.Sum256(comb)
+		cur = h[:]
+	}
+	return cur
+}
+
+// IMT is a fixed-depth Indexed Merkle Tree (Aztec-style).
+//
+// The tree holds a sorted linked list of occupied nullifier values.  Each leaf
+// stores (Value, Next) where Next is the value of the successor in the sorted
+// order (Next==0 means +infinity).
+//
+// Leaf index 0 always contains the genesis sentinel (0, 0).
+// Subsequent inserts occupy indices 1, 2, … in insertion order.
+type IMT struct {
+	depth    int
+	leaves   map[uint32]Leaf // occupied leaves
+	occupied map[uint32]bool // set of occupied indices (for subtree-empty checks)
+	size     uint32
+	dflt     [][]byte          // dflt[i] is the default hash for a subtree of height i
+	cache    map[uint64][]byte // nodeHash cache: key = level<<32|idx
+}
+
+// subtreeKey packs level and idx into a uint64 for the cache.
+func subtreeKey(level int, idx uint32) uint64 {
+	return uint64(level)<<32 | uint64(idx)
+}
+
+// NewIMT creates a depth-D indexed Merkle tree with the genesis leaf (0,0) at
+// index 0. Size() == 1 after construction.
+func NewIMT(depth int) *IMT {
+	// Build default hashes: dflt[0] = 32 zero bytes; dflt[i] = SHA256(dflt[i-1]||dflt[i-1]).
+	dflt := make([][]byte, depth+1)
+	dflt[0] = EmptyLeafHash()
+	for i := 1; i <= depth; i++ {
+		h := sha256.Sum256(append(dflt[i-1], dflt[i-1]...))
+		dflt[i] = h[:]
+	}
+
+	t := &IMT{
+		depth:    depth,
+		leaves:   make(map[uint32]Leaf),
+		occupied: make(map[uint32]bool),
+		size:     0,
+		dflt:     dflt,
+		cache:    make(map[uint64][]byte),
+	}
+
+	// Insert genesis sentinel: Leaf{0, 0} at index 0.
+	genesis := Leaf{Value: new(big.Int), Next: new(big.Int)}
+	t.leaves[0] = genesis
+	t.occupied[0] = true
+	t.size = 1
+
+	return t
+}
+
+// Depth returns the fixed depth of the tree.
+func (t *IMT) Depth() int { return t.depth }
+
+// Size returns the number of occupied leaves (genesis counts as 1).
+func (t *IMT) Size() uint32 { return t.size }
+
+// Root returns the Merkle root of the full tree.
+func (t *IMT) Root() []byte { return t.nodeHash(t.depth, 0) }
+
+// invalidateCache clears the entire node-hash cache after any mutation.
+// With only a handful of leaves a full-clear is cheap.
+func (t *IMT) invalidateCache() {
+	t.cache = make(map[uint64][]byte)
+}
+
+// hasOccupiedLeaf reports whether the subtree rooted at (level, idx) contains
+// at least one occupied leaf.  The subtree covers leaf indices
+// [idx*2^level, (idx+1)*2^level).
+func (t *IMT) hasOccupiedLeaf(level int, idx uint32) bool {
+	lo := idx << uint(level)
+	hi := lo + (1 << uint(level)) // exclusive
+	for i := lo; i < hi; i++ {
+		if t.occupied[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeHash computes the hash of the subtree rooted at (level, idx) using the
+// short-circuit: if no occupied leaf falls under the subtree, return dflt[level].
+func (t *IMT) nodeHash(level int, idx uint32) []byte {
+	key := subtreeKey(level, idx)
+	if v, ok := t.cache[key]; ok {
+		return v
+	}
+
+	var h []byte
+	if !t.hasOccupiedLeaf(level, idx) {
+		h = t.dflt[level]
+	} else if level == 0 {
+		if t.occupied[idx] {
+			leaf := t.leaves[idx]
+			h = leaf.Hash()
+		} else {
+			h = EmptyLeafHash()
+		}
+	} else {
+		left := t.nodeHash(level-1, 2*idx)
+		right := t.nodeHash(level-1, 2*idx+1)
+		sum := sha256.Sum256(append(left, right...))
+		h = sum[:]
+	}
+
+	t.cache[key] = h
+	return h
+}
+
+// merklePathFor computes the D siblings for the leaf at index i.
+// siblings[0] is the sibling at level 0 (leaf level), siblings[D-1] is at level D-1.
+func (t *IMT) merklePathFor(leafIdx uint32) [][]byte {
+	sibs := make([][]byte, t.depth)
+	cur := leafIdx
+	for lv := 0; lv < t.depth; lv++ {
+		sibIdx := cur ^ 1 // toggle LSB
+		sibs[lv] = t.nodeHash(lv, sibIdx)
+		cur >>= 1
+	}
+	return sibs
+}
+
+// findLow finds the predecessor ("low") leaf for value k: the occupied leaf L
+// with L.Value < k and (L.Next == 0 OR L.Next > k).
+// Returns the Leaf and its index.
+func (t *IMT) findLow(k *big.Int) (Leaf, uint32) {
+	var bestLeaf Leaf
+	var bestIdx uint32
+	found := false
+
+	for idx := range t.occupied {
+		leaf := t.leaves[idx]
+		// Must have leaf.Value < k.
+		if leaf.Value.Cmp(k) >= 0 {
+			continue
+		}
+		// Must bracket k: Next == 0 (sentinel/+inf) OR Next > k.
+		if leaf.Next.Sign() != 0 && leaf.Next.Cmp(k) <= 0 {
+			continue
+		}
+		// Among all qualifying leaves, pick the one with the largest Value
+		// (closest predecessor).
+		if !found || leaf.Value.Cmp(bestLeaf.Value) > 0 {
+			bestLeaf = Leaf{
+				Value: new(big.Int).Set(leaf.Value),
+				Next:  new(big.Int).Set(leaf.Next),
+			}
+			bestIdx = idx
+			found = true
+		}
+	}
+	return bestLeaf, bestIdx
+}
+
+// NonMembership returns the predecessor ("low") leaf bracketing k, its index,
+// and its Merkle path (D siblings, level-0 first) against the current root.
+// Caller must ensure k is not already a member; if it is, the result is
+// undefined (the predecessor's Next will equal k, not bracket it).
+func (t *IMT) NonMembership(k *big.Int) (low Leaf, lowIdx uint32, lowPath [][]byte) {
+	low, lowIdx = t.findLow(k)
+	lowPath = t.merklePathFor(lowIdx)
+	return low, lowIdx, lowPath
+}
+
+// Insert adds nullifier k to the tree.
+//
+// It performs two sub-operations:
+//  1. Update the low leaf's Next pointer from oldLowNext to k; recompute root1.
+//  2. Store the new leaf (k, oldLowNext) at appendIdx = Size(); recompute newRoot.
+//
+// Returns:
+//   - root1:     intermediate Merkle root after low-leaf update but before new leaf
+//   - newRoot:   final Merkle root after new leaf insertion
+//   - szSibs:    Merkle path of appendIdx under root1 (all siblings are empty/default)
+//   - appendIdx: the leaf index where the new leaf was stored
+//
+// The caller must supply low, lowIdx, lowPath from a prior NonMembership call
+// for the same k (they are used for consistency but the tree recomputes paths
+// internally after mutation).
+func (t *IMT) Insert(k *big.Int, low Leaf, lowIdx uint32, lowPath [][]byte) (root1, newRoot []byte, szSibs [][]byte, appendIdx uint32) {
+	// Save original Next of the low leaf.
+	oldLowNext := new(big.Int).Set(low.Next)
+
+	// Step 1: update low leaf's Next to k.
+	updatedLow := Leaf{
+		Value: new(big.Int).Set(low.Value),
+		Next:  new(big.Int).Set(k),
+	}
+	t.leaves[lowIdx] = updatedLow
+	t.invalidateCache()
+
+	root1 = t.Root()
+
+	// Step 2: compute the Merkle path for the append slot (currently empty).
+	appendIdx = t.size
+	szSibs = t.merklePathFor(appendIdx)
+
+	// Sanity-check the coupling invariant (will also be tested externally).
+	_ = root1 // used below for assertion in tests; already computed
+
+	// Step 3: store new leaf (k, oldLowNext) at appendIdx.
+	newLeaf := Leaf{
+		Value: new(big.Int).Set(k),
+		Next:  oldLowNext,
+	}
+	t.leaves[appendIdx] = newLeaf
+	t.occupied[appendIdx] = true
+	t.size++
+	t.invalidateCache()
+
+	newRoot = t.Root()
+	return root1, newRoot, szSibs, appendIdx
+}

--- a/pkg/arkade/cashupool/imt_test.go
+++ b/pkg/arkade/cashupool/imt_test.go
@@ -1,0 +1,187 @@
+package cashupool
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIMT_Genesis verifies that a freshly created IMT has the expected state.
+func TestIMT_Genesis(t *testing.T) {
+	t.Parallel()
+
+	tree := NewIMT(16)
+	require.Equal(t, 16, tree.Depth())
+	require.Equal(t, uint32(1), tree.Size())
+
+	root := tree.Root()
+	require.Len(t, root, 32, "root must be 32 bytes")
+	require.False(t, bytes.Equal(root, make([]byte, 32)), "root must not be all-zero")
+
+	// Root must be deterministic.
+	tree2 := NewIMT(16)
+	require.Equal(t, root, tree2.Root(), "genesis root must be deterministic")
+}
+
+// TestIMT_NonMembershipGenesis verifies non-membership proof for a positive k
+// in a fresh tree containing only (0,0).
+func TestIMT_NonMembershipGenesis(t *testing.T) {
+	t.Parallel()
+
+	tree := NewIMT(16)
+	root := tree.Root()
+
+	k := big.NewInt(42)
+	low, lowIdx, lowPath := tree.NonMembership(k)
+
+	// Low leaf must be (0, 0) — the genesis sentinel.
+	require.Equal(t, 0, low.Value.Sign(), "low.Value must be 0")
+	require.Equal(t, 0, low.Next.Sign(), "low.Next must be 0 (sentinel = +inf)")
+
+	// Path must verify against current root.
+	computed := RecomputeRoot(16, lowIdx, low.Hash(), lowPath)
+	require.True(t, bytes.Equal(computed, root),
+		"RecomputeRoot of low leaf path must equal Root()")
+}
+
+// TestIMT_Insert verifies a single insertion.
+func TestIMT_Insert(t *testing.T) {
+	t.Parallel()
+
+	tree := NewIMT(16)
+	prevRoot := tree.Root()
+
+	k := big.NewInt(100)
+	low, lowIdx, lowPath := tree.NonMembership(k)
+
+	root1, newRoot, szSibs, appendIdx := tree.Insert(k, low, lowIdx, lowPath)
+
+	// newRoot must equal live Root() after insert.
+	require.Equal(t, newRoot, tree.Root(), "newRoot must equal Root() after insert")
+	// Root must have changed.
+	require.False(t, bytes.Equal(newRoot, prevRoot), "root must change after insert")
+	// Size must have incremented.
+	require.Equal(t, uint32(2), tree.Size())
+
+	// Coupling invariant: root1 was the intermediate root with low leaf updated
+	// but append slot still empty.
+	coupling := RecomputeRoot(16, appendIdx, EmptyLeafHash(), szSibs)
+	require.True(t, bytes.Equal(coupling, root1),
+		"coupling invariant: RecomputeRoot(appendIdx, emptyHash, szSibs) must == root1")
+
+	// Final root coupling: newLeaf = (k, old low.Next) at appendIdx under root1's siblings.
+	newLeaf := Leaf{Value: k, Next: new(big.Int).Set(low.Next)}
+	finalCoupling := RecomputeRoot(16, appendIdx, newLeaf.Hash(), szSibs)
+	require.True(t, bytes.Equal(finalCoupling, newRoot),
+		"final coupling invariant: RecomputeRoot(appendIdx, newLeaf.Hash(), szSibs) must == newRoot")
+}
+
+// TestIMT_InsertRootChaining verifies that a fresh tree replaying the same
+// insert yields the same root.
+func TestIMT_InsertRootChaining(t *testing.T) {
+	t.Parallel()
+
+	k := big.NewInt(77)
+
+	tree1 := NewIMT(16)
+	low, lowIdx, lowPath := tree1.NonMembership(k)
+	_, newRoot1, _, _ := tree1.Insert(k, low, lowIdx, lowPath)
+
+	tree2 := NewIMT(16)
+	low2, lowIdx2, lowPath2 := tree2.NonMembership(k)
+	_, newRoot2, _, _ := tree2.Insert(k, low2, lowIdx2, lowPath2)
+
+	require.Equal(t, newRoot1, newRoot2,
+		"replaying the same insert on a fresh tree must produce the same root")
+}
+
+// TestIMT_InsertMembershipExclusion verifies that after inserting k,
+// there is no longer a bracketing low leaf for k (k is now a member).
+func TestIMT_InsertMembershipExclusion(t *testing.T) {
+	t.Parallel()
+
+	tree := NewIMT(16)
+	k := big.NewInt(55)
+
+	low, lowIdx, lowPath := tree.NonMembership(k)
+	tree.Insert(k, low, lowIdx, lowPath)
+
+	// After insertion, searching for a bracketing predecessor should not find
+	// any leaf L where L.Value < k AND (L.Next == 0 OR L.Next > k).
+	// Instead the leaf with Value==k should be in the tree; we verify by
+	// checking that the predecessor's Next now points to k (not past it).
+	low2, _, _ := tree.NonMembership(big.NewInt(56)) // just above k
+	// The predecessor of 56 should now be k (or something >=k).
+	// low2.Value should be k (the newly inserted leaf).
+	require.Equal(t, 0, low2.Value.Cmp(k),
+		"after inserting k, the predecessor of k+1 must be k itself")
+	// And its Next must be 0 (was the old sentinel) since k was inserted before any larger value.
+	require.Equal(t, 0, low2.Next.Sign(),
+		"Next of k must be 0 (sentinel) since no larger value was inserted")
+}
+
+// TestIMT_MultiInsert inserts several values and after each verifies:
+// - RecomputeRoot of each returned proof == live Root()
+// - membership-vs-nonmembership consistency
+// - insert coupling invariant
+func TestIMT_MultiInsert(t *testing.T) {
+	t.Parallel()
+
+	// Fixed set of distinct keys in insertion order.
+	keys := []*big.Int{
+		big.NewInt(300),
+		big.NewInt(50),
+		big.NewInt(700),
+		big.NewInt(150),
+		big.NewInt(10),
+	}
+
+	tree := NewIMT(16)
+
+	for i, k := range keys {
+		prevRoot := tree.Root()
+
+		low, lowIdx, lowPath := tree.NonMembership(k)
+
+		// Verify non-membership path against pre-insert root.
+		computed := RecomputeRoot(16, lowIdx, low.Hash(), lowPath)
+		require.True(t, bytes.Equal(computed, prevRoot),
+			"key[%d]: non-membership path must verify against pre-insert root", i)
+
+		root1, newRoot, szSibs, appendIdx := tree.Insert(k, low, lowIdx, lowPath)
+
+		// newRoot == live Root()
+		require.Equal(t, newRoot, tree.Root(),
+			"key[%d]: newRoot must equal Root() after insert", i)
+
+		// Root changed
+		require.False(t, bytes.Equal(newRoot, prevRoot),
+			"key[%d]: root must change after insert", i)
+
+		// Coupling invariant
+		coupling := RecomputeRoot(16, appendIdx, EmptyLeafHash(), szSibs)
+		require.True(t, bytes.Equal(coupling, root1),
+			"key[%d]: coupling invariant must hold", i)
+
+		// Final root coupling
+		newLeaf := Leaf{Value: k, Next: new(big.Int).Set(low.Next)}
+		finalCoupling := RecomputeRoot(16, appendIdx, newLeaf.Hash(), szSibs)
+		require.True(t, bytes.Equal(finalCoupling, newRoot),
+			"key[%d]: final coupling invariant must hold", i)
+	}
+
+	// Verify all proofs are still valid against the final root.
+	finalRoot := tree.Root()
+	for i, k := range keys {
+		// Each key is now a member; its NonMembership predecessor should not bracket it.
+		// Specifically, if we query k's predecessor, predecessor.Next should == k.
+		low, lowIdx, lowPath := tree.NonMembership(new(big.Int).Add(k, big.NewInt(1)))
+		// predecessor of k+1 is either k or something larger with a gap.
+		// The predecessor's path must verify.
+		computed := RecomputeRoot(16, lowIdx, low.Hash(), lowPath)
+		require.True(t, bytes.Equal(computed, finalRoot),
+			"key[%d]: post-insert non-membership path must verify against final root", i)
+	}
+}

--- a/pkg/arkade/cashupool/state.go
+++ b/pkg/arkade/cashupool/state.go
@@ -1,0 +1,62 @@
+package cashupool
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Byte-layout constants for the 68-byte on-chain pool-state packet.
+// The layout is fixed so that an in-script OP_SUBSTR can pull fields at known
+// offsets without any parsing logic.
+const (
+	PoolStateSize = 68 // total wire size in bytes
+
+	OffPrevRoot = 0  // bytes [0:32]  — previous IMT root
+	OffNewRoot  = 32 // bytes [32:64] — new IMT root after this tx's insert
+	OffSize     = 64 // bytes [64:68] — occupied-leaf count (u32 LE)
+)
+
+// PoolState is the decoded form of the 68-byte pool-state packet carried in a
+// custom 0x05 extension packet and read in-script via OP_INSPECTPACKET.
+type PoolState struct {
+	PrevRoot []byte // 32 bytes — previous IMT root
+	NewRoot  []byte // 32 bytes — new IMT root after this tx's insert
+	Size     uint32 // occupied-leaf count after this tx's insert
+}
+
+// Serialize returns prev_root(32) || new_root(32) || size_le(4).
+// It panics if PrevRoot or NewRoot is not exactly 32 bytes (programmer error).
+func (s PoolState) Serialize() []byte {
+	if len(s.PrevRoot) != 32 {
+		panic(fmt.Sprintf("cashupool: PoolState.PrevRoot must be 32 bytes, got %d", len(s.PrevRoot)))
+	}
+	if len(s.NewRoot) != 32 {
+		panic(fmt.Sprintf("cashupool: PoolState.NewRoot must be 32 bytes, got %d", len(s.NewRoot)))
+	}
+
+	b := make([]byte, PoolStateSize)
+	copy(b[OffPrevRoot:OffNewRoot], s.PrevRoot)
+	copy(b[OffNewRoot:OffSize], s.NewRoot)
+	binary.LittleEndian.PutUint32(b[OffSize:PoolStateSize], s.Size)
+	return b
+}
+
+// ParsePoolState decodes a 68-byte payload into a PoolState.
+// It returns an error if the payload length is not exactly PoolStateSize.
+func ParsePoolState(b []byte) (PoolState, error) {
+	if len(b) != PoolStateSize {
+		return PoolState{}, fmt.Errorf("cashupool: ParsePoolState requires %d bytes, got %d", PoolStateSize, len(b))
+	}
+
+	prevRoot := make([]byte, 32)
+	newRoot := make([]byte, 32)
+	copy(prevRoot, b[OffPrevRoot:OffNewRoot])
+	copy(newRoot, b[OffNewRoot:OffSize])
+	size := binary.LittleEndian.Uint32(b[OffSize:PoolStateSize])
+
+	return PoolState{
+		PrevRoot: prevRoot,
+		NewRoot:  newRoot,
+		Size:     size,
+	}, nil
+}

--- a/pkg/arkade/cashupool/state_test.go
+++ b/pkg/arkade/cashupool/state_test.go
@@ -1,0 +1,69 @@
+package cashupool
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolState_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	prevRoot := make([]byte, 32)
+	newRoot := make([]byte, 32)
+	for i := range prevRoot {
+		prevRoot[i] = byte(i + 1)
+	}
+	for i := range newRoot {
+		newRoot[i] = byte(i + 0x80)
+	}
+
+	s := PoolState{
+		PrevRoot: prevRoot,
+		NewRoot:  newRoot,
+		Size:     7,
+	}
+
+	b := s.Serialize()
+	require.Len(t, b, PoolStateSize, "serialized length must be 68 bytes")
+
+	got, err := ParsePoolState(b)
+	require.NoError(t, err)
+	require.Equal(t, s, got)
+}
+
+func TestPoolState_WrongLength(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParsePoolState(make([]byte, 67))
+	require.Error(t, err, "67 bytes should fail")
+
+	_, err = ParsePoolState(make([]byte, 69))
+	require.Error(t, err, "69 bytes should fail")
+}
+
+func TestPoolState_FieldOffsets(t *testing.T) {
+	t.Parallel()
+
+	prevRoot := make([]byte, 32)
+	newRoot := make([]byte, 32)
+	for i := range prevRoot {
+		prevRoot[i] = byte(i + 1)
+	}
+	for i := range newRoot {
+		newRoot[i] = byte(i + 0x40)
+	}
+
+	s := PoolState{
+		PrevRoot: prevRoot,
+		NewRoot:  newRoot,
+		Size:     0xDEADBEEF,
+	}
+
+	b := s.Serialize()
+
+	require.Equal(t, prevRoot, b[OffPrevRoot:OffNewRoot], "PrevRoot bytes at expected offset")
+	require.Equal(t, newRoot, b[OffNewRoot:OffSize], "NewRoot bytes at expected offset")
+	require.Equal(t, uint32(0xDEADBEEF), binary.LittleEndian.Uint32(b[OffSize:PoolStateSize]), "Size LE at expected offset")
+}

--- a/pkg/arkade/cashupool_claim_script_test.go
+++ b/pkg/arkade/cashupool_claim_script_test.go
@@ -780,6 +780,32 @@ func (env *ClaimEnv) craftClaimTx(
 	return tx, fetcher
 }
 
+// prepareDoubleSpend crafts a second claim of an already-spent token. The
+// attacker can only replay the stale (pre-insert) non-membership proof from the
+// original claim, but the pool has advanced: the current tx's PrevRoot must
+// equal the new parent.NewRoot, while the replayed low-leaf recomputes to the
+// old root, so the IMT non-membership EQUALVERIFY fails.
+func (env *ClaimEnv) prepareDoubleSpend(orig claimArtifacts) claimArtifacts {
+	// The replayed claim reuses orig's witness verbatim (same token + same stale
+	// IMT proof). It claims to transition the CURRENT pool state (env's advanced
+	// view) by re-inserting nf: this.PrevRoot = parent.NewRoot (advanced),
+	// this.Size = parentSize+1.
+	parentNewRoot := append([]byte(nil), env.parentRoot...)
+	parentSize := env.parentSize
+
+	a := orig
+	a.witness = append([][]byte(nil), orig.witness...)
+	// The packet claims continuity with the advanced pool, but the IMT proof is
+	// stale: prevRoot in the packet = parentNewRoot (advanced), newRoot is a
+	// best-effort guess derived off-chain replay (the engine rejects regardless
+	// because the stale low proof cannot recompute to the advanced prevRoot).
+	a.prevRoot = parentNewRoot
+	a.newRoot = orig.newRoot
+	a.thisSize = parentSize + 1
+	a.tx, a.fetcher = env.craftClaimTx(parentNewRoot, parentSize, a.prevRoot, a.newRoot, a.thisSize)
+	return a
+}
+
 // genesisPrevRoot returns the all-zero 32-byte root used as the genesis
 // PrevRoot of the very first pool state.
 func (env *ClaimEnv) genesisPrevRoot() []byte { return make([]byte, 32) }
@@ -833,4 +859,101 @@ func TestClaimScript(t *testing.T) {
 		a := env.prepareClaim(claimSecret("claim-valid"))
 		require.NoError(t, env.runClaim(a))
 	})
+
+	t.Run("double-spend rejected", func(t *testing.T) {
+		env := newClaimEnv(t)
+		secret := claimSecret("claim-ds")
+		a1 := env.prepareClaim(secret)
+		require.NoError(t, env.runClaim(a1))
+		// Claiming the SAME secret again: the nullifier is now in the tree, so
+		// the only proof the attacker has is the stale pre-insert one, which no
+		// longer recomputes to the advanced pool root. The IMT phase must fail.
+		a2 := env.prepareDoubleSpend(a1)
+		require.Error(t, env.runClaim(a2))
+	})
+
+	t.Run("tampered e rejected", func(t *testing.T) {
+		env := newClaimEnv(t)
+		a := env.prepareClaim(claimSecret("claim-e"))
+		// e is witness index wE.
+		badE := new(big.Int).Add(new(big.Int).SetBytes(reverseForBig(a.witness[wE])), big.NewInt(1))
+		badE.Mod(badE, btcec.S256().N)
+		a.witness[wE] = encodeBig(badE)
+		require.Error(t, env.runClaim(a))
+	})
+
+	t.Run("wrong claimant value rejected", func(t *testing.T) {
+		env := newClaimEnv(t)
+		a := env.prepareClaim(claimSecret("claim-cv"))
+		a.tx.TxOut[0].Value = claimDenomSat + 1
+		require.Error(t, env.runClaim(a))
+	})
+
+	t.Run("wrong pool value rejected", func(t *testing.T) {
+		env := newClaimEnv(t)
+		a := env.prepareClaim(claimSecret("claim-pv"))
+		a.tx.TxOut[1].Value = claimPoolValue - claimDenomSat - 1
+		require.Error(t, env.runClaim(a))
+	})
+
+	t.Run("broken continuity rejected", func(t *testing.T) {
+		env := newClaimEnv(t)
+		a := env.prepareClaim(claimSecret("claim-cont"))
+		// Corrupt the parent packet so this.PrevRoot != parent.NewRoot.
+		parentTx := a.fetcher.(*testArkPrevOutFetcher).arkTxs[a.tx.TxIn[0].PreviousOutPoint]
+		corruptParent := corruptPoolStateNewRoot(t, parentTx)
+		a.fetcher.(*testArkPrevOutFetcher).arkTxs[a.tx.TxIn[0].PreviousOutPoint] = corruptParent
+		require.Error(t, env.runClaim(a))
+	})
+
+	t.Run("wrong newRoot rejected", func(t *testing.T) {
+		env := newClaimEnv(t)
+		a := env.prepareClaim(claimSecret("claim-nr"))
+		// Corrupt this tx's packet NewRoot so the IMT insert assertion fails.
+		badRoot := append([]byte(nil), a.newRoot...)
+		badRoot[0] ^= 0x01
+		a.tx.TxOut[2] = mustExtTxOut(t, cashupool.PoolState{
+			PrevRoot: a.prevRoot, NewRoot: badRoot, Size: a.thisSize,
+		})
+		require.Error(t, env.runClaim(a))
+	})
+}
+
+// reverseForBig reverses a little-endian Arkade number encoding into big-endian
+// so it can be loaded with big.Int.SetBytes.
+func reverseForBig(le []byte) []byte {
+	be := make([]byte, len(le))
+	for i := range le {
+		be[len(le)-1-i] = le[i]
+	}
+	return be
+}
+
+// corruptPoolStateNewRoot returns a copy of parentTx whose 0x05 PoolState has a
+// flipped NewRoot byte, breaking this.PrevRoot == parent.NewRoot continuity.
+func corruptPoolStateNewRoot(t *testing.T, parentTx *wire.MsgTx) *wire.MsgTx {
+	t.Helper()
+	state, err := cashupool.ParsePoolState(parentExtData(t, parentTx))
+	require.NoError(t, err)
+	state.NewRoot = append([]byte(nil), state.NewRoot...)
+	state.NewRoot[0] ^= 0x01
+
+	cp := parentTx.Copy()
+	cp.TxOut[1] = mustExtTxOut(t, state)
+	return cp
+}
+
+// parentExtData extracts the raw 0x05 PoolState payload from a parent tx's
+// extension output by re-parsing its extension.
+func parentExtData(t *testing.T, parentTx *wire.MsgTx) []byte {
+	t.Helper()
+	ext, err := extension.NewExtensionFromTx(parentTx)
+	require.NoError(t, err)
+	for _, pkt := range ext {
+		if up, ok := pkt.(extension.UnknownPacket); ok && up.PacketType == cashuPoolPacketType {
+			return up.Data
+		}
+	}
+	t.Fatalf("parent tx has no 0x05 PoolState extension")
+	return nil
 }

--- a/pkg/arkade/cashupool_claim_script_test.go
+++ b/pkg/arkade/cashupool_claim_script_test.go
@@ -1,0 +1,836 @@
+package arkade
+
+// Phase 5: the FULL Cashu nullifier-pool ClaimScript.
+//
+// This file composes the four already-built in-script phases — packet/state
+// continuity, NUT-00 hash_to_curve, NUT-12 r-blinded DLEQ, and the IMT
+// non-membership + insert — into one Arkade Script, plus a recursive-covenant
+// and value check, and exercises the whole thing through the engine over a
+// crafted current+parent transaction.
+//
+// The off-chain reference (github.com/arkade-os/emulator/pkg/arkade/cashupool)
+// is the source of truth for every value; the script re-derives each one and
+// asserts equality, so a real Cashu token must be accepted and every tampered
+// negative must be rejected.
+//
+// Run with: cd pkg/arkade && go test . -run TestClaimScript -v
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	"github.com/arkade-os/emulator/pkg/arkade/cashupool"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// Claim-model constants.
+const (
+	claimDenomSat   = 1000   // Dsat: fixed per-claim payout to the claimant.
+	claimPoolValue  = 100000 // V: value locked in the spent pool input.
+	claimTreeDepth  = 16     // IMT depth (matches imtD in the IMT script test).
+	claimMaxCounter = 4      // bounded hash_to_curve counter range (K).
+)
+
+// claimBuilder is a depth-tracked Arkade Script builder for the full claim. It
+// mirrors the per-phase builders: depth models the runtime data stack so that
+// OP_PICK offsets into the immutable base region are always correct.
+type claimBuilder struct {
+	bld   *txscript.ScriptBuilder
+	depth int
+}
+
+func (b *claimBuilder) data(v []byte)        { b.bld.AddData(v); b.depth++ }
+func (b *claimBuilder) i64(v int64)          { b.bld.AddInt64(v); b.depth++ }
+func (b *claimBuilder) op(o byte, delta int) { b.bld.AddOp(o); b.depth += delta }
+func (b *claimBuilder) rawOp(o byte)         { b.bld.AddOp(o) }
+
+// pick copies the immutable base item at absolute index baseIdx to the top.
+func (b *claimBuilder) pick(baseIdx int) {
+	b.i64(int64(b.depth - 1 - baseIdx))
+	b.op(OP_PICK, 0)
+}
+
+func (b *claimBuilder) script() []byte {
+	s, err := b.bld.Script()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// be32FromIdx leaves the 32-byte big-endian encoding of the witness number at
+// baseIdx on top. Stack: [...] -> [... be32(num)].
+func (b *claimBuilder) be32FromIdx(baseIdx int) {
+	b.pick(baseIdx)
+	b.be32Top()
+}
+
+// be32Top turns the number on top into its 32-byte big-endian fixed-width
+// encoding. Stack: [... v] -> [... be32(v)].
+func (b *claimBuilder) be32Top() {
+	b.i64(33)
+	b.op(OP_NUM2BIN, -1)
+	b.op(OP_REVERSEBYTES, 0)
+	b.i64(32)
+	b.op(OP_RIGHT, -1)
+}
+
+// appendZeroByte concatenates a single 0x00 byte onto the byte string on top.
+// Stack: [... bytes] -> [... bytes||0x00].
+func (b *claimBuilder) appendZeroByte() {
+	b.op(OP_0, 1)
+	b.op(OP_1, 1)
+	b.op(OP_NUM2BIN, -1)
+	b.op(OP_CAT, -1)
+}
+
+// digestToNum converts the 32-byte big-endian digest on top to a non-negative
+// Arkade number. Stack: [... be32] -> [... num].
+func (b *claimBuilder) digestToNum() {
+	b.op(OP_REVERSEBYTES, 0)
+	b.appendZeroByte()
+	b.op(OP_BIN2NUM, 0)
+}
+
+// modP reduces the top item modulo p. Stack: [... a] -> [... a mod p].
+func (b *claimBuilder) modP(p *big.Int) {
+	b.data(encodeBig(p))
+	b.op(OP_MOD, -1)
+}
+
+// rhsCurve computes (x³ + 7) mod p for the x_int at absolute index xIdx,
+// leaving the result on top. Stack: [...] -> [... (x³+7) mod p].
+func (b *claimBuilder) rhsCurve(xIdx int, p *big.Int) {
+	b.pick(xIdx)
+	b.pick(xIdx)
+	b.op(OP_MUL, -1)
+	b.modP(p)
+	b.pick(xIdx)
+	b.op(OP_MUL, -1)
+	b.modP(p)
+	b.data(encodeBig(big.NewInt(7)))
+	b.op(OP_ADD, -1)
+	b.modP(p)
+}
+
+// serializeUncompressed turns the affine point on top into its 65-byte SEC1
+// uncompressed encoding 0x04 || be32(x) || be32(y). Stack: [... x y] -> [... U(P)].
+func (b *claimBuilder) serializeUncompressed() {
+	b.be32Top()      // x be32(y)
+	b.op(OP_SWAP, 0) // be32(y) x
+	b.be32Top()      // be32(y) be32(x)
+	b.op(OP_4, 1)    // be32(y) be32(x) 0x04
+	b.op(OP_SWAP, 0) // be32(y) 0x04 be32(x)
+	b.op(OP_CAT, -1) // be32(y) 0x04||be32(x)
+	b.op(OP_SWAP, 0) // 0x04||be32(x) be32(y)
+	b.op(OP_CAT, -1) // 0x04||be32(x)||be32(y)
+}
+
+// scalarMulBaked leaves k*p as affine (x, y) on top for a BAKED point p, where
+// k is the base scalar at kIdx. Stack: [...] -> [... x y].
+func (b *claimBuilder) scalarMulBaked(p *btcec.PublicKey, kIdx int) {
+	px, py := pubCoords(p)
+	b.data(encodeBig(px))
+	b.data(encodeBig(py))
+	b.pick(kIdx)
+	b.op(OP_0, 1)
+	b.op(OP_ECMUL, -2)
+}
+
+// scalarMulXY leaves k*(px,py) on top for a RUNTIME point whose coords are base
+// items at xIdx, yIdx; k is the base scalar at kIdx. Stack: [...] -> [... x y].
+func (b *claimBuilder) scalarMulXY(xIdx, yIdx, kIdx int) {
+	b.pick(xIdx)
+	b.pick(yIdx)
+	b.pick(kIdx)
+	b.op(OP_0, 1)
+	b.op(OP_ECMUL, -2)
+}
+
+// ecAdd combines the two affine points on top. [... x1 y1 x2 y2] -> [... x3 y3].
+func (b *claimBuilder) ecAdd() {
+	b.op(OP_0, 1)
+	b.op(OP_ECADD, -3)
+}
+
+// Witness layout (bottom -> top), with D = claimTreeDepth. See buildClaimScript.
+const (
+	wSecret  = 0
+	wCU      = 1
+	wYx      = 2
+	wYy      = 3
+	wR       = 4
+	wCx      = 5
+	wCy      = 6
+	wE       = 7
+	wS       = 8
+	wLowVal  = 9
+	wLowNext = 10
+	wLowIdx  = 11
+	wLowPath = 12 // lowPath[i] at wLowPath+i
+)
+
+// buildClaimScript assembles the full ClaimScript.
+//
+// Witness layout (bottom -> top), with D = d:
+//
+//	idx 0 : secret
+//	idx 1 : cU                (hash_to_curve winning counter)
+//	idx 2 : Yx                (token point x; also the nullifier nf)
+//	idx 3 : Yy                (token point y)
+//	idx 4 : r                 (revealed DLEQ blinding factor)
+//	idx 5 : Cx
+//	idx 6 : Cy
+//	idx 7 : e
+//	idx 8 : s
+//	idx 9 : low.Value
+//	idx 10: low.Next
+//	idx 11: lowIdx
+//	idx 12 .. 12+D-1     : lowPath[0..D-1]
+//	idx 12+D .. 12+2D-1  : szSibs[0..D-1]
+//
+// Phase 1 reads prevRoot, newRoot and appendIdx from the 0x05 packets and
+// appends them as immutable base items above the witness:
+//
+//	idx 12+2D     : prevRoot   (32 bytes)
+//	idx 12+2D+1   : newRoot    (32 bytes)
+//	idx 12+2D+2   : appendIdx  (number, = parent size)
+func buildClaimScript(A *btcec.PublicKey, dsat int64, packetType int64, d int, kCounters uint32) []byte {
+	p := h2cFieldP()
+	n := btcec.S256().N
+	pMinus1Over2 := new(big.Int).Rsh(new(big.Int).Sub(p, big.NewInt(1)), 1)
+	pMinus1 := new(big.Int).Sub(p, big.NewInt(1))
+
+	wSzSibs := wLowPath + d
+	witnessLen := wSzSibs + d
+
+	b := &claimBuilder{bld: txscript.NewScriptBuilder(), depth: witnessLen}
+
+	// Base indices for the packet-derived items appended by Phase 1.
+	idxPrevRoot := witnessLen
+	idxNewRoot := witnessLen + 1
+	idxAppendIdx := witnessLen + 2
+
+	// ---------------------------------------------------------------------
+	// Phase 1: read state from the 0x05 packets and assert continuity.
+	// On exit the stack has gained exactly three base items in order:
+	//   [... prevRoot newRoot appendIdx].
+	// ---------------------------------------------------------------------
+
+	// this PoolState = OP_INSPECTPACKET(packetType) -> [data, flag].
+	b.i64(packetType)
+	b.op(OP_INSPECTPACKET, 1) // pops type; pushes data then flag (net +1)
+	b.op(OP_1, 1)
+	b.op(OP_EQUALVERIFY, -2) // flag must be 1 (present); leaves [... data]
+
+	// thisData on top. Extract prevRoot, newRoot, thisSize.
+	b.op(OP_DUP, 1) // data data
+	b.i64(0)
+	b.i64(32)
+	b.op(OP_SUBSTR, -2) // data prevRoot   (data[0:32])
+	b.op(OP_SWAP, 0)    // prevRoot data
+	b.op(OP_DUP, 1)     // prevRoot data data
+	b.i64(32)
+	b.i64(32)
+	b.op(OP_SUBSTR, -2) // prevRoot data newRoot   (data[32:64])
+	b.op(OP_SWAP, 0)    // prevRoot newRoot data
+	b.i64(64)
+	b.i64(4)
+	b.op(OP_SUBSTR, -2) // prevRoot newRoot sizeBytes   (data[64:68])
+	b.op(OP_BIN2NUM, 0) // prevRoot newRoot thisSize
+
+	// parent PoolState = OP_INSPECTINPUTPACKET(packetType, currentInputIndex).
+	b.i64(packetType)
+	b.op(OP_PUSHCURRENTINPUTINDEX, 1)
+	b.op(OP_INSPECTINPUTPACKET, 0) // pops type,index; pushes data then flag (net 0)
+	b.op(OP_1, 1)
+	b.op(OP_EQUALVERIFY, -2) // flag must be 1; leaves [... prevRoot newRoot thisSize pdata]
+
+	// parentNewRoot = pdata[32:64]; assert prevRoot == parentNewRoot.
+	b.op(OP_DUP, 1) // ... pdata pdata
+	b.i64(32)
+	b.i64(32)
+	b.op(OP_SUBSTR, -2) // ... pdata parentNewRoot
+	// prevRoot is 5 items below the top (prevRoot newRoot thisSize pdata parentNewRoot).
+	b.op(OP_4, 1)            // ... pdata parentNewRoot 4
+	b.op(OP_PICK, 0)         // ... pdata parentNewRoot prevRoot
+	b.op(OP_EQUALVERIFY, -2) // assert; leaves [... prevRoot newRoot thisSize pdata]
+
+	// parentSize = BIN2NUM(pdata[64:68]); assert thisSize == parentSize + 1.
+	b.i64(64)
+	b.i64(4)
+	b.op(OP_SUBSTR, -2) // ... thisSize parentSize(bytes)
+	b.op(OP_BIN2NUM, 0) // ... thisSize parentSize
+	// appendIdx = parentSize (kept below); also need thisSize == parentSize+1.
+	b.op(OP_DUP, 1)  // ... thisSize parentSize parentSize
+	b.op(OP_1, 1)    // ... thisSize parentSize parentSize 1
+	b.op(OP_ADD, -1) // ... thisSize parentSize (parentSize+1)
+	// compare to thisSize (3 below top): thisSize parentSize sum.
+	b.op(OP_2, 1)               // ... thisSize parentSize sum 2
+	b.op(OP_PICK, 0)            // ... thisSize parentSize sum thisSize
+	b.op(OP_NUMEQUALVERIFY, -2) // assert sum == thisSize; leaves [... thisSize parentSize]
+	// Drop thisSize from under parentSize, leaving appendIdx (=parentSize) on top.
+	b.op(OP_SWAP, 0)  // ... parentSize thisSize
+	b.op(OP_DROP, -1) // ... parentSize  (== appendIdx)
+	// Stack now: prevRoot newRoot appendIdx  (the three Phase-1 base items).
+
+	// ---------------------------------------------------------------------
+	// Phase 2: hash_to_curve. Prove HashToCurve(secret).x == Yx and that
+	// (Yx, Yy) is the even-Y on-curve point, over the bounded counter range.
+	// All work is consumed; net 0 to the base region.
+	// ---------------------------------------------------------------------
+
+	// msg = SHA256(DOMAIN || secret), parked on the alt stack so it survives the
+	// loop without occupying a shifting main-stack slot.
+	b.data(h2cDomain)
+	b.pick(wSecret)
+	b.op(OP_CAT, -1)
+	b.op(OP_SHA256, 0)      // ... msg
+	b.op(OP_TOALTSTACK, -1) // alt: [msg]
+
+	// Bounded first-valid loop over counters 0..k-1. legendreFromAlt pushes
+	// legendre_c using msg from the alt stack (restoring it each time).
+	legendreForCounter := func(c uint32) {
+		// recover msg, compute cand_c, restore msg.
+		b.op(OP_FROMALTSTACK, 1) // ... msg
+		b.op(OP_DUP, 1)          // ... msg msg
+		b.op(OP_TOALTSTACK, -1)  // ... msg ; alt: [msg]
+		b.data(h2cCounterLE(c))  // ... msg ctr_c
+		b.op(OP_CAT, -1)         // ... (msg||ctr_c)
+		b.op(OP_SHA256, 0)       // ... cand_c
+		b.digestToNum()          // ... x_c
+		xIdx := b.depth - 1
+		b.rhsCurve(xIdx, p) // ... x_c v
+		b.data(encodeBig(pMinus1Over2))
+		b.data(encodeBig(p))
+		b.op(OP_MODEXP, -2) // ... x_c legendre_c
+		b.op(OP_SWAP, 0)    // ... legendre_c x_c
+		b.op(OP_DROP, -1)   // ... legendre_c
+	}
+
+	for c := uint32(0); c < kCounters; c++ {
+		legendreForCounter(c)
+		depthWithLegendre := b.depth
+		b.i64(int64(c))
+		b.pick(wCU)
+		b.op(OP_LESSTHAN, -1)
+		b.op(OP_IF, -1)
+		{
+			b.data(encodeBig(pMinus1))
+			b.op(OP_NUMEQUALVERIFY, -2)
+		}
+		b.op(OP_ELSE, 0)
+		{
+			b.depth = depthWithLegendre
+			b.i64(int64(c))
+			b.pick(wCU)
+			b.op(OP_NUMEQUAL, -1)
+			b.op(OP_IF, -1)
+			{
+				b.op(OP_1, 1)
+				b.op(OP_NUMEQUALVERIFY, -2)
+			}
+			b.op(OP_ELSE, 0)
+			{
+				b.depth = depthWithLegendre
+				b.op(OP_DROP, -1)
+			}
+			b.op(OP_ENDIF, 0)
+		}
+		b.op(OP_ENDIF, 0)
+		b.depth = depthWithLegendre - 1
+	}
+
+	// Bind the winning point to the witness (Yx, Yy):
+	// x_cU = digestToNum(SHA256(msg || ctr_cU)); assert == Yx.
+	b.op(OP_FROMALTSTACK, 1) // ... msg
+	b.pick(wCU)              // ... msg cU
+	b.i64(4)
+	b.op(OP_NUM2BIN, -1) // ... msg ctr_cU
+	b.op(OP_CAT, -1)     // ... (msg||ctr_cU)
+	b.op(OP_SHA256, 0)
+	b.digestToNum() // ... x_cU
+	b.pick(wYx)
+	b.op(OP_NUMEQUALVERIFY, -2) // assert x_cU == Yx; stack back to base region
+
+	// Assert (Yx, Yy) on-curve and Yy even (NUT-00 even-Y lift).
+	b.pick(wYy)
+	b.op(OP_2, 1)
+	b.op(OP_MOD, -1)
+	b.op(OP_0NOTEQUAL, 0)
+	b.op(OP_NOT, 0)
+	b.op(OP_VERIFY, -1) // Yy even
+
+	b.pick(wYx)
+	b.data(encodeBig(p))
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_VERIFY, -1) // Yx < p
+	b.pick(wYy)
+	b.data(encodeBig(p))
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_VERIFY, -1) // Yy < p
+
+	b.pick(wYy)
+	b.pick(wYy)
+	b.op(OP_MUL, -1)
+	b.modP(p)
+	b.rhsCurve(wYx, p)
+	b.op(OP_NUMEQUALVERIFY, -2) // Yy² == Yx³+7 (mod p)
+
+	// ---------------------------------------------------------------------
+	// Phase 3: NUT-12 r-blinded DLEQ. Y = (Yx, Yy) from witness; A baked.
+	// B' = Y + r*G ; C' = C + r*A
+	// R1 = s*G + (n-e)*A ; R2 = s*B' + (n-e)*C'
+	// e' = bigendian(SHA256(U(R1)||U(R2)||U(A)||U(C'))) mod n ; assert e' == e.
+	// (n-e), B', C' are appended as temporary base items above the Phase-1
+	// items, then dropped at the end of this phase, restoring the base region.
+	// ---------------------------------------------------------------------
+
+	idxNE := b.depth // n - e
+	idxBpx := b.depth + 1
+	idxBpy := b.depth + 2
+	idxCpx := b.depth + 3
+	idxCpy := b.depth + 4
+
+	// n - e
+	b.data(encodeBig(n))
+	b.pick(wE)
+	b.op(OP_SUB, -1) // ... (n-e)
+
+	// B' = Y + r*G
+	G := scalarBaseMultPoint()
+	b.scalarMulBaked(G, wR) // r*G
+	b.pick(wYx)
+	b.pick(wYy)
+	b.ecAdd() // B' = (r*G)+Y -> Bpx Bpy
+
+	// C' = C + r*A
+	b.scalarMulBaked(A, wR) // r*A
+	b.pick(wCx)
+	b.pick(wCy)
+	b.ecAdd() // C' = (r*A)+C -> Cpx Cpy
+
+	// R1 = s*G + (n-e)*A ; serialize and park on alt stack.
+	b.scalarMulBaked(G, wS)
+	b.scalarMulBaked(A, idxNE)
+	b.ecAdd()
+	b.serializeUncompressed()
+	b.op(OP_TOALTSTACK, -1) // alt: [U(R1)]
+
+	// R2 = s*B' + (n-e)*C' ; append U(R2).
+	b.scalarMulXY(idxBpx, idxBpy, wS)
+	b.scalarMulXY(idxCpx, idxCpy, idxNE)
+	b.ecAdd()
+	b.serializeUncompressed()
+	b.op(OP_FROMALTSTACK, 1)
+	b.op(OP_SWAP, 0)
+	b.op(OP_CAT, -1)
+	b.op(OP_TOALTSTACK, -1) // alt: [U(R1)||U(R2)]
+
+	// append U(A)
+	ax, ay := pubCoords(A)
+	b.data(encodeBig(ax))
+	b.data(encodeBig(ay))
+	b.serializeUncompressed()
+	b.op(OP_FROMALTSTACK, 1)
+	b.op(OP_SWAP, 0)
+	b.op(OP_CAT, -1)
+	b.op(OP_TOALTSTACK, -1)
+
+	// append U(C')
+	b.pick(idxCpx)
+	b.pick(idxCpy)
+	b.serializeUncompressed()
+	b.op(OP_FROMALTSTACK, 1)
+	b.op(OP_SWAP, 0)
+	b.op(OP_CAT, -1) // preimage
+
+	// e' = bigendian(SHA256(preimage)) mod n
+	b.op(OP_SHA256, 0)
+	b.op(OP_REVERSEBYTES, 0)
+	b.op(OP_0, 1)
+	b.op(OP_1, 1)
+	b.op(OP_NUM2BIN, -1)
+	b.op(OP_CAT, -1)
+	b.op(OP_BIN2NUM, 0)
+	b.data(encodeBig(n))
+	b.op(OP_MOD, -1) // e'
+	b.pick(wE)
+	b.op(OP_NUMEQUALVERIFY, -2) // assert e' == e
+
+	// Drop the five DLEQ temporaries (n-e, Bpx, Bpy, Cpx, Cpy), restoring base.
+	b.op(OP_2DROP, -2)
+	b.op(OP_2DROP, -2)
+	b.op(OP_DROP, -1)
+
+	// ---------------------------------------------------------------------
+	// Phase 4: IMT non-membership + coupled insert. k = nf = Yx (witness).
+	// prevRoot/newRoot/appendIdx from Phase 1. Uses imtRecomputeRoot.
+	// All work is consumed; net 0 to the base region.
+	// ---------------------------------------------------------------------
+
+	emptyLeaf := cashupool.EmptyLeafHash()
+
+	// Non-membership: recompute root from low leaf and assert == prevRoot.
+	b.be32FromIdx(wLowVal)
+	b.be32FromIdx(wLowNext)
+	b.op(OP_CAT, -1)
+	b.op(OP_SHA256, 0) // lowLeafHash
+	imtRecomputeRoot(d, wLowIdx, wLowPath, b.op, b.rawOp, b.i64, b.pick)
+	b.pick(idxPrevRoot)
+	b.op(OP_EQUALVERIFY, -2)
+
+	// Range check: low.Value < k AND (low.Next == 0 OR k < low.Next), k = Yx.
+	b.pick(wLowVal)
+	b.pick(wYx)
+	b.op(OP_LESSTHAN, -1)
+	b.pick(wLowNext)
+	b.op(OP_0, 1)
+	b.op(OP_NUMEQUAL, -1)
+	b.pick(wYx)
+	b.pick(wLowNext)
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_BOOLOR, -1)
+	b.op(OP_BOOLAND, -1)
+	b.op(OP_VERIFY, -1)
+
+	// Insert step 1: lowPrimeHash = SHA256(be32(low.Value)||be32(k)); root1.
+	b.be32FromIdx(wLowVal)
+	b.be32FromIdx(wYx)
+	b.op(OP_CAT, -1)
+	b.op(OP_SHA256, 0)
+	imtRecomputeRoot(d, wLowIdx, wLowPath, b.op, b.rawOp, b.i64, b.pick)
+	b.op(OP_TOALTSTACK, -1) // alt: [root1]
+
+	// Insert step 2: recompute(EMPTY, appendIdx, szSibs) == root1.
+	b.data(emptyLeaf)
+	imtRecomputeRoot(d, idxAppendIdx, wSzSibs, b.op, b.rawOp, b.i64, b.pick)
+	b.op(OP_FROMALTSTACK, 1) // ... rootEmpty root1
+	b.op(OP_DUP, 1)
+	b.op(OP_TOALTSTACK, -1) // alt: [root1]
+	b.op(OP_EQUALVERIFY, -2)
+
+	// Insert step 3: newLeafHash = SHA256(be32(k)||be32(low.Next)); == newRoot.
+	b.be32FromIdx(wYx)
+	b.be32FromIdx(wLowNext)
+	b.op(OP_CAT, -1)
+	b.op(OP_SHA256, 0)
+	imtRecomputeRoot(d, idxAppendIdx, wSzSibs, b.op, b.rawOp, b.i64, b.pick)
+	b.pick(idxNewRoot)
+	b.op(OP_EQUALVERIFY, -2)
+
+	// Drop the cached root1.
+	b.op(OP_FROMALTSTACK, 1)
+	b.op(OP_DROP, -1)
+
+	// ---------------------------------------------------------------------
+	// Phase 5: covenant + value.
+	//   OP_INSPECTNUMOUTPUTS == 3
+	//   OP_INSPECTOUTPUTVALUE(0) == Dsat
+	//   OP_INSPECTOUTPUTSCRIPTPUBKEY(1) == input scriptPubKey (recursive, v1)
+	//   OP_INSPECTOUTPUTVALUE(1) == INSPECTINPUTVALUE - Dsat
+	// ---------------------------------------------------------------------
+
+	// numOutputs == 3 (claimant, pool, extension).
+	b.op(OP_INSPECTNUMOUTPUTS, 1)
+	b.i64(3)
+	b.op(OP_NUMEQUALVERIFY, -2)
+
+	// outputValue(0) == Dsat.
+	b.i64(0)
+	b.op(OP_INSPECTOUTPUTVALUE, 0)
+	b.i64(dsat)
+	b.op(OP_NUMEQUALVERIFY, -2)
+
+	// outputScriptPubKey(1) == inputScriptPubKey (segwit v1, compare programs).
+	b.i64(1)
+	b.op(OP_INSPECTOUTPUTSCRIPTPUBKEY, 1) // pops index; pushes program then version (net +1)
+	b.op(OP_1, 1)
+	b.op(OP_EQUALVERIFY, -2) // version must be segwit v1; leaves [... outProg]
+	b.op(OP_PUSHCURRENTINPUTINDEX, 1)
+	b.op(OP_INSPECTINPUTSCRIPTPUBKEY, 1) // pops index; pushes program then version (net +1)
+	b.op(OP_1, 1)
+	b.op(OP_EQUALVERIFY, -2) // version must be segwit v1; leaves [... outProg inProg]
+	b.op(OP_EQUALVERIFY, -2) // outProg == inProg
+
+	// outputValue(1) == inputValue - Dsat.
+	b.i64(1)
+	b.op(OP_INSPECTOUTPUTVALUE, 0) // outVal1
+	b.op(OP_PUSHCURRENTINPUTINDEX, 1)
+	b.op(OP_INSPECTINPUTVALUE, 0) // outVal1 inVal
+	b.i64(dsat)
+	b.op(OP_SUB, -1) // outVal1 (inVal-Dsat)
+	b.op(OP_NUMEQUALVERIFY, -2)
+
+	// All checks passed; clear the witness + Phase-1 base items so the engine
+	// sees a single truthy result.
+	for b.depth >= 2 {
+		b.op(OP_2DROP, -2)
+	}
+	for b.depth >= 1 {
+		b.op(OP_DROP, -1)
+	}
+	b.op(OP_1, 1) // success
+
+	return b.script()
+}
+
+// claimWitness assembles the witness stack in the exact order buildClaimScript
+// picks: [secret, cU, Yx, Yy, r, Cx, Cy, e, s, low.Value, low.Next, lowIdx,
+// lowPath[0..D-1], szSibs[0..D-1]].
+func claimWitness(
+	secret []byte, cU uint32,
+	Yx, Yy, r, Cx, Cy, e, s *big.Int,
+	low cashupool.Leaf, lowIdx uint32, lowPath [][]byte, szSibs [][]byte,
+) [][]byte {
+	w := make([][]byte, 0, 12+len(lowPath)+len(szSibs))
+	w = append(w, secret)
+	w = append(w, encodeBig(new(big.Int).SetUint64(uint64(cU))))
+	w = append(w, encodeBig(Yx), encodeBig(Yy))
+	w = append(w, encodeBig(r), encodeBig(Cx), encodeBig(Cy))
+	w = append(w, encodeBig(e), encodeBig(s))
+	w = append(w, encodeBig(low.Value), encodeBig(low.Next))
+	w = append(w, encodeBig(new(big.Int).SetUint64(uint64(lowIdx))))
+	for _, sib := range lowPath {
+		w = append(w, sib)
+	}
+	for _, sib := range szSibs {
+		w = append(w, sib)
+	}
+	return w
+}
+
+// ClaimEnv holds the persistent state of a Cashu nullifier pool plus the baked
+// mint key and the segwit-v1 pool program (the recursive-covenant target).
+type ClaimEnv struct {
+	t          *testing.T
+	k          *btcec.PrivateKey // mint private key
+	A          *btcec.PublicKey  // mint public key A = k*G
+	tree       *cashupool.IMT    // off-chain nullifier tree
+	poolPk     []byte            // segwit-v1 pool scriptPubKey
+	script     []byte            // the full ClaimScript
+	parentRoot []byte            // current pool root (NewRoot of the latest tx)
+	parentSize uint32            // current pool size
+}
+
+// newClaimEnv builds a fresh pool: mint key, genesis IMT, the ClaimScript, and a
+// genesis parent PoolState {PrevRoot: zero32, NewRoot: tree.Root(), Size: 1}.
+func newClaimEnv(t *testing.T) *ClaimEnv {
+	t.Helper()
+	k := mustPrivKeyFromSeed(t, "cashu-pool-mint")
+	tree := cashupool.NewIMT(claimTreeDepth)
+
+	// A deterministic 32-byte segwit-v1 program for the pool.
+	prog := make([]byte, 32)
+	for i := range prog {
+		prog[i] = byte(0x10 + i)
+	}
+	poolPk := append([]byte{OP_1, OP_DATA_32}, prog...)
+
+	return &ClaimEnv{
+		t:          t,
+		k:          k,
+		A:          k.PubKey(),
+		tree:       tree,
+		poolPk:     poolPk,
+		script:     buildClaimScript(k.PubKey(), claimDenomSat, cashuPoolPacketType, claimTreeDepth, claimMaxCounter),
+		parentRoot: append([]byte(nil), tree.Root()...),
+		parentSize: tree.Size(),
+	}
+}
+
+// claimArtifacts bundles everything needed to run one claim through the engine.
+type claimArtifacts struct {
+	tx       *wire.MsgTx
+	fetcher  ArkPrevOutFetcher
+	witness  [][]byte
+	prevRoot []byte
+	newRoot  []byte
+	thisSize uint32
+
+	// Token + IMT proof pieces, captured so a follow-up double-spend can replay
+	// the same (now stale) non-membership proof against the advanced pool state.
+	secret  []byte
+	cU      uint32
+	Yx, Yy  *big.Int
+	r       *big.Int
+	Cx, Cy  *big.Int
+	e, s    *big.Int
+	low     cashupool.Leaf
+	lowIdx  uint32
+	lowPath [][]byte
+	szSibs  [][]byte
+}
+
+// prepareClaim performs the off-chain Cashu work for claiming token `secret`,
+// mutates the pool tree by inserting the nullifier, and crafts the current +
+// parent transactions (with 0x05 PoolState packets) plus the witness.
+func (env *ClaimEnv) prepareClaim(secret []byte) claimArtifacts {
+	t := env.t
+	t.Helper()
+
+	// Cashu token: Y = HashToCurve(secret); nf = Y.x; C = k*Y.
+	Y, cU := cashupool.HashToCurve(secret)
+	require.Less(t, cU, uint32(claimMaxCounter), "secret must grind within the bounded counter range")
+	C := cashupool.Sign(env.k, Y)
+	Yx, Yy := pubCoords(Y)
+	Cx, Cy := pubCoords(C)
+	nf := new(big.Int).Set(Yx)
+
+	// NUT-12 r-blinded DLEQ proof.
+	r := mustPrivKeyFromSeed(t, "cashu-claim-r-"+string(secret))
+	e, s := cashupool.ProveProofDLEQ(env.k, Y, C, r)
+	require.True(t, cashupool.VerifyProofDLEQ(env.A, Y, C, r, e, s),
+		"off-chain DLEQ must verify before running the script")
+
+	// IMT non-membership + insert (mutates the off-chain tree).
+	low, lowIdx, lowPath := env.tree.NonMembership(nf)
+	prevRoot := append([]byte(nil), env.tree.Root()...)
+	_, newRoot, szSibs, appendIdx := env.tree.Insert(nf, low, lowIdx, lowPath)
+	require.Equal(t, env.parentSize, appendIdx, "append index must equal parent size")
+	require.Equal(t, env.parentRoot, prevRoot, "this.PrevRoot must equal parent.NewRoot")
+
+	thisSize := env.parentSize + 1
+
+	rBig := scalarToBig(&r.Key)
+	eBig := scalarToBig(e)
+	sBig := scalarToBig(s)
+
+	witness := claimWitness(secret, cU, Yx, Yy, rBig, Cx, Cy, eBig, sBig, low, lowIdx, lowPath, szSibs)
+
+	// Parent state = env's current view (the latest committed pool state).
+	parentNewRoot := append([]byte(nil), env.parentRoot...)
+	parentSize := env.parentSize
+
+	a := claimArtifacts{
+		witness:  witness,
+		prevRoot: prevRoot,
+		newRoot:  newRoot,
+		thisSize: thisSize,
+		secret:   secret,
+		cU:       cU,
+		Yx:       Yx, Yy: Yy,
+		r:  rBig,
+		Cx: Cx, Cy: Cy,
+		e: eBig, s: sBig,
+		low:     low,
+		lowIdx:  lowIdx,
+		lowPath: lowPath,
+		szSibs:  szSibs,
+	}
+	a.tx, a.fetcher = env.craftClaimTx(parentNewRoot, parentSize, prevRoot, newRoot, thisSize)
+
+	// Advance the env's view to this tx's state for any chained claim.
+	env.parentRoot = append([]byte(nil), newRoot...)
+	env.parentSize = thisSize
+
+	return a
+}
+
+// craftClaimTx builds the current claim tx (claimant, pool, ext outputs) and the
+// prevout fetcher, with a parent tx carrying parentNewRoot/parentSize in a 0x05
+// packet. The current tx's 0x05 packet carries {prevRoot, newRoot, thisSize}.
+func (env *ClaimEnv) craftClaimTx(
+	parentNewRoot []byte, parentSize uint32,
+	prevRoot, newRoot []byte, thisSize uint32,
+) (*wire.MsgTx, ArkPrevOutFetcher) {
+	t := env.t
+
+	// Parent tx: carries the parent PoolState in a 0x05 extension; its output[0]
+	// is the segwit-v1 pool program (so the recursive covenant binds output[1]).
+	parentState := cashupool.PoolState{
+		PrevRoot: env.genesisPrevRoot(),
+		NewRoot:  append([]byte(nil), parentNewRoot...),
+		Size:     parentSize,
+	}
+	parentTx := env.buildExtTx(env.poolPk, claimPoolValue, parentState)
+
+	inputOutpoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+
+	thisExtOut := mustExtTxOut(t, cashupool.PoolState{
+		PrevRoot: append([]byte(nil), prevRoot...),
+		NewRoot:  append([]byte(nil), newRoot...),
+		Size:     thisSize,
+	})
+
+	claimantPk := append([]byte{OP_1, OP_DATA_32}, make([]byte, 32)...)
+	tx := &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: inputOutpoint}},
+		TxOut: []*wire.TxOut{
+			{Value: claimDenomSat, PkScript: claimantPk},
+			{Value: claimPoolValue - claimDenomSat, PkScript: env.poolPk},
+			thisExtOut,
+		},
+	}
+
+	base := txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+		inputOutpoint: {Value: claimPoolValue, PkScript: env.poolPk},
+	})
+	fetcher := newTestArkPrevOutFetcher(
+		base,
+		map[wire.OutPoint]*wire.MsgTx{inputOutpoint: parentTx},
+		map[wire.OutPoint]uint32{inputOutpoint: 0},
+	)
+	return tx, fetcher
+}
+
+// genesisPrevRoot returns the all-zero 32-byte root used as the genesis
+// PrevRoot of the very first pool state.
+func (env *ClaimEnv) genesisPrevRoot() []byte { return make([]byte, 32) }
+
+// buildExtTx builds a parent-style tx whose output[0] carries `value` under
+// pkScript and which holds `state` in a 0x05 extension output.
+func (env *ClaimEnv) buildExtTx(pkScript []byte, value int64, state cashupool.PoolState) *wire.MsgTx {
+	extOut := mustExtTxOut(env.t, state)
+	return &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{0x00}, Index: 0}}},
+		TxOut:   []*wire.TxOut{{Value: value, PkScript: pkScript}, extOut},
+	}
+}
+
+// mustExtTxOut builds a 0x05 extension output carrying the serialized PoolState.
+func mustExtTxOut(t *testing.T, state cashupool.PoolState) *wire.TxOut {
+	t.Helper()
+	ext := extension.Extension{
+		extension.UnknownPacket{PacketType: cashuPoolPacketType, Data: state.Serialize()},
+	}
+	out, err := ext.TxOut()
+	require.NoError(t, err)
+	return out
+}
+
+// runClaim executes the ClaimScript over the prepared artifacts.
+func (env *ClaimEnv) runClaim(a claimArtifacts) error {
+	engine, err := NewEngine(
+		env.script, a.tx, 0,
+		txscript.NewSigCache(100),
+		txscript.NewTxSigHashes(a.tx, a.fetcher),
+		1_000_000,
+		a.fetcher,
+	)
+	require.NoError(env.t, err)
+	engine.SetStack(a.witness)
+	return engine.Execute()
+}
+
+func TestClaimScript(t *testing.T) {
+	t.Parallel()
+
+	// claimSecret grinds a secret whose hash_to_curve counter is within K.
+	claimSecret := func(tag string) []byte {
+		return cashupool.GrindSecret(tag, claimMaxCounter-1)
+	}
+
+	t.Run("valid claim", func(t *testing.T) {
+		env := newClaimEnv(t)
+		a := env.prepareClaim(claimSecret("claim-valid"))
+		require.NoError(t, env.runClaim(a))
+	})
+}

--- a/pkg/arkade/cashupool_dleq_script_test.go
+++ b/pkg/arkade/cashupool_dleq_script_test.go
@@ -1,0 +1,286 @@
+package arkade
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/arkade-os/emulator/pkg/arkade/cashupool"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProofDLEQScript verifies a NUT-12 r-blinded proof DLEQ entirely inside an
+// Arkade Script, matching cashupool.ProveProofDLEQ / VerifyProofDLEQ
+// byte-for-byte. This is the in-script counterpart of the off-chain reference in
+// pkg/arkade/cashupool/dleq.go.
+//
+// The wallet (spender) reveals the blinding factor r so the verifier can
+// reconstruct B' and C'. The script:
+//
+//	B' = Y + r*G ; C' = C + r*A
+//	R1 = s*G + (n-e)*A ; R2 = s*B' + (n-e)*C'
+//	e' = bigendian(SHA256(U(R1)||U(R2)||U(A)||U(C'))) mod n ; assert e' == e
+//
+// Conventions that DIFFER from dleq_script_test.go:
+//   - Points are hashed in SEC1 UNCOMPRESSED form (0x04 || be32(X) || be32(Y)).
+//   - The challenge digest is read BIG-endian (OP_REVERSEBYTES before the 0x00
+//     pad + OP_BIN2NUM), matching new(big.Int).SetBytes(d) mod n off-chain.
+//   - B' and C' are reconstructed in-script from the revealed r.
+func TestProofDLEQScript(t *testing.T) {
+	t.Parallel()
+
+	n := btcec.S256().N
+
+	// Public instance: mint key A = k*G.
+	k := mustPrivKeyFromSeed(t, "cashu-mint")
+	A := k.PubKey()
+
+	// Token point Y = HashToCurve(secret); signature C = k*Y.
+	secret := cashupool.GrindSecret("dleqs", 4)
+	Y, _ := cashupool.HashToCurve(secret)
+	C := cashupool.Sign(k, Y)
+
+	// Wallet blinding factor r.
+	r := mustPrivKeyFromSeed(t, "cashu-r")
+
+	// Off-chain proof (e, s).
+	e, s := cashupool.ProveProofDLEQ(k, Y, C, r)
+	require.True(t, cashupool.VerifyProofDLEQ(A, Y, C, r, e, s),
+		"off-chain proof must verify before testing the script")
+
+	eBig := scalarToBig(e)
+	sBig := scalarToBig(s)
+	require.NotEqual(t, 0, eBig.Sign(), "e must be non-zero so (n-e) is a valid scalar")
+	require.NotEqual(t, 0, sBig.Sign(), "s must be non-zero")
+
+	rBig := scalarToBig(&r.Key)
+	Yx, Yy := pubCoords(Y)
+	Cx, Cy := pubCoords(C)
+
+	script := buildProofDLEQVerifyScript(A, n)
+
+	// Witness order (bottom -> top): r, Yx, Yy, Cx, Cy, e, s.
+	validWitness := [][]byte{
+		encodeBig(rBig),
+		encodeBig(Yx), encodeBig(Yy),
+		encodeBig(Cx), encodeBig(Cy),
+		encodeBig(eBig), encodeBig(sBig),
+	}
+
+	witnessWith := func(rb, eb, sb *big.Int) [][]byte {
+		return [][]byte{
+			encodeBig(rb),
+			encodeBig(Yx), encodeBig(Yy),
+			encodeBig(Cx), encodeBig(Cy),
+			encodeBig(eb), encodeBig(sb),
+		}
+	}
+
+	t.Run("valid proof verifies", func(t *testing.T) {
+		require.NoError(t, runArkadeScript(t, script, validWitness))
+	})
+
+	t.Run("tampered s fails", func(t *testing.T) {
+		badS := new(big.Int).Mod(new(big.Int).Add(sBig, big.NewInt(1)), n)
+		require.Error(t, runArkadeScript(t, script, witnessWith(rBig, eBig, badS)))
+	})
+
+	t.Run("tampered e fails", func(t *testing.T) {
+		badE := new(big.Int).Mod(new(big.Int).Add(eBig, big.NewInt(1)), n)
+		require.Error(t, runArkadeScript(t, script, witnessWith(rBig, badE, sBig)))
+	})
+
+	t.Run("wrong mint key fails", func(t *testing.T) {
+		// Script commits to a different A2, but the witness proves against A.
+		k2 := mustPrivKeyFromSeed(t, "cashu-mint-other")
+		script2 := buildProofDLEQVerifyScript(k2.PubKey(), n)
+		require.Error(t, runArkadeScript(t, script2, validWitness))
+	})
+
+	t.Run("wrong r fails", func(t *testing.T) {
+		r2 := mustPrivKeyFromSeed(t, "cashu-r-other")
+		require.Error(t, runArkadeScript(t, script, witnessWith(scalarToBig(&r2.Key), eBig, sBig)))
+	})
+}
+
+// buildProofDLEQVerifyScript assembles the inline NUT-12 proof-DLEQ verifier for
+// the public mint key A = k*G and group order n. The spender's witness, bottom
+// to top, is: r, Yx, Yy, Cx, Cy, e, s.
+//
+// The builder tracks the runtime stack depth so OP_PICK offsets for the re-used
+// witness scalars (r, e, s) and the derived (n-e) are always correct.
+func buildProofDLEQVerifyScript(A *btcec.PublicKey, n *big.Int) []byte {
+	bld := txscript.NewScriptBuilder()
+
+	// depth models the data stack at runtime, starting with the seven witness
+	// items [r, Yx, Yy, Cx, Cy, e, s] pushed by SetStack.
+	depth := 7
+
+	data := func(v []byte) { bld.AddData(v); depth++ }
+	i64 := func(v int64) { bld.AddInt64(v); depth++ }
+	op := func(o byte, delta int) { bld.AddOp(o); depth += delta }
+
+	// Immutable base item indices (counted from the bottom of the stack). The
+	// first seven are the witness; n-e, B' and C' are appended as base items so
+	// they can be re-picked without recomputation.
+	const (
+		idxR   = 0
+		idxYx  = 1
+		idxYy  = 2
+		idxCx  = 3
+		idxCy  = 4
+		idxE   = 5
+		idxS   = 6
+		idxNE  = 7  // n - e
+		idxBpx = 8  // B'.x
+		idxBpy = 9  // B'.y
+		idxCpx = 10 // C'.x
+		idxCpy = 11 // C'.y
+	)
+
+	// pick copies the immutable base item at baseIdx to the top. Net effect: +1.
+	pick := func(baseIdx int) {
+		i64(int64(depth - 1 - baseIdx))
+		op(OP_PICK, 0)
+	}
+
+	// scalarMul leaves k*(px,py) as affine (x, y) on top for a BAKED point p,
+	// where k is the base scalar at kIdx. Stack: [...] -> [... x y].
+	scalarMul := func(p *btcec.PublicKey, kIdx int) {
+		px, py := pubCoords(p)
+		data(encodeBig(px))
+		data(encodeBig(py))
+		pick(kIdx)
+		op(OP_0, 1)      // curve id 0 = secp256k1
+		op(OP_ECMUL, -2) // pops x,y,k,curve; pushes x,y
+	}
+
+	// scalarMulXY leaves k*(px,py) as affine (x, y) on top for a RUNTIME point
+	// whose coords are base items at xIdx, yIdx. k is the base scalar at kIdx.
+	scalarMulXY := func(xIdx, yIdx, kIdx int) {
+		pick(xIdx)
+		pick(yIdx)
+		pick(kIdx)
+		op(OP_0, 1)      // curve id 0 = secp256k1
+		op(OP_ECMUL, -2) // pops x,y,k,curve; pushes x,y
+	}
+
+	// ecAdd combines the two affine points on top. [... x1 y1 x2 y2] -> [... x3 y3].
+	ecAdd := func() {
+		op(OP_0, 1)
+		op(OP_ECADD, -3) // pops x1,y1,x2,y2,curve; pushes x3,y3
+	}
+
+	// be32 turns a curve-coordinate number on top into its 32-byte big-endian
+	// fixed-width encoding. [... v] -> [... be32(v)]. Reuses the
+	// NUM2BIN(33)->REVERSEBYTES->RIGHT(32) trick to drop the sign byte.
+	be32 := func() {
+		i64(33)                // v 33
+		op(OP_NUM2BIN, -1)     // le33(v)
+		op(OP_REVERSEBYTES, 0) // be33(v) == 0x00 || be32(v)
+		i64(32)                // be33(v) 32
+		op(OP_RIGHT, -1)       // be32(v)
+	}
+
+	// serializeUncompressed turns the affine point on top into its 65-byte SEC1
+	// uncompressed encoding 0x04 || be32(x) || be32(y). [... x y] -> [... U(P)].
+	serializeUncompressed := func() {
+		// Stack: x y
+		be32()         // x be32(y)
+		op(OP_SWAP, 0) // be32(y) x
+		be32()         // be32(y) be32(x)
+		op(OP_4, 1)    // be32(y) be32(x) 0x04  (OP_4 pushes the single byte 0x04)
+		op(OP_SWAP, 0) // be32(y) 0x04 be32(x)
+		op(OP_CAT, -1) // be32(y) 0x04||be32(x)
+		op(OP_SWAP, 0) // 0x04||be32(x) be32(y)
+		op(OP_CAT, -1) // 0x04||be32(x)||be32(y)
+	}
+
+	G := scalarBaseMultPoint()
+
+	// --- n - e (base item idxNE) ---
+	data(encodeBig(n))
+	pick(idxE)     // copy e
+	op(OP_SUB, -1) // n - e
+
+	// --- B' = Y + r*G (leaves Bpx Bpy as base items idxBpx, idxBpy) ---
+	scalarMul(G, idxR) // r*G
+	pick(idxYx)
+	pick(idxYy)
+	ecAdd() // B' = (r*G) + Y
+
+	// --- C' = C + r*A (leaves Cpx Cpy as base items idxCpx, idxCpy) ---
+	scalarMul(A, idxR) // r*A
+	pick(idxCx)
+	pick(idxCy)
+	ecAdd() // C' = (r*A) + C
+
+	// --- R1 = s*G + (n-e)*A, serialize and park on the alt stack ---
+	scalarMul(G, idxS)  // s*G
+	scalarMul(A, idxNE) // (n-e)*A
+	ecAdd()             // R1
+	serializeUncompressed()
+	op(OP_TOALTSTACK, -1) // alt: [U(R1)]
+
+	// --- R2 = s*B' + (n-e)*C', append U(R2) to the alt-stacked preimage ---
+	scalarMulXY(idxBpx, idxBpy, idxS)  // s*B'
+	scalarMulXY(idxCpx, idxCpy, idxNE) // (n-e)*C'
+	ecAdd()                            // R2
+	serializeUncompressed()
+	op(OP_FROMALTSTACK, 1) // U(R2) U(R1)
+	op(OP_SWAP, 0)         // U(R1) U(R2)
+	op(OP_CAT, -1)         // U(R1)||U(R2)
+	op(OP_TOALTSTACK, -1)  // alt: [acc]
+
+	// --- append U(A) ---
+	ax, ay := pubCoords(A)
+	data(encodeBig(ax))
+	data(encodeBig(ay))
+	serializeUncompressed()
+	op(OP_FROMALTSTACK, 1)
+	op(OP_SWAP, 0)
+	op(OP_CAT, -1)
+	op(OP_TOALTSTACK, -1)
+
+	// --- append U(C'): build the full preimage on the main stack ---
+	pick(idxCpx)
+	pick(idxCpy)
+	serializeUncompressed()
+	op(OP_FROMALTSTACK, 1)
+	op(OP_SWAP, 0)
+	op(OP_CAT, -1) // preimage = U(R1)||U(R2)||U(A)||U(C')
+
+	// --- e' = bigendian(SHA256(preimage)) mod n ---
+	op(OP_SHA256, 0)       // 32-byte digest
+	op(OP_REVERSEBYTES, 0) // reverse so big-endian magnitude reads LE for BIN2NUM
+	op(OP_0, 1)            // 0
+	op(OP_1, 1)            // 0 1
+	op(OP_NUM2BIN, -1)     // 0x00 byte
+	op(OP_CAT, -1)         // reversed-digest||0x00 (positive little-endian)
+	op(OP_BIN2NUM, 0)      // H (big-endian value of the digest)
+	data(encodeBig(n))     // H n
+	op(OP_MOD, -1)         // e' = H mod n
+
+	// --- assert e' == e, then clean up the 12 base items and leave success ---
+	pick(idxE)
+	op(OP_NUMEQUALVERIFY, -2)
+	// Drop the 12 immutable base items: r,Yx,Yy,Cx,Cy,e,s,n-e,Bpx,Bpy,Cpx,Cpy.
+	for i := 0; i < 6; i++ {
+		op(OP_2DROP, -2)
+	}
+	op(OP_1, 1) // success
+
+	script, err := bld.Script()
+	if err != nil {
+		panic(err)
+	}
+	return script
+}
+
+// scalarBaseMultPoint returns the secp256k1 generator G as a *btcec.PublicKey.
+func scalarBaseMultPoint() *btcec.PublicKey {
+	one := new(btcec.ModNScalar)
+	one.SetInt(1)
+	return scalarBaseMult(one)
+}

--- a/pkg/arkade/cashupool_h2c_script_test.go
+++ b/pkg/arkade/cashupool_h2c_script_test.go
@@ -1,6 +1,7 @@
 package arkade
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -215,5 +216,237 @@ func TestH2CScriptC0(t *testing.T) {
 		copy(badY, y)
 		badY[0] ^= 0x01
 		require.Error(t, runArkadeScript(t, script, [][]byte{secret, badY}))
+	})
+}
+
+// h2cMsgFromSecret pushes msg = SHA256(DOMAIN||secret) for the secret at
+// absolute stack index secretIdx, leaving msg on top.
+//
+// Stack: [...] -> [... msg]
+func (b *h2cBuilder) h2cMsgFromSecret(secretIdx int) {
+	b.data(h2cDomain) // ... DOMAIN
+	b.pick(secretIdx) // ... DOMAIN secret
+	b.op(OP_CAT, -1)  // ... (DOMAIN||secret)
+	b.op(OP_SHA256, 0)
+}
+
+// candXFromMsg computes x_int = digestToNum(SHA256(msg || ctr_c)) for the msg
+// at absolute stack index msgIdx and the loop constant counter c, leaving x_int
+// on top. msg is left untouched on the stack.
+//
+// Stack: [...] -> [... x_int]
+func (b *h2cBuilder) candXFromMsg(msgIdx int, c uint32) {
+	b.pick(msgIdx)          // ... msg
+	b.data(h2cCounterLE(c)) // ... msg ctr_c
+	b.op(OP_CAT, -1)        // ... (msg||ctr_c)
+	b.op(OP_SHA256, 0)      // ... cand_c
+	b.digestToNum()         // ... x_int
+}
+
+// legendreForCounter computes legendre_c = ((x_c³+7) mod p)^((p-1)/2) mod p for
+// the loop constant counter c and the msg at absolute index msgIdx, leaving only
+// legendre_c on top (the intermediate candidate x is dropped). For a residue
+// (a point exists at this counter) legendre_c == 1; for a non-residue it is p-1.
+//
+// Stack: [...] -> [... legendre_c]
+func (b *h2cBuilder) legendreForCounter(msgIdx int, c uint32, p, pMinus1Over2 *big.Int) {
+	b.candXFromMsg(msgIdx, c) // ... x_c
+	xIdx := b.depth - 1
+	b.rhsCurve(xIdx, p) // ... x_c v=(x_c³+7) mod p   (base)
+	b.data(encodeBig(pMinus1Over2))
+	b.data(encodeBig(p))
+	b.op(OP_MODEXP, -2) // ... x_c legendre_c   (pops base, exp, modulus)
+	// drop x_c from beneath legendre_c.
+	b.op(OP_SWAP, 0) // ... legendre_c x_c
+	b.op(OP_DROP, -1)
+}
+
+// buildH2CScript builds the Stage B script that verifies hash_to_curve over a
+// bounded counter range 0..K-1, enforcing that the witness winning counter cU
+// is the *first* counter whose candidate x is a quadratic residue.
+//
+// Witness layout (bottom -> top): [secret, cU, y].
+//
+// For each loop constant c in 0..K-1 the script computes legendre_c and, driven
+// by comparing c to cU with OP_LESSTHAN / OP_NUMEQUAL and OP_IF/OP_ELSE/OP_ENDIF:
+//   - c < cU  : assert legendre_c == p-1 (every earlier counter is a non-residue)
+//   - c == cU : assert legendre_c == 1   (the winning counter is a residue)
+//   - c > cU  : no constraint (drop legendre_c)
+//
+// After the loop the winning point is bound to the witness: cand_cU is recomputed
+// from the witness cU, and y is checked even, < p and on-curve against x_cU.
+func buildH2CScript(k uint32) []byte {
+	p := h2cFieldP()
+	pMinus1Over2 := new(big.Int).Rsh(new(big.Int).Sub(p, big.NewInt(1)), 1)
+	pMinus1 := new(big.Int).Sub(p, big.NewInt(1))
+
+	// Witness: [secret(idx0), cU(idx1), y(idx2)].
+	const (
+		secretIdx = 0
+		cUIdx     = 1
+		yIdx      = 2
+	)
+	b := newH2CBuilder(3)
+
+	// msg = SHA256(DOMAIN||secret), kept as a base item at absolute index 3.
+	b.h2cMsgFromSecret(secretIdx)
+	const msgIdx = 3
+
+	// --- bounded first-valid loop over counters 0..k-1 ---
+	for c := uint32(0); c < k; c++ {
+		// legendre_c on top (depth grows by 1 vs. loop-start).
+		b.legendreForCounter(msgIdx, c, p, pMinus1Over2)
+
+		// depthWithLegendre is the runtime depth with legendre_c on top; every
+		// branch below consumes exactly legendre_c, so the post-ENDIF depth is
+		// depthWithLegendre-1 on every path. We restore b.depth to that value
+		// after emitting the (multi-branch) conditional.
+		depthWithLegendre := b.depth
+
+		// c < cU ?
+		b.i64(int64(c))
+		b.pick(cUIdx)
+		b.op(OP_LESSTHAN, -1)
+		b.op(OP_IF, -1)
+		{
+			// earlier counter: must be a non-residue (legendre == p-1).
+			b.data(encodeBig(pMinus1))
+			b.op(OP_NUMEQUALVERIFY, -2)
+		}
+		b.op(OP_ELSE, 0)
+		{
+			// reset builder depth to the start of this branch: legendre_c is
+			// still on the stack (the OP_IF condition was already consumed).
+			b.depth = depthWithLegendre
+			// c == cU ?
+			b.i64(int64(c))
+			b.pick(cUIdx)
+			b.op(OP_NUMEQUAL, -1)
+			b.op(OP_IF, -1)
+			{
+				// winning counter: must be a residue (legendre == 1).
+				b.op(OP_1, 1)
+				b.op(OP_NUMEQUALVERIFY, -2)
+			}
+			b.op(OP_ELSE, 0)
+			{
+				// later counter: no constraint, drop legendre_c.
+				b.depth = depthWithLegendre
+				b.op(OP_DROP, -1)
+			}
+			b.op(OP_ENDIF, 0)
+		}
+		b.op(OP_ENDIF, 0)
+
+		// Normalise depth: all paths removed exactly legendre_c.
+		b.depth = depthWithLegendre - 1
+	}
+
+	// --- bind the winning point to the witness y ---
+	// x_cU = digestToNum(SHA256(msg || ctr_cU)), using the witness cU.
+	b.pick(msgIdx)        // ... msg
+	b.pick(cUIdx)         // ... msg cU
+	b.i64(4)              // ... msg cU 4
+	b.op(OP_NUM2BIN, -1)  // ... msg ctr_cU (4-byte LE of cU)
+	b.op(OP_CAT, -1)      // ... (msg||ctr_cU)
+	b.op(OP_SHA256, 0)    // ... cand_cU
+	b.digestToNum()       // ... x_cU
+	xCUIdx := b.depth - 1 // absolute index of x_cU
+
+	// y_int = digestToNum(y).
+	b.pick(yIdx)    // ... x_cU y
+	b.digestToNum() // ... x_cU y_int
+	yIntIdx := b.depth - 1
+
+	// assert x_cU < p and y_int < p.
+	b.pick(xCUIdx)
+	b.data(encodeBig(p))
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_VERIFY, -1)
+	b.pick(yIntIdx)
+	b.data(encodeBig(p))
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_VERIFY, -1)
+
+	// assert y_int even.
+	b.pick(yIntIdx)
+	b.op(OP_2, 1)
+	b.op(OP_MOD, -1)
+	b.op(OP_0NOTEQUAL, 0)
+	b.op(OP_NOT, 0)
+	b.op(OP_VERIFY, -1)
+
+	// on-curve: y_int² mod p == (x_cU³ + 7) mod p.
+	b.pick(yIntIdx)
+	b.pick(yIntIdx)
+	b.op(OP_MUL, -1)
+	b.modP(p)
+	b.rhsCurve(xCUIdx, p)
+	b.op(OP_NUMEQUALVERIFY, -2)
+
+	// Clean up: drop x_cU, y_int, msg, and the three witness items, leave OP_1.
+	b.op(OP_2DROP, -2) // x_cU, y_int
+	b.op(OP_2DROP, -2) // msg, y
+	b.op(OP_2DROP, -2) // cU, secret
+	b.op(OP_1, 1)
+
+	return b.script()
+}
+
+func TestH2CScript(t *testing.T) {
+	t.Parallel()
+
+	const k = 4
+	script := buildH2CScript(k)
+
+	// Vector 1: a counter-0 secret.
+	secret0 := cashupool.GrindSecret("h2c-b0", 0)
+	point0, c0 := cashupool.HashToCurve(secret0)
+	require.Equal(t, uint32(0), c0)
+	y0 := h2cWitnessY(point0)
+
+	// Vector 2: a secret whose winning counter is >= 1 and < k.
+	var secret1 []byte
+	var c1 uint32
+	var point1 *btcec.PublicKey
+	for i := 0; ; i++ {
+		s := []byte(fmt.Sprintf("h2c-b1-%d", i))
+		pt, c := cashupool.HashToCurve(s)
+		if c >= 1 && c < k {
+			secret1, c1, point1 = s, c, pt
+			break
+		}
+	}
+	y1 := h2cWitnessY(point1)
+
+	cBytes := func(c uint32) []byte { return encodeBig(big.NewInt(int64(c))) }
+
+	t.Run("counter-0 vector verifies", func(t *testing.T) {
+		require.NoError(t, runArkadeScript(t, script, [][]byte{secret0, cBytes(c0), y0}))
+	})
+
+	t.Run("counter>=1 vector verifies", func(t *testing.T) {
+		require.NoError(t, runArkadeScript(t, script, [][]byte{secret1, cBytes(c1), y1}))
+	})
+
+	t.Run("wrong y fails", func(t *testing.T) {
+		badY := make([]byte, len(y1))
+		copy(badY, y1)
+		badY[0] ^= 0x01
+		require.Error(t, runArkadeScript(t, script, [][]byte{secret1, cBytes(c1), badY}))
+	})
+
+	t.Run("cU one less than true fails", func(t *testing.T) {
+		// cU = c1-1 is an earlier (non-residue) counter wrongly claimed as the
+		// winner; the c==cU branch asserts a residue and fails.
+		require.GreaterOrEqual(t, c1, uint32(1))
+		require.Error(t, runArkadeScript(t, script, [][]byte{secret1, cBytes(c1 - 1), y1}))
+	})
+
+	t.Run("cU larger than true fails", func(t *testing.T) {
+		// cU = c1+1 (still < k) skips the true residue c1; at c==c1 (< cU) the
+		// loop asserts a non-residue and fails.
+		require.Less(t, c1+1, uint32(k))
+		require.Error(t, runArkadeScript(t, script, [][]byte{secret1, cBytes(c1 + 1), y1}))
 	})
 }

--- a/pkg/arkade/cashupool_h2c_script_test.go
+++ b/pkg/arkade/cashupool_h2c_script_test.go
@@ -1,0 +1,219 @@
+package arkade
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/arkade-os/emulator/pkg/arkade/cashupool"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// This file verifies Cashu NUT-00 hash_to_curve entirely inside an Arkade
+// Script, mirroring the off-chain reference in
+// github.com/arkade-os/emulator/pkg/arkade/cashupool.
+//
+// NUT-00 hash_to_curve:
+//
+//	DOMAIN = "Secp256k1_HashToCurve_Cashu_"
+//	msg    = SHA256(DOMAIN || secret)
+//	for c = 0, 1, 2, …:
+//	    cand_c = SHA256(msg || uint32_le(c))   // 32-byte big-endian SEC1 x
+//	    if cand_c is a valid secp256k1 x-coordinate: point exists at counter c
+//
+// The first counter c whose cand_c is a valid x-coordinate "wins"; the point
+// is the even-Y lift of cand_c (0x02 prefix).
+//
+// In script we read each 32-byte big-endian digest as a non-negative Arkade
+// number with the digest-to-number trick from dleq_script_test.go: reverse the
+// bytes (big-endian -> little-endian of the same value), append a 0x00 byte so
+// the high bit is never read as a sign bit, then OP_BIN2NUM.
+//
+// A counter is a residue (point exists) iff v = x³ + 7 is a quadratic residue
+// mod p, tested via the Euler criterion: legendre = v^((p-1)/2) mod p, which is
+// 1 for a residue and p-1 for a non-residue. The winning counter additionally
+// has its full point verified: the witness supplies the big-endian Y, and the
+// script asserts Y is even, x < p, y < p, and y² ≡ x³ + 7 (mod p).
+
+// h2cDomain is the NUT-00 hash_to_curve domain tag, identical to
+// cashupool.DomainSeparator.
+var h2cDomain = []byte("Secp256k1_HashToCurve_Cashu_")
+
+// h2cFieldP returns the secp256k1 field modulus p.
+func h2cFieldP() *big.Int {
+	return new(big.Int).Set(btcec.S256().P)
+}
+
+// h2cCounterLE returns the 4-byte little-endian encoding of counter c, exactly
+// as NUT-00 appends it to msg before SHA256.
+func h2cCounterLE(c uint32) []byte {
+	return []byte{byte(c), byte(c >> 8), byte(c >> 16), byte(c >> 24)}
+}
+
+// h2cWitnessY returns the 32-byte big-endian Y coordinate of the hash_to_curve
+// point for secret, as the script's witness expects it.
+func h2cWitnessY(point *btcec.PublicKey) []byte {
+	u := point.SerializeUncompressed() // 0x04 || be32(x) || be32(y)
+	return u[33:65]
+}
+
+// h2cBuilder wraps a txscript.ScriptBuilder with the depth-tracked emit helpers
+// used throughout the in-script crypto tests. depth models the runtime data
+// stack so OP_PICK offsets stay correct.
+type h2cBuilder struct {
+	bld   *txscript.ScriptBuilder
+	depth int
+}
+
+func newH2CBuilder(initialDepth int) *h2cBuilder {
+	return &h2cBuilder{bld: txscript.NewScriptBuilder(), depth: initialDepth}
+}
+
+func (b *h2cBuilder) data(v []byte)        { b.bld.AddData(v); b.depth++ }
+func (b *h2cBuilder) i64(v int64)          { b.bld.AddInt64(v); b.depth++ }
+func (b *h2cBuilder) op(o byte, delta int) { b.bld.AddOp(o); b.depth += delta }
+
+// pick copies the item at absolute stack index baseIdx (0 = bottom) to the top.
+func (b *h2cBuilder) pick(baseIdx int) {
+	b.i64(int64(b.depth - 1 - baseIdx))
+	b.op(OP_PICK, 0)
+}
+
+func (b *h2cBuilder) script() []byte {
+	s, err := b.bld.Script()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// appendZeroByte synthesizes a single 0x00 byte on top of the stack and
+// concatenates it onto the byte string below it. Minimal-push forbids a literal
+// 0x00 data push, so the byte is built via OP_0 OP_1 OP_NUM2BIN.
+//
+// Stack: [... bytes] -> [... bytes||0x00]
+func (b *h2cBuilder) appendZeroByte() {
+	b.op(OP_0, 1)        // bytes 0
+	b.op(OP_1, 1)        // bytes 0 1
+	b.op(OP_NUM2BIN, -1) // bytes 0x00
+	b.op(OP_CAT, -1)     // bytes||0x00
+}
+
+// digestToNum converts the 32-byte big-endian digest on top of the stack to a
+// non-negative Arkade number: reverse to little-endian, append 0x00, BIN2NUM.
+//
+// Stack: [... be32] -> [... num]
+func (b *h2cBuilder) digestToNum() {
+	b.op(OP_REVERSEBYTES, 0) // little-endian of the same magnitude
+	b.appendZeroByte()       // force non-negative
+	b.op(OP_BIN2NUM, 0)      // integer
+}
+
+// modP reduces the top item modulo p. Stack: [... a] -> [... a mod p]
+func (b *h2cBuilder) modP(p *big.Int) {
+	b.data(encodeBig(p))
+	b.op(OP_MOD, -1)
+}
+
+// rhsCurve computes (x³ + 7) mod p for the x_int currently at absolute stack
+// index xIdx, leaving the result on top. Every intermediate stays reduced.
+//
+// Stack: [...] -> [... (x³+7) mod p]
+func (b *h2cBuilder) rhsCurve(xIdx int, p *big.Int) {
+	b.pick(xIdx)     // x
+	b.pick(xIdx)     // x x
+	b.op(OP_MUL, -1) // x²
+	b.modP(p)        // x² mod p
+	b.pick(xIdx)     // (x² mod p) x
+	b.op(OP_MUL, -1) // x³ (reduced * x)
+	b.modP(p)        // x³ mod p
+	b.data(encodeBig(big.NewInt(7)))
+	b.op(OP_ADD, -1) // x³+7
+	b.modP(p)        // (x³+7) mod p
+}
+
+// buildH2CScriptC0 builds the Stage A script that assumes the winning counter is
+// 0. Witness layout (bottom -> top): [secret, y].
+//
+//	cand_0 = SHA256(SHA256(DOMAIN||secret) || 0x00000000)
+//	x_int  = digestToNum(cand_0)
+//	y_int  = digestToNum(y)
+//	assert y_int even, x_int < p, y_int < p, and
+//	       y_int² ≡ x_int³ + 7 (mod p)
+//	leave OP_1
+func buildH2CScriptC0() []byte {
+	p := h2cFieldP()
+
+	// Witness: [secret(idx0), y(idx1)].
+	b := newH2CBuilder(2)
+
+	// --- x_int = digestToNum(SHA256(SHA256(DOMAIN||secret) || ctr0)) ---
+	b.data(h2cDomain) // secret y DOMAIN
+	b.pick(0)         // secret y DOMAIN secret
+	b.op(OP_CAT, -1)  // secret y (DOMAIN||secret)
+	b.op(OP_SHA256, 0)
+	b.data(h2cCounterLE(0)) // secret y msg ctr0
+	b.op(OP_CAT, -1)        // secret y (msg||ctr0)
+	b.op(OP_SHA256, 0)      // secret y cand_0
+	b.digestToNum()         // secret y x_int  (x_int at idx2)
+
+	// --- y_int = digestToNum(y) ---
+	b.pick(1)       // secret y x_int y
+	b.digestToNum() // secret y x_int y_int  (y_int at idx3)
+
+	// assert x_int < p and y_int < p (operands fit the EC field).
+	b.pick(2) // ... x_int
+	b.data(encodeBig(p))
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_VERIFY, -1)
+	b.pick(3) // ... y_int
+	b.data(encodeBig(p))
+	b.op(OP_LESSTHAN, -1)
+	b.op(OP_VERIFY, -1)
+
+	// assert y_int is even (NUT-00 picks the even-Y lift).
+	b.pick(3)     // ... y_int
+	b.op(OP_2, 1) // ... y_int 2
+	b.op(OP_MOD, -1)
+	b.op(OP_0NOTEQUAL, 0) // 1 if odd, 0 if even
+	b.op(OP_NOT, 0)       // 1 if even
+	b.op(OP_VERIFY, -1)
+
+	// on-curve: y_int² mod p == (x_int³ + 7) mod p.
+	b.pick(3)        // ... y_int
+	b.pick(3)        // ... y_int y_int
+	b.op(OP_MUL, -1) // y_int²
+	b.modP(p)        // y_int² mod p
+	b.rhsCurve(2, p) // ... lhs rhs
+	b.op(OP_NUMEQUALVERIFY, -2)
+
+	// Clean up the four base items and leave success.
+	b.op(OP_2DROP, -2) // drop x_int, y_int
+	b.op(OP_2DROP, -2) // drop secret, y
+	b.op(OP_1, 1)
+
+	return b.script()
+}
+
+func TestH2CScriptC0(t *testing.T) {
+	t.Parallel()
+
+	secret := cashupool.GrindSecret("h2c-c0", 0)
+	point, c := cashupool.HashToCurve(secret)
+	require.Equal(t, uint32(0), c, "GrindSecret must yield a counter-0 secret")
+
+	script := buildH2CScriptC0()
+	y := h2cWitnessY(point)
+
+	t.Run("valid counter-0 witness verifies", func(t *testing.T) {
+		require.NoError(t, runArkadeScript(t, script, [][]byte{secret, y}))
+	})
+
+	t.Run("tampered y fails", func(t *testing.T) {
+		badY := make([]byte, len(y))
+		copy(badY, y)
+		badY[0] ^= 0x01
+		require.Error(t, runArkadeScript(t, script, [][]byte{secret, badY}))
+	})
+}

--- a/pkg/arkade/cashupool_imt_script_test.go
+++ b/pkg/arkade/cashupool_imt_script_test.go
@@ -1,6 +1,7 @@
 package arkade
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 	"testing"
@@ -10,8 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This file verifies an Indexed Merkle Tree (IMT) non-membership proof entirely
-// inside an Arkade Script, mirroring the off-chain reference in
+// This file verifies an Indexed Merkle Tree (IMT) non-membership proof and a
+// coupled non-membership + insert update entirely inside an Arkade Script,
+// mirroring the off-chain reference in
 // github.com/arkade-os/emulator/pkg/arkade/cashupool (imt.go).
 //
 // The on-chain core is a positional Merkle walk that recomputes a root from a
@@ -185,6 +187,121 @@ func buildIMTNonMembershipScript(d int, prevRoot []byte) []byte {
 	return script
 }
 
+// buildIMTInsertScript builds a locking script that verifies a coupled
+// non-membership + insert update: it proves k is absent under prevRoot and that
+// inserting k transitions the tree to newRoot, via the IMT dual update.
+//
+// Witness layout (bottom of stack first):
+//
+//	[ low.Value, low.Next, lowIdx, lowPath[0..D-1], k, appendIdx, szSibs[0..D-1] ]
+func buildIMTInsertScript(d int, prevRoot, newRoot []byte) []byte {
+	bld := txscript.NewScriptBuilder()
+
+	const (
+		lowValIdx  = 0
+		lowNextIdx = 1
+		lowIdxIdx  = 2
+		lowPathIdx = 3
+	)
+	kIdx := lowPathIdx + d
+	appendIdxIdx := kIdx + 1
+	szSibsIdx := appendIdxIdx + 1 // szSibs[i] at szSibsIdx+i
+
+	depth := szSibsIdx + d // number of witness items pushed by SetStack
+
+	data := func(v []byte) { bld.AddData(v); depth++ }
+	i64 := func(v int64) { bld.AddInt64(v); depth++ }
+	op := func(o byte, delta int) { bld.AddOp(o); depth += delta }
+	rawOp := func(o byte) { bld.AddOp(o) }
+
+	pick := func(baseIdx int) {
+		i64(int64(depth - 1 - baseIdx))
+		op(OP_PICK, 0)
+	}
+
+	be32 := func(baseIdx int) {
+		pick(baseIdx)
+		i64(33)
+		op(OP_NUM2BIN, -1)
+		op(OP_REVERSEBYTES, 0)
+		i64(32)
+		op(OP_RIGHT, -1)
+	}
+
+	// --- non-membership (identical checks to Stage A) ---
+	be32(lowValIdx)
+	be32(lowNextIdx)
+	op(OP_CAT, -1)
+	op(OP_SHA256, 0)
+	imtRecomputeRoot(d, lowIdxIdx, lowPathIdx, op, rawOp, i64, pick)
+	data(prevRoot)
+	op(OP_EQUALVERIFY, -2)
+
+	pick(lowValIdx)
+	pick(kIdx)
+	op(OP_LESSTHAN, -1)
+	pick(lowNextIdx)
+	op(OP_0, 1)
+	op(OP_NUMEQUAL, -1)
+	pick(kIdx)
+	pick(lowNextIdx)
+	op(OP_LESSTHAN, -1)
+	op(OP_BOOLOR, -1)
+	op(OP_BOOLAND, -1)
+	op(OP_VERIFY, -1)
+
+	// --- insert (coupled dual update) ---
+
+	// 1. lowPrimeHash = SHA256(be32(low.Value) || be32(k)); root1 from low slot.
+	be32(lowValIdx)  // [... be32(low.Value)]
+	be32(kIdx)       // [... be32(low.Value) be32(k)]
+	op(OP_CAT, -1)   // [... le64]
+	op(OP_SHA256, 0) // [... lowPrimeHash]
+	imtRecomputeRoot(d, lowIdxIdx, lowPathIdx, op, rawOp, i64, pick)
+	// [... root1]; keep it on the alt stack for the next two checks.
+	op(OP_TOALTSTACK, -1) // alt: [root1]
+
+	// 2. recompute(EMPTY, appendIdx, szSibs) == root1: append slot is empty and
+	//    szSibs are consistent with root1.
+	emptyLeaf := cashupool.EmptyLeafHash()
+	data(emptyLeaf) // [... EMPTY]
+	imtRecomputeRoot(d, appendIdxIdx, szSibsIdx, op, rawOp, i64, pick)
+	op(OP_FROMALTSTACK, 1) // [... rootEmpty root1]
+	op(OP_DUP, 1)          // [... rootEmpty root1 root1]
+	op(OP_TOALTSTACK, -1)  // alt: [root1]; [... rootEmpty root1]
+	op(OP_EQUALVERIFY, -2) // assert rootEmpty == root1
+
+	// 3. newLeafHash = SHA256(be32(k) || be32(low.Next)); recompute over the
+	//    append slot and assert == newRoot.
+	be32(kIdx)       // [... be32(k)]
+	be32(lowNextIdx) // [... be32(k) be32(low.Next)]
+	op(OP_CAT, -1)   // [... le64]
+	op(OP_SHA256, 0) // [... newLeafHash]
+	imtRecomputeRoot(d, appendIdxIdx, szSibsIdx, op, rawOp, i64, pick)
+	data(newRoot)          // [... rootNew newRoot]
+	op(OP_EQUALVERIFY, -2) // assert rootNew == newRoot
+
+	// Drop the cached root1 left on the alt stack.
+	op(OP_FROMALTSTACK, 1) // [... root1]
+	op(OP_DROP, -1)        // [...]
+
+	// All checks passed; clear the witness items so the engine sees a single
+	// truthy result.
+	for depth >= 2 {
+		op(OP_2DROP, -2)
+	}
+	for depth >= 1 {
+		op(OP_DROP, -1)
+	}
+	op(OP_1, 1) // success
+
+	script, err := bld.Script()
+	if err != nil {
+		panic(err)
+	}
+	return script
+}
+
 // imtNonMembershipWitness builds the witness stack for the non-membership
 // script: [ low.Value, low.Next, lowIdx, lowPath[0..D-1], k ].
 func imtNonMembershipWitness(low cashupool.Leaf, lowIdx uint32, lowPath [][]byte, k *big.Int) [][]byte {
@@ -196,6 +313,20 @@ func imtNonMembershipWitness(low cashupool.Leaf, lowIdx uint32, lowPath [][]byte
 		w = append(w, s)
 	}
 	w = append(w, encodeBig(k))
+	return w
+}
+
+// imtInsertWitness extends the non-membership witness with the insert proof:
+// [ ..., k, appendIdx, szSibs[0..D-1] ].
+func imtInsertWitness(
+	low cashupool.Leaf, lowIdx uint32, lowPath [][]byte, k *big.Int,
+	appendIdx uint32, szSibs [][]byte,
+) [][]byte {
+	w := imtNonMembershipWitness(low, lowIdx, lowPath, k)
+	w = append(w, encodeBig(new(big.Int).SetUint64(uint64(appendIdx))))
+	for _, s := range szSibs {
+		w = append(w, s)
+	}
 	return w
 }
 
@@ -278,6 +409,74 @@ func TestIMTNonMembershipScript(t *testing.T) {
 
 		script := buildIMTNonMembershipScript(imtD, tree.Root())
 		w := imtNonMembershipWitness(low, lowIdx, lowPath, k2)
+		require.Error(t, runArkadeScript(t, script, w))
+	})
+}
+
+func TestIMTInsertScript(t *testing.T) {
+	t.Parallel()
+
+	// setup returns a fresh tree (with a couple of seed leaves) plus a valid
+	// insert proof for key k.
+	setup := func(t *testing.T) (prevRoot, newRoot []byte, low cashupool.Leaf,
+		lowIdx uint32, lowPath [][]byte, k *big.Int, appendIdx uint32, szSibs [][]byte) {
+		t.Helper()
+		tree := cashupool.NewIMT(imtD)
+		for _, tag := range []string{"imt-seed-1", "imt-seed-2"} {
+			kk := imtKFromTag(tag)
+			lo, li, lp := tree.NonMembership(kk)
+			tree.Insert(kk, lo, li, lp)
+		}
+		k = imtKFromTag("imt-a")
+		low, lowIdx, lowPath = tree.NonMembership(k)
+		prevRoot = append([]byte(nil), tree.Root()...) // BEFORE insert
+		var root1 []byte
+		root1, newRoot, szSibs, appendIdx = tree.Insert(k, low, lowIdx, lowPath)
+
+		// Sanity: in-script-equivalent root computations match the reference.
+		lowPrime := cashupool.Leaf{Value: low.Value, Next: k}
+		require.Equal(t, root1, cashupool.RecomputeRoot(imtD, lowIdx, lowPrime.Hash(), lowPath))
+		require.Equal(t, root1, cashupool.RecomputeRoot(imtD, appendIdx, cashupool.EmptyLeafHash(), szSibs))
+		newLeaf := cashupool.Leaf{Value: k, Next: low.Next}
+		require.Equal(t, newRoot, cashupool.RecomputeRoot(imtD, appendIdx, newLeaf.Hash(), szSibs))
+		return
+	}
+
+	t.Run("valid insert verifies", func(t *testing.T) {
+		prevRoot, newRoot, low, lowIdx, lowPath, k, appendIdx, szSibs := setup(t)
+		script := buildIMTInsertScript(imtD, prevRoot, newRoot)
+		w := imtInsertWitness(low, lowIdx, lowPath, k, appendIdx, szSibs)
+		require.NoError(t, runArkadeScript(t, script, w))
+	})
+
+	t.Run("wrong newRoot fails", func(t *testing.T) {
+		prevRoot, newRoot, low, lowIdx, lowPath, k, appendIdx, szSibs := setup(t)
+		badRoot := append([]byte(nil), newRoot...)
+		badRoot[0] ^= 0x01
+		script := buildIMTInsertScript(imtD, prevRoot, badRoot)
+		w := imtInsertWitness(low, lowIdx, lowPath, k, appendIdx, szSibs)
+		require.Error(t, runArkadeScript(t, script, w))
+	})
+
+	t.Run("tampered szSibs fails", func(t *testing.T) {
+		prevRoot, newRoot, low, lowIdx, lowPath, k, appendIdx, szSibs := setup(t)
+		bad := make([][]byte, len(szSibs))
+		copy(bad, szSibs)
+		tampered := append([]byte(nil), bad[0]...)
+		tampered[0] ^= 0x01
+		bad[0] = tampered
+		script := buildIMTInsertScript(imtD, prevRoot, newRoot)
+		w := imtInsertWitness(low, lowIdx, lowPath, k, appendIdx, bad)
+		require.Error(t, runArkadeScript(t, script, w))
+	})
+
+	t.Run("insert proof for a different k fails", func(t *testing.T) {
+		prevRoot, newRoot, low, lowIdx, lowPath, _, appendIdx, szSibs := setup(t)
+		// Use a different key than the one the proof was built for.
+		kOther := imtKFromTag("imt-different")
+		require.False(t, bytes.Equal(encodeBig(kOther), encodeBig(imtKFromTag("imt-a"))))
+		script := buildIMTInsertScript(imtD, prevRoot, newRoot)
+		w := imtInsertWitness(low, lowIdx, lowPath, kOther, appendIdx, szSibs)
 		require.Error(t, runArkadeScript(t, script, w))
 	})
 }

--- a/pkg/arkade/cashupool_imt_script_test.go
+++ b/pkg/arkade/cashupool_imt_script_test.go
@@ -1,0 +1,283 @@
+package arkade
+
+import (
+	"crypto/sha256"
+	"math/big"
+	"testing"
+
+	"github.com/arkade-os/emulator/pkg/arkade/cashupool"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// This file verifies an Indexed Merkle Tree (IMT) non-membership proof entirely
+// inside an Arkade Script, mirroring the off-chain reference in
+// github.com/arkade-os/emulator/pkg/arkade/cashupool (imt.go).
+//
+// The on-chain core is a positional Merkle walk that recomputes a root from a
+// 32-byte leaf hash, a leaf index, and D sibling hashes. It matches
+// cashupool.RecomputeRoot byte-for-byte: the walk is LSB-first and at level i,
+//
+//	bit == 0  =>  current is LEFT  child:  SHA256(cur || sib)
+//	bit == 1  =>  current is RIGHT child:  SHA256(sib || cur)
+//
+// where bit is the i-th least-significant bit of the leaf index. Leaf hashes
+// are SHA256(be32(Value) || be32(Next)); the 32-byte big-endian encoding of a
+// script number is produced with NUM2BIN(33) -> REVERSEBYTES -> RIGHT(32).
+//
+// imtD is the fixed tree depth used throughout the in-script tests.
+const imtD = 16
+
+// imtKFromTag returns a 256-bit nullifier value derived from a tag, used as the
+// IMT key k. It is the SHA256 of the tag interpreted as a big-endian unsigned
+// integer, which is non-zero with overwhelming probability.
+func imtKFromTag(tag string) *big.Int {
+	d := sha256.Sum256([]byte(tag))
+	return new(big.Int).SetBytes(d[:])
+}
+
+// imtRecomputeRoot emits opcodes that recompute a Merkle root by walking D
+// levels LSB-first, matching cashupool.RecomputeRoot exactly.
+//
+// On entry the 32-byte leafHash is on top of the data stack; the leaf index is
+// the immutable witness item at base position idxBaseIdx, and the D sibling
+// hashes are the immutable witness items at base positions sibBaseIdx+0 ..
+// sibBaseIdx+D-1 (sib level 0 first). On exit the recomputed 32-byte root is on
+// top of the data stack and all working values have been cleaned up.
+//
+// The running index is kept on the alt stack across each level so that the main
+// stack inside the OP_IF/OP_ELSE branches contains exactly [cur sib], keeping
+// both branches stack-balanced (each leaves a single concatenated preimage).
+func imtRecomputeRoot(
+	d int,
+	idxBaseIdx, sibBaseIdx int,
+	op func(byte, int),
+	rawOp func(byte),
+	i64 func(int64),
+	pick func(int),
+) {
+	// Seed the running index on the alt stack from a copy of the witness index.
+	pick(idxBaseIdx)      // [... leafHash idxCopy]
+	op(OP_TOALTSTACK, -1) // [... leafHash]; alt: [idxWork]
+
+	for i := 0; i < d; i++ {
+		// Recover the running index, derive (bit, next) and re-stash next.
+		op(OP_FROMALTSTACK, 1) // [... cur idxWork]
+		op(OP_DUP, 1)          // [... cur idxWork idxWork]
+		op(OP_2, 1)            // [... cur idxWork idxWork 2]
+		op(OP_DIV, -1)         // [... cur idxWork next]
+		op(OP_TOALTSTACK, -1)  // [... cur idxWork]; alt: [next]
+		op(OP_2, 1)            // [... cur idxWork 2]
+		op(OP_MOD, -1)         // [... cur bit]
+
+		// Fetch the level-i sibling and arrange [cur sib bit] for the branch.
+		pick(sibBaseIdx + i) // [... cur bit sib]
+		op(OP_SWAP, 0)       // [... cur sib bit]
+
+		// Both branches consume bit and turn [cur sib] into one preimage, so
+		// the whole conditional has a single net effect of -2 (pop bit, then
+		// the branch that runs concatenates two items into one). Only the IF
+		// path is counted in depth; the ELSE path is emitted raw so the two
+		// arms are not double-counted.
+		op(OP_IF, -2) // net of the conditional: pops bit, branch nets -1
+		// bit == 1: current is the RIGHT child -> SHA256(sib || cur).
+		rawOp(OP_SWAP) // [... sib cur]
+		rawOp(OP_CAT)  // [... sib||cur]
+		rawOp(OP_ELSE)
+		// bit == 0: current is the LEFT child -> SHA256(cur || sib).
+		rawOp(OP_CAT) // [... cur||sib]
+		rawOp(OP_ENDIF)
+		op(OP_SHA256, 0) // [... newCur]
+	}
+
+	// Discard the exhausted running index (0 after D divisions).
+	op(OP_FROMALTSTACK, 1) // [... cur idxWork]
+	op(OP_DROP, -1)        // [... cur]
+}
+
+// buildIMTNonMembershipScript builds a locking script that verifies a
+// non-membership proof for a key k against the baked prevRoot.
+//
+// Witness layout (bottom of stack first):
+//
+//	[ low.Value, low.Next, lowIdx, lowPath[0..D-1], k ]
+func buildIMTNonMembershipScript(d int, prevRoot []byte) []byte {
+	bld := txscript.NewScriptBuilder()
+
+	// Witness base positions.
+	const (
+		lowValIdx  = 0
+		lowNextIdx = 1
+		lowIdxIdx  = 2
+		lowPathIdx = 3 // lowPath[i] at lowPathIdx+i
+	)
+	kIdx := lowPathIdx + d
+
+	depth := kIdx + 1 // number of witness items pushed by SetStack
+
+	data := func(v []byte) { bld.AddData(v); depth++ }
+	i64 := func(v int64) { bld.AddInt64(v); depth++ }
+	op := func(o byte, delta int) { bld.AddOp(o); depth += delta }
+	rawOp := func(o byte) { bld.AddOp(o) }
+
+	pick := func(baseIdx int) {
+		i64(int64(depth - 1 - baseIdx))
+		op(OP_PICK, 0)
+	}
+
+	// be32 leaves the 32-byte big-endian encoding of the witness number at
+	// baseIdx on top of the stack.
+	be32 := func(baseIdx int) {
+		pick(baseIdx)          // [... num]
+		i64(33)                // [... num 33]
+		op(OP_NUM2BIN, -1)     // [... le33(num)]
+		op(OP_REVERSEBYTES, 0) // [... be33(num) == 0x00||be32(num)]
+		i64(32)                // [... be33 32]
+		op(OP_RIGHT, -1)       // [... be32(num)]
+	}
+
+	emitNonMembership := func() {
+		// 1. lowLeafHash = SHA256(be32(low.Value) || be32(low.Next)).
+		be32(lowValIdx)  // [... be32(low.Value)]
+		be32(lowNextIdx) // [... be32(low.Value) be32(low.Next)]
+		op(OP_CAT, -1)   // [... le64]
+		op(OP_SHA256, 0) // [... lowLeafHash]
+
+		// 2. recompute the root from the low leaf and assert == prevRoot.
+		imtRecomputeRoot(d, lowIdxIdx, lowPathIdx, op, rawOp, i64, pick)
+		data(prevRoot)         // [... root prevRoot]
+		op(OP_EQUALVERIFY, -2) // assert equal
+
+		// 3. range check: low.Value < k AND (low.Next == 0 OR k < low.Next).
+		pick(lowValIdx)     // [... low.Value]
+		pick(kIdx)          // [... low.Value k]
+		op(OP_LESSTHAN, -1) // [... (low.Value<k)]
+
+		pick(lowNextIdx)    // [... lt low.Next]
+		op(OP_0, 1)         // [... lt low.Next 0]
+		op(OP_NUMEQUAL, -1) // [... lt (low.Next==0)]
+
+		pick(kIdx)          // [... lt isInf k]
+		pick(lowNextIdx)    // [... lt isInf k low.Next]
+		op(OP_LESSTHAN, -1) // [... lt isInf (k<low.Next)]
+
+		op(OP_BOOLOR, -1)  // [... lt (isInf OR k<low.Next)]
+		op(OP_BOOLAND, -1) // [... (low.Value<k AND bracket)]
+		op(OP_VERIFY, -1)  // assert range holds
+	}
+
+	emitNonMembership()
+
+	// All checks passed; clear the witness items so the engine sees a single
+	// truthy result.
+	for depth >= 2 {
+		op(OP_2DROP, -2)
+	}
+	for depth >= 1 {
+		op(OP_DROP, -1)
+	}
+	op(OP_1, 1) // success
+
+	script, err := bld.Script()
+	if err != nil {
+		panic(err)
+	}
+	return script
+}
+
+// imtNonMembershipWitness builds the witness stack for the non-membership
+// script: [ low.Value, low.Next, lowIdx, lowPath[0..D-1], k ].
+func imtNonMembershipWitness(low cashupool.Leaf, lowIdx uint32, lowPath [][]byte, k *big.Int) [][]byte {
+	w := make([][]byte, 0, 3+len(lowPath)+1)
+	w = append(w, encodeBig(low.Value))
+	w = append(w, encodeBig(low.Next))
+	w = append(w, encodeBig(new(big.Int).SetUint64(uint64(lowIdx))))
+	for _, s := range lowPath {
+		w = append(w, s)
+	}
+	w = append(w, encodeBig(k))
+	return w
+}
+
+func TestIMTNonMembershipScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid non-membership against genesis", func(t *testing.T) {
+		tree := cashupool.NewIMT(imtD)
+		k := imtKFromTag("imt-a")
+		low, lowIdx, lowPath := tree.NonMembership(k)
+
+		// Sanity: the in-script root must match the off-chain reference.
+		root := cashupool.RecomputeRoot(imtD, lowIdx, low.Hash(), lowPath)
+		require.Equal(t, tree.Root(), root)
+
+		script := buildIMTNonMembershipScript(imtD, tree.Root())
+		w := imtNonMembershipWitness(low, lowIdx, lowPath, k)
+		require.NoError(t, runArkadeScript(t, script, w))
+	})
+
+	t.Run("valid non-membership with occupied predecessor", func(t *testing.T) {
+		tree := cashupool.NewIMT(imtD)
+		// Insert a couple of leaves so the predecessor is a real leaf.
+		for _, tag := range []string{"imt-seed-1", "imt-seed-2"} {
+			kk := imtKFromTag(tag)
+			low, lowIdx, lowPath := tree.NonMembership(kk)
+			tree.Insert(kk, low, lowIdx, lowPath)
+		}
+		k := imtKFromTag("imt-a")
+		low, lowIdx, lowPath := tree.NonMembership(k)
+
+		script := buildIMTNonMembershipScript(imtD, tree.Root())
+		w := imtNonMembershipWitness(low, lowIdx, lowPath, k)
+		require.NoError(t, runArkadeScript(t, script, w))
+	})
+
+	t.Run("tampered lowPath sibling fails", func(t *testing.T) {
+		tree := cashupool.NewIMT(imtD)
+		k := imtKFromTag("imt-a")
+		low, lowIdx, lowPath := tree.NonMembership(k)
+
+		bad := make([][]byte, len(lowPath))
+		copy(bad, lowPath)
+		tampered := append([]byte(nil), bad[0]...)
+		tampered[0] ^= 0x01
+		bad[0] = tampered
+
+		script := buildIMTNonMembershipScript(imtD, tree.Root())
+		w := imtNonMembershipWitness(low, lowIdx, bad, k)
+		require.Error(t, runArkadeScript(t, script, w))
+	})
+
+	t.Run("k outside proven low range fails", func(t *testing.T) {
+		// Insert two leaves, prove non-membership of a key k1, then reuse that
+		// low proof for a key k2 that is NOT bracketed by low (k2 < low.Value).
+		tree := cashupool.NewIMT(imtD)
+		seeds := []string{"imt-seed-1", "imt-seed-2"}
+		for _, tag := range seeds {
+			kk := imtKFromTag(tag)
+			low, lowIdx, lowPath := tree.NonMembership(kk)
+			tree.Insert(kk, low, lowIdx, lowPath)
+		}
+
+		// Find a high key whose low predecessor is an occupied (non-sentinel)
+		// leaf, so that a key smaller than low.Value is outside its range.
+		var low cashupool.Leaf
+		var lowIdx uint32
+		var lowPath [][]byte
+		for _, tag := range []string{"imt-hi-1", "imt-hi-2", "imt-hi-3", "imt-hi-4"} {
+			k1 := imtKFromTag(tag)
+			low, lowIdx, lowPath = tree.NonMembership(k1)
+			if low.Value.Sign() != 0 {
+				break
+			}
+		}
+		require.NotZero(t, low.Value.Sign(), "need an occupied predecessor")
+
+		// k2 < low.Value: not bracketed by low, so the range check must fail.
+		k2 := new(big.Int).Sub(low.Value, big.NewInt(1))
+
+		script := buildIMTNonMembershipScript(imtD, tree.Root())
+		w := imtNonMembershipWitness(low, lowIdx, lowPath, k2)
+		require.Error(t, runArkadeScript(t, script, w))
+	})
+}

--- a/pkg/arkade/cashupool_packet_spike_test.go
+++ b/pkg/arkade/cashupool_packet_spike_test.go
@@ -1,0 +1,294 @@
+package arkade
+
+// Spike: custom 0x05 state-packet round-trip through the Arkade engine.
+//
+// Purpose: confirm that a custom extension packet (type 0x05) can be:
+//   (a) attached to an Arkade transaction and read back inside an Arkade Script
+//       via OP_INSPECTPACKET,
+//   (b) read from a PARENT transaction via OP_INSPECTINPUTPACKET,
+//   (c) determine how an extension output affects OP_INSPECTNUMOUTPUTS.
+//
+// Run with: cd pkg/arkade && go test . -run TestPoolStatePacket -v
+
+import (
+	"testing"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// cashuPoolPacketType is the custom packet type byte reserved for the Cashu
+// nullifier-pool state.  All values 0x02–0xFE that are not already claimed by
+// asset.Packet (0x00) or EmulatorPacket (0x01) are fair game; 0x05 is used
+// here so it does not collide with the test values in engine_test.go (0x02–0x04).
+const cashuPoolPacketType = 0x05
+
+// poolStatePayload is the 3-byte payload written into the extension.
+var poolStatePayload = []byte{0xab, 0xcd, 0xef}
+
+// runPacketEngine is a local helper that mirrors runArkadeScript but accepts a
+// caller-supplied *wire.MsgTx (so the caller can attach an extension output)
+// and a caller-supplied ArkPrevOutFetcher (so OP_INSPECTINPUTPACKET can
+// resolve a parent tx).  It constructs the engine at txIdx=0 and returns the
+// Execute() result.
+func runPacketEngine(
+	t *testing.T,
+	script []byte,
+	tx *wire.MsgTx,
+	fetcher ArkPrevOutFetcher,
+) error {
+	t.Helper()
+	engine, err := NewEngine(
+		script, tx, 0,
+		txscript.NewSigCache(100),
+		txscript.NewTxSigHashes(tx, fetcher),
+		1_000_000,
+		fetcher,
+	)
+	require.NoError(t, err)
+	return engine.Execute()
+}
+
+// makePrevoutFetcher builds the base prevout fetcher that the engine needs to
+// resolve the spending input's scriptPubKey.  The outpoint passed in must match
+// tx.TxIn[0].PreviousOutPoint.
+func makePrevoutFetcher(outpoint wire.OutPoint) txscript.PrevOutputFetcher {
+	return txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+		outpoint: {
+			Value: 1_000_000,
+			PkScript: []byte{
+				OP_1, OP_DATA_32,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+		},
+	})
+}
+
+// TestPoolStatePacketA_CurrentTx verifies that a 0x05 extension packet attached
+// to the current transaction is readable via OP_INSPECTPACKET.
+//
+// Findings:
+//   - OP_INSPECTPACKET returns UnknownPacket.Data verbatim (no framing bytes,
+//     no type prefix — the raw Data slice is pushed).
+//   - When the packet type is not present, OP_INSPECTPACKET pushes (<empty>, 0).
+func TestPoolStatePacketA_CurrentTx(t *testing.T) {
+	t.Parallel()
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x01}, Index: 0}
+
+	// Build a tx carrying a 0x05 extension output alongside a regular output.
+	ext := extension.Extension{
+		extension.UnknownPacket{PacketType: cashuPoolPacketType, Data: poolStatePayload},
+	}
+	extOut, err := ext.TxOut()
+	require.NoError(t, err)
+
+	claimantOut := &wire.TxOut{Value: 1_000, PkScript: []byte{OP_TRUE}}
+
+	tx := &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: outpoint}},
+		// Two TxOut: one claimant output, one extension output.
+		TxOut: []*wire.TxOut{claimantOut, extOut},
+	}
+
+	fetcher := newTestArkPrevOutFetcher(makePrevoutFetcher(outpoint), nil, nil)
+
+	t.Run("positive_packet_found", func(t *testing.T) {
+		t.Parallel()
+		// Script: push type 0x05 → OP_INSPECTPACKET → stack: [Data, 1]
+		// Verify flag==1 then data==poolStatePayload.
+		script, err := txscript.NewScriptBuilder().
+			AddInt64(cashuPoolPacketType).
+			AddOp(OP_INSPECTPACKET).
+			AddOp(OP_1).
+			AddOp(OP_EQUALVERIFY). // flag must be 1 (found)
+			AddData(poolStatePayload).
+			AddOp(OP_EQUAL). // content must equal the raw payload
+			Script()
+		require.NoError(t, err)
+
+		err = runPacketEngine(t, script, tx, fetcher)
+		// FINDING: OP_INSPECTPACKET returns UnknownPacket.Data verbatim.
+		require.NoError(t, err, "0x05 packet round-trip via OP_INSPECTPACKET must pass")
+	})
+
+	t.Run("negative_type_not_found", func(t *testing.T) {
+		t.Parallel()
+		// Query type 0x06 which is not in the extension — expect flag==0 and
+		// content==empty.
+		script, err := txscript.NewScriptBuilder().
+			AddInt64(0x06).
+			AddOp(OP_INSPECTPACKET).
+			// stack: [<empty>, 0]
+			AddOp(OP_0).
+			AddOp(OP_EQUALVERIFY). // flag must be 0 (not found)
+			AddOp(OP_0).
+			AddOp(OP_EQUAL). // content must be empty bytes
+			Script()
+		require.NoError(t, err)
+
+		err = runPacketEngine(t, script, tx, fetcher)
+		require.NoError(t, err, "missing type must push (empty,0)")
+	})
+}
+
+// TestPoolStatePacketB_InputPacket verifies that OP_INSPECTINPUTPACKET can read
+// a 0x05 packet from the PARENT transaction that the current tx spends.
+//
+// Stack convention for OP_INSPECTINPUTPACKET:
+//
+//	Push packet_type first, then input_index on top.
+//	The opcode pops index first (top), then packetType (second).
+//
+// Parent tx registration: keyed in arkTxs by the child's input outpoint
+// (tx.TxIn[idx].PreviousOutPoint).
+//
+// Findings:
+//   - OP_INSPECTINPUTPACKET works at engine level when the parent tx is
+//     registered in the prevout fetcher's arkTxs map.
+//   - OP_PUSHCURRENTINPUTINDEX pushes txIdx (0), which selects TxIn[0].
+func TestPoolStatePacketB_InputPacket(t *testing.T) {
+	t.Parallel()
+
+	// Build the PARENT tx: carries the 0x05 packet.
+	ext := extension.Extension{
+		extension.UnknownPacket{PacketType: cashuPoolPacketType, Data: poolStatePayload},
+	}
+	parentExtOut, err := ext.TxOut()
+	require.NoError(t, err)
+	parentTx := &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{0x00}, Index: 0}}},
+		TxOut:   []*wire.TxOut{{Value: 1_000, PkScript: []byte{OP_TRUE}}, parentExtOut},
+	}
+
+	// Build the CHILD tx: spends parentOutpoint (parentTx output index 0).
+	childOutpoint := wire.OutPoint{Hash: chainhash.Hash{0x02}, Index: 0}
+	childTx := &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: childOutpoint}},
+		TxOut:   []*wire.TxOut{{Value: 500, PkScript: []byte{OP_TRUE}}},
+	}
+
+	// Register the parent tx in the fetcher, keyed by the child's input outpoint.
+	base := makePrevoutFetcher(childOutpoint)
+	arkTxs := map[wire.OutPoint]*wire.MsgTx{childOutpoint: parentTx}
+	prevoutIdxs := map[wire.OutPoint]uint32{childOutpoint: 0}
+	fetcher := newTestArkPrevOutFetcher(base, arkTxs, prevoutIdxs)
+
+	t.Run("positive_input_packet_via_pushcurrentinputindex", func(t *testing.T) {
+		t.Parallel()
+		// Script: push type 0x05, then push current input index (0),
+		// then OP_INSPECTINPUTPACKET → stack: [Data, 1].
+		script, err := txscript.NewScriptBuilder().
+			AddInt64(cashuPoolPacketType).
+			AddOp(OP_PUSHCURRENTINPUTINDEX).
+			AddOp(OP_INSPECTINPUTPACKET).
+			AddOp(OP_1).
+			AddOp(OP_EQUALVERIFY). // flag must be 1 (found)
+			AddData(poolStatePayload).
+			AddOp(OP_EQUAL). // content must equal raw payload
+			Script()
+		require.NoError(t, err)
+
+		err = runPacketEngine(t, script, childTx, fetcher)
+		// FINDING: OP_INSPECTINPUTPACKET resolves parent by looking up
+		// tx.TxIn[index].PreviousOutPoint in the fetcher's arkTxs map, then
+		// calls findPacketByType on the parent tx.  Data is returned verbatim.
+		require.NoError(t, err, "OP_INSPECTINPUTPACKET must read parent 0x05 packet")
+	})
+
+	t.Run("negative_type_not_in_parent", func(t *testing.T) {
+		t.Parallel()
+		// Query type 0x07 which is absent in the parent — expect flag==0.
+		script, err := txscript.NewScriptBuilder().
+			AddInt64(0x07).
+			AddOp(OP_PUSHCURRENTINPUTINDEX).
+			AddOp(OP_INSPECTINPUTPACKET).
+			AddOp(OP_0).
+			AddOp(OP_EQUALVERIFY). // flag must be 0
+			AddOp(OP_0).
+			AddOp(OP_EQUAL). // content must be empty
+			Script()
+		require.NoError(t, err)
+
+		err = runPacketEngine(t, script, childTx, fetcher)
+		require.NoError(t, err, "missing type in parent must push (empty,0)")
+	})
+}
+
+// TestPoolStatePacketC_NumOutputs determines empirically how many outputs
+// OP_INSPECTNUMOUTPUTS counts when an extension output is present.
+//
+// Findings:
+//   - OP_INSPECTNUMOUTPUTS returns len(tx.TxOut), which INCLUDES the
+//     extension output.  A tx with [claimant, pool, extension] has 3 TxOut
+//     and OP_INSPECTNUMOUTPUTS pushes 3.
+//   - Conclusion: scripts that enforce an exact output count must include the
+//     extension output in their count.  For a Cashu pool tx with 2 spendable
+//     outputs and 1 extension output, scripts must assert OP_INSPECTNUMOUTPUTS
+//     == 3.
+func TestPoolStatePacketC_NumOutputs(t *testing.T) {
+	t.Parallel()
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x03}, Index: 0}
+
+	ext := extension.Extension{
+		extension.UnknownPacket{PacketType: cashuPoolPacketType, Data: poolStatePayload},
+	}
+	extOut, err := ext.TxOut()
+	require.NoError(t, err)
+
+	// Simulate a pool tx: claimant output, pool output, extension output = 3 TxOut.
+	claimantOut := &wire.TxOut{Value: 1_000, PkScript: []byte{OP_TRUE}}
+	poolOut := &wire.TxOut{Value: 500, PkScript: []byte{OP_TRUE}}
+
+	tx := &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: outpoint}},
+		TxOut:   []*wire.TxOut{claimantOut, poolOut, extOut},
+	}
+	fetcher := newTestArkPrevOutFetcher(makePrevoutFetcher(outpoint), nil, nil)
+
+	t.Run("extension_output_counted", func(t *testing.T) {
+		t.Parallel()
+		// OP_INSPECTNUMOUTPUTS must return 3 (claimant + pool + extension).
+		script, err := txscript.NewScriptBuilder().
+			AddOp(OP_INSPECTNUMOUTPUTS).
+			AddInt64(3).
+			AddOp(OP_EQUAL).
+			Script()
+		require.NoError(t, err)
+
+		err = runPacketEngine(t, script, tx, fetcher)
+		// FINDING: extension output IS counted by OP_INSPECTNUMOUTPUTS.
+		// Scripts constraining output layout must account for it.
+		require.NoError(t, err, "OP_INSPECTNUMOUTPUTS must count extension output (result=3)")
+	})
+
+	t.Run("two_outputs_without_extension", func(t *testing.T) {
+		t.Parallel()
+		// Control: same tx but without the extension output to confirm baseline.
+		txNoExt := &wire.MsgTx{
+			Version: 1,
+			TxIn:    []*wire.TxIn{{PreviousOutPoint: outpoint}},
+			TxOut:   []*wire.TxOut{claimantOut, poolOut},
+		}
+		script, err := txscript.NewScriptBuilder().
+			AddOp(OP_INSPECTNUMOUTPUTS).
+			AddInt64(2).
+			AddOp(OP_EQUAL).
+			Script()
+		require.NoError(t, err)
+
+		err = runPacketEngine(t, script, txNoExt, fetcher)
+		require.NoError(t, err, "without extension, OP_INSPECTNUMOUTPUTS must return 2")
+	})
+}

--- a/pkg/arkade/dleq_script_test.go
+++ b/pkg/arkade/dleq_script_test.go
@@ -1,0 +1,299 @@
+package arkade
+
+import (
+	"crypto/sha256"
+	"math/big"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDLEQScript verifies a Cashu/BDHKE-style DLEQ (Discrete Log Equality)
+// proof entirely inside an Arkade Script, exercising the elliptic-curve
+// opcodes (OP_ECMUL/OP_ECADD), byte-surgery opcodes (OP_NUM2BIN/OP_BIN2NUM/
+// OP_REVERSEBYTES/OP_RIGHT/OP_CAT) and OP_SHA256/OP_MOD together.
+//
+// Bob proves the same secret a links A = a*G and C' = a*B' without revealing a:
+//
+//	Bob:   r random; R1 = r*G; R2 = r*B'; e = H(R1,R2,A,C'); s = r + e*a → (e, s)
+//	Alice: R1 = s*G - e*A; R2 = s*B' - e*C'; accept iff e == H(R1,R2,A,C')
+//
+// Here Alice is the script. The public instance (G, A, B', C') is baked into
+// the locking script; the spender supplies the proof (e, s) as the witness.
+//
+// Conventions chosen so the script and the off-chain prover agree exactly:
+//   - Points are hashed in SEC1 compressed form (0x02/0x03 || big-endian X),
+//     which the script reconstructs from the affine (x, y) coordinates that the
+//     EC opcodes operate on.
+//   - The challenge digest is read as a little-endian unsigned integer (Arkade
+//     numbers are sign-magnitude little-endian); a 0x00 byte is appended before
+//     OP_BIN2NUM so the 256-bit digest is never interpreted as negative.
+//   - Point subtraction is done as s*G + (n-e)*A, since (n-e)*A == -e*A and
+//     there is no point-negation opcode.
+func TestDLEQScript(t *testing.T) {
+	t.Parallel()
+
+	n := btcec.S256().N
+
+	// Public DLEQ instance.
+	a := mustPrivKeyFromSeed(t, "dleq-script-secret-a")  // Bob's secret
+	b := mustPrivKeyFromSeed(t, "dleq-script-blinded-b") // gives a well-formed B'
+	r := mustPrivKeyFromSeed(t, "dleq-script-nonce-r")   // proof nonce
+
+	one := new(btcec.ModNScalar)
+	one.SetInt(1)
+	G := scalarBaseMult(one)
+
+	A := a.PubKey()                 // A  = a*G
+	Bp := b.PubKey()                // B' = b*G (any point)
+	Cp := scalarMultPub(&a.Key, Bp) // C' = a*B'
+	R1 := scalarBaseMult(&r.Key)    // R1 = r*G
+	R2 := scalarMultPub(&r.Key, Bp) // R2 = r*B'
+
+	// e = H(R1 || R2 || A || C') mod n, with the digest read little-endian to
+	// match the script's OP_BIN2NUM. s = r + e*a mod n.
+	e := dleqScriptChallenge(R1, R2, A, Cp, n)
+	require.NotEqual(t, 0, e.Sign(), "challenge e must be non-zero so (n-e) is a valid scalar")
+
+	aBig := scalarToBig(&a.Key)
+	rBig := scalarToBig(&r.Key)
+	s := new(big.Int).Mod(new(big.Int).Add(rBig, new(big.Int).Mul(e, aBig)), n)
+	require.NotEqual(t, 0, s.Sign(), "response s must be non-zero")
+
+	script := buildDLEQVerifyScript(G, A, Bp, Cp, n)
+
+	// The witness is the proof (e, s): bottom-of-stack e, top-of-stack s.
+	validWitness := [][]byte{encodeBig(e), encodeBig(s)}
+
+	t.Run("valid proof verifies", func(t *testing.T) {
+		require.NoError(t, runArkadeScript(t, script, validWitness))
+	})
+
+	t.Run("tampered s fails", func(t *testing.T) {
+		badS := new(big.Int).Mod(new(big.Int).Add(s, big.NewInt(1)), n)
+		require.Error(t, runArkadeScript(t, script, [][]byte{encodeBig(e), encodeBig(badS)}))
+	})
+
+	t.Run("tampered e fails", func(t *testing.T) {
+		badE := new(big.Int).Mod(new(big.Int).Add(e, big.NewInt(1)), n)
+		require.Error(t, runArkadeScript(t, script, [][]byte{encodeBig(badE), encodeBig(s)}))
+	})
+
+	t.Run("proof for a different secret fails", func(t *testing.T) {
+		// A valid (e2, s2) for a different secret a2 must not satisfy the
+		// script, whose public instance still commits to A = a*G, C' = a*B'.
+		a2 := mustPrivKeyFromSeed(t, "dleq-script-other-secret")
+		C2 := scalarMultPub(&a2.Key, Bp)
+		e2 := dleqScriptChallenge(R1, R2, a2.PubKey(), C2, n)
+		s2 := new(big.Int).Mod(
+			new(big.Int).Add(rBig, new(big.Int).Mul(e2, scalarToBig(&a2.Key))), n)
+		require.Error(t, runArkadeScript(t, script, [][]byte{encodeBig(e2), encodeBig(s2)}))
+	})
+}
+
+// buildDLEQVerifyScript assembles the inline DLEQ verification script for the
+// public instance (G, A, B', C') and group order n. The spender's witness is
+// the proof (e, s) with e at the bottom of the stack and s on top.
+//
+// The builder tracks the runtime stack depth as it emits opcodes so that
+// OP_PICK offsets for the re-used scalars (e, s, n-e) are always correct.
+func buildDLEQVerifyScript(G, A, Bp, Cp *btcec.PublicKey, n *big.Int) []byte {
+	bld := txscript.NewScriptBuilder()
+
+	// depth models the data stack at runtime, starting with the two witness
+	// items [e, s] already pushed by SetStack.
+	depth := 2
+
+	data := func(v []byte) { bld.AddData(v); depth++ }
+	i64 := func(v int64) { bld.AddInt64(v); depth++ }
+	op := func(o byte, delta int) { bld.AddOp(o); depth += delta }
+
+	// pick copies the immutable base item at baseIdx (0 = e, 1 = s, 2 = n-e)
+	// to the top of the stack. Net stack effect: +1.
+	pick := func(baseIdx int) {
+		i64(int64(depth - 1 - baseIdx))
+		op(OP_PICK, 0)
+	}
+
+	// scalarMul leaves k*(px,py) as affine (x, y) on top, where k is the base
+	// scalar at kIdx. Stack: [...] -> [... x y].
+	scalarMul := func(p *btcec.PublicKey, kIdx int) {
+		px, py := pubCoords(p)
+		data(encodeBig(px))
+		data(encodeBig(py))
+		pick(kIdx)
+		op(OP_0, 1)      // curve id 0 = secp256k1
+		op(OP_ECMUL, -2) // pops x,y,k,curve; pushes x,y
+	}
+
+	// ecAdd combines the two affine points on top. [... x1 y1 x2 y2] -> [... x3 y3].
+	ecAdd := func() {
+		op(OP_0, 1)
+		op(OP_ECADD, -3) // pops x1,y1,x2,y2,curve; pushes x3,y3
+	}
+
+	// serializeCompressed turns the affine point on top into its 33-byte SEC1
+	// compressed encoding. [... x y] -> [... 0x02|0x03 || be32(x)].
+	serializeCompressed := func() {
+		op(OP_DUP, 1)          // x y y
+		op(OP_2, 1)            // x y y 2
+		op(OP_MOD, -1)         // x y (y%2)
+		op(OP_2, 1)            // x y (y%2) 2
+		op(OP_ADD, -1)         // x y prefixNum (2=even, 3=odd)
+		op(OP_1, 1)            // x y prefixNum 1
+		op(OP_NUM2BIN, -1)     // x y prefixByte
+		op(OP_SWAP, 0)         // x prefixByte y
+		op(OP_DROP, -1)        // x prefixByte
+		op(OP_SWAP, 0)         // prefixByte x
+		i64(33)                // prefixByte x 33
+		op(OP_NUM2BIN, -1)     // prefixByte le33(x)
+		op(OP_REVERSEBYTES, 0) // prefixByte be33(x) == 0x00||be32(x)
+		i64(32)                // prefixByte be33(x) 32
+		op(OP_RIGHT, -1)       // prefixByte be32(x)
+		op(OP_CAT, -1)         // compressed point
+	}
+
+	// --- n - e (kept as base item index 2, reused for both -e*A and -e*C') ---
+	data(encodeBig(n))
+	pick(0)        // copy e
+	op(OP_SUB, -1) // n - e
+
+	// --- R1 = s*G + (n-e)*A, push compressed(R1) to the alt stack ---
+	scalarMul(G, 1) // s*G
+	scalarMul(A, 2) // (n-e)*A
+	ecAdd()         // R1
+	serializeCompressed()
+	op(OP_TOALTSTACK, -1) // alt: [c(R1)]
+
+	// --- R2 = s*B' + (n-e)*C', accumulate c(R1)||c(R2) on the alt stack ---
+	scalarMul(Bp, 1) // s*B'
+	scalarMul(Cp, 2) // (n-e)*C'
+	ecAdd()          // R2
+	serializeCompressed()
+	op(OP_FROMALTSTACK, 1) // c(R2) c(R1)
+	op(OP_SWAP, 0)         // c(R1) c(R2)
+	op(OP_CAT, -1)         // c(R1)||c(R2)
+	op(OP_TOALTSTACK, -1)  // alt: [acc]
+
+	// --- append compressed(A) ---
+	ax, ay := pubCoords(A)
+	data(encodeBig(ax))
+	data(encodeBig(ay))
+	serializeCompressed()
+	op(OP_FROMALTSTACK, 1)
+	op(OP_SWAP, 0)
+	op(OP_CAT, -1)
+	op(OP_TOALTSTACK, -1)
+
+	// --- append compressed(C'): leaves the full preimage on the main stack ---
+	cx, cy := pubCoords(Cp)
+	data(encodeBig(cx))
+	data(encodeBig(cy))
+	serializeCompressed()
+	op(OP_FROMALTSTACK, 1)
+	op(OP_SWAP, 0)
+	op(OP_CAT, -1) // preimage = c(R1)||c(R2)||c(A)||c(C')
+
+	// --- e' = H(preimage) mod n, read little-endian and forced non-negative ---
+	op(OP_SHA256, 0)   // 32-byte digest
+	op(OP_0, 1)        // 0
+	op(OP_1, 1)        // 0 1
+	op(OP_NUM2BIN, -1) // 0x00 byte
+	op(OP_CAT, -1)     // digest||0x00 (positive little-endian)
+	op(OP_BIN2NUM, 0)  // H
+	data(encodeBig(n)) // H n
+	op(OP_MOD, -1)     // e' = H mod n
+
+	// --- assert e' == e, then leave a single truthy item ---
+	pick(0) // copy e
+	op(OP_NUMEQUALVERIFY, -2)
+	op(OP_2DROP, -2) // drop n-e, s
+	op(OP_DROP, -1)  // drop e
+	op(OP_1, 1)      // success
+
+	script, err := bld.Script()
+	if err != nil {
+		panic(err)
+	}
+	return script
+}
+
+// runArkadeScript executes script with the given witness as the initial data
+// stack and returns the engine result.
+func runArkadeScript(t *testing.T, script []byte, witness [][]byte) error {
+	t.Helper()
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}
+	prevoutFetcher := newTestArkPrevOutFetcher(
+		txscript.NewMultiPrevOutFetcher(map[wire.OutPoint]*wire.TxOut{
+			outpoint: {
+				Value: 1_000_000_000,
+				PkScript: []byte{
+					OP_1, OP_DATA_32,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				},
+			},
+		}), nil, nil,
+	)
+
+	tx := &wire.MsgTx{
+		Version: 1,
+		TxIn:    []*wire.TxIn{{PreviousOutPoint: outpoint}},
+	}
+
+	engine, err := NewEngine(
+		script, tx, 0,
+		txscript.NewSigCache(100),
+		txscript.NewTxSigHashes(tx, prevoutFetcher),
+		0,
+		prevoutFetcher,
+	)
+	require.NoError(t, err)
+
+	if len(witness) > 0 {
+		engine.SetStack(witness)
+	}
+	return engine.Execute()
+}
+
+// dleqScriptChallenge computes e = H(R1||R2||A||C') mod n exactly as the script
+// does: SHA256 over the SEC1 compressed points, with the digest interpreted as
+// a little-endian unsigned integer.
+func dleqScriptChallenge(R1, R2, A, Cp *btcec.PublicKey, n *big.Int) *big.Int {
+	pre := make([]byte, 0, 33*4)
+	pre = append(pre, R1.SerializeCompressed()...)
+	pre = append(pre, R2.SerializeCompressed()...)
+	pre = append(pre, A.SerializeCompressed()...)
+	pre = append(pre, Cp.SerializeCompressed()...)
+
+	digest := sha256.Sum256(pre)
+
+	// The script appends a 0x00 byte and runs OP_BIN2NUM, reading the bytes as
+	// sign-magnitude little-endian. Reverse to big-endian to load the same
+	// magnitude into a big.Int.
+	be := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		be[i] = digest[31-i]
+	}
+	h := new(big.Int).SetBytes(be)
+	return new(big.Int).Mod(h, n)
+}
+
+// pubCoords returns the affine (x, y) coordinates of a public key as big.Ints.
+func pubCoords(p *btcec.PublicKey) (x, y *big.Int) {
+	u := p.SerializeUncompressed() // 0x04 || be32(x) || be32(y)
+	return new(big.Int).SetBytes(u[1:33]), new(big.Int).SetBytes(u[33:65])
+}
+
+// scalarToBig converts a secp256k1 scalar to a big.Int.
+func scalarToBig(s *btcec.ModNScalar) *big.Int {
+	b := s.Bytes()
+	return new(big.Int).SetBytes(b[:])
+}

--- a/pkg/arkade/dleq_test.go
+++ b/pkg/arkade/dleq_test.go
@@ -1,0 +1,153 @@
+package arkade
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDLEQProof exercises a Cashu/BDHKE-style DLEQ (Discrete Log Equality)
+// proof. Bob proves that the same secret a links A = a*G and C' = a*B' without
+// revealing a:
+//
+//	Bob:   r random; R1 = r*G; R2 = r*B'; e = hash(R1,R2,A,C'); s = r + e*a
+//	Alice: R1 = s*G - e*A; R2 = s*B' - e*C'; accept iff e == hash(R1,R2,A,C')
+func TestDLEQProof(t *testing.T) {
+	// a is Bob's secret (the signing key), A = a*G is public.
+	a := mustPrivKeyFromSeed(t, "dleq-secret-a")
+	A := a.PubKey()
+
+	// B' is Alice's blinded message (any point); b is its discrete log here
+	// only so the test can construct a well-formed B'.
+	b := mustPrivKeyFromSeed(t, "dleq-blinded-b")
+	bPub := b.PubKey()
+
+	// C' = a*B' is Bob's signature over the blinded message.
+	cPrime := scalarMultPub(&a.Key, bPub)
+
+	t.Run("valid proof verifies", func(t *testing.T) {
+		e, s := dleqProve(t, a, bPub, cPrime)
+		require.True(t, dleqVerify(e, s, A, bPub, cPrime))
+	})
+
+	t.Run("wrong A fails", func(t *testing.T) {
+		e, s := dleqProve(t, a, bPub, cPrime)
+		wrongA := mustPrivKeyFromSeed(t, "dleq-wrong-a").PubKey()
+		require.False(t, dleqVerify(e, s, wrongA, bPub, cPrime))
+	})
+
+	t.Run("wrong C' (different secret) fails", func(t *testing.T) {
+		e, s := dleqProve(t, a, bPub, cPrime)
+		other := mustPrivKeyFromSeed(t, "dleq-other-secret")
+		wrongCPrime := scalarMultPub(&other.Key, bPub)
+		require.False(t, dleqVerify(e, s, A, bPub, wrongCPrime))
+	})
+
+	t.Run("tampered s fails", func(t *testing.T) {
+		e, s := dleqProve(t, a, bPub, cPrime)
+		tampered := new(btcec.ModNScalar).Set(s)
+		tampered.Add(new(btcec.ModNScalar).SetInt(1))
+		require.False(t, dleqVerify(e, tampered, A, bPub, cPrime))
+	})
+
+	t.Run("tampered e fails", func(t *testing.T) {
+		e, s := dleqProve(t, a, bPub, cPrime)
+		tampered := new(btcec.ModNScalar).Set(e)
+		tampered.Add(new(btcec.ModNScalar).SetInt(1))
+		require.False(t, dleqVerify(tampered, s, A, bPub, cPrime))
+	})
+}
+
+func mustPrivKeyFromSeed(t *testing.T, seed string) *btcec.PrivateKey {
+	t.Helper()
+	digest := sha256.Sum256([]byte(seed))
+	priv, _ := btcec.PrivKeyFromBytes(digest[:])
+	return priv
+}
+
+// dleqProve is Bob's side of the proof. It picks a nonce r (derived
+// deterministically here so the test is reproducible), then returns the
+// challenge e and response s proving that a links A = a*G and cPrime = a*B'.
+func dleqProve(t *testing.T, a *btcec.PrivateKey, bPub, cPrime *btcec.PublicKey) (e, s *btcec.ModNScalar) {
+	t.Helper()
+
+	// Deterministic nonce r = H(a || B' || C'); any uniformly random scalar
+	// works, but a fixed derivation keeps failures reproducible.
+	h := sha256.New()
+	aBytes := a.Key.Bytes()
+	h.Write(aBytes[:])
+	h.Write(bPub.SerializeCompressed())
+	h.Write(cPrime.SerializeCompressed())
+	var nonce [32]byte
+	copy(nonce[:], h.Sum(nil))
+	r := new(btcec.ModNScalar)
+	r.SetBytes(&nonce)
+
+	A := a.PubKey()
+	R1 := scalarBaseMult(r)      // r*G
+	R2 := scalarMultPub(r, bPub) // r*B'
+	e = dleqChallenge(R1, R2, A, cPrime)
+
+	// s = r + e*a
+	ea := new(btcec.ModNScalar).Mul2(e, &a.Key)
+	s = new(btcec.ModNScalar).Add2(r, ea)
+	return e, s
+}
+
+// dleqVerify is Alice's side. It recomputes R1 = s*G - e*A and
+// R2 = s*B' - e*C', then checks the challenge matches.
+func dleqVerify(e, s *btcec.ModNScalar, A, bPub, cPrime *btcec.PublicKey) bool {
+	negE := new(btcec.ModNScalar).Set(e)
+	negE.Negate()
+
+	// R1 = s*G - e*A = s*G + (-e)*A
+	R1 := pointAdd(scalarBaseMult(s), scalarMultPub(negE, A))
+	// R2 = s*B' - e*C' = s*B' + (-e)*C'
+	R2 := pointAdd(scalarMultPub(s, bPub), scalarMultPub(negE, cPrime))
+
+	expected := dleqChallenge(R1, R2, A, cPrime)
+	return expected.Equals(e)
+}
+
+// dleqChallenge computes e = H(R1 || R2 || A || C') as a scalar.
+func dleqChallenge(R1, R2, A, cPrime *btcec.PublicKey) *btcec.ModNScalar {
+	h := sha256.New()
+	h.Write(R1.SerializeCompressed())
+	h.Write(R2.SerializeCompressed())
+	h.Write(A.SerializeCompressed())
+	h.Write(cPrime.SerializeCompressed())
+	var digest [32]byte
+	copy(digest[:], h.Sum(nil))
+	e := new(btcec.ModNScalar)
+	e.SetBytes(&digest)
+	return e
+}
+
+// scalarBaseMult returns scalar*G.
+func scalarBaseMult(scalar *btcec.ModNScalar) *btcec.PublicKey {
+	var result btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(scalar, &result)
+	result.ToAffine()
+	return btcec.NewPublicKey(&result.X, &result.Y)
+}
+
+// scalarMultPub returns scalar*point.
+func scalarMultPub(scalar *btcec.ModNScalar, point *btcec.PublicKey) *btcec.PublicKey {
+	var p, result btcec.JacobianPoint
+	point.AsJacobian(&p)
+	btcec.ScalarMultNonConst(scalar, &p, &result)
+	result.ToAffine()
+	return btcec.NewPublicKey(&result.X, &result.Y)
+}
+
+// pointAdd returns a + b.
+func pointAdd(a, b *btcec.PublicKey) *btcec.PublicKey {
+	var pa, pb, result btcec.JacobianPoint
+	a.AsJacobian(&pa)
+	b.AsJacobian(&pb)
+	btcec.AddNonConst(&pa, &pb, &result)
+	result.ToAffine()
+	return btcec.NewPublicKey(&result.X, &result.Y)
+}

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -2178,7 +2178,14 @@ func opcodeCat(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	vm.dstack.PushByteArray(append(x1, x2...))
+	// Stack objects may share backing arrays (e.g. data pushes alias the
+	// script buffer and OP_PICK copies items by reference), so the result must
+	// be a freshly allocated buffer. Using append(x1, x2...) directly can write
+	// into x1's spare capacity and corrupt the script or other stack items.
+	result := make([]byte, 0, len(x1)+len(x2))
+	result = append(result, x1...)
+	result = append(result, x2...)
+	vm.dstack.PushByteArray(result)
 	return nil
 }
 


### PR DESCRIPTION
@
## Summary

A **trust-minimized Cashu ecash exit verified entirely in Arkade Script** — the no-SNARK, buildable-today sibling of the `v1-zec` shielded-pool design. A shared fixed-denomination pool VTXO lets any holder of a genuine mint token claim a denomination by proving the token in-script and inserting its nullifier into an on-chain Indexed Merkle Tree, with a recursive covenant rolling the pool state forward. **No mint involvement; no `OP_VERIFY_ZKP`.**

Cashus DLEQ (the mint signature) replaces v1-zecs commitment tree + SNARK — so only the nullifier IMT is needed, on opcodes that exist today.

> Stacked on #95 (reuses its `runArkadeScript`/`encodeBig` harness). Base will retarget to `master` once #95 merges.

## Whats included (all engine-level, fully tested)

**Off-chain reference library** `pkg/arkade/cashupool/` — the byte-for-byte source of truth:
- `hashtocurve.go` — NUT-00 `hash_to_curve` + secret grinder
- `dleq.go` — NUT-12 r-blinded proof DLEQ (uncompressed-point hash, big-endian `e`)
- `imt.go` — depth-parameterized Indexed Merkle Tree (non-membership + coupled insert)
- `state.go` — `PoolState` codec (`prev_root || new_root || size`)

**In-script verifier** (`pkg/arkade/cashupool_*_script_test.go`, package `arkade`):
- `hash_to_curve` with a bounded counter loop (K=4), Euler non-residue via `OP_MODEXP`
- NUT-12 r-blinded DLEQ over `OP_ECMUL`/`OP_ECADD` (the `(n-e)` subtraction trick)
- IMT non-membership + insert via a positional Merkle walk
- **full `ClaimScript`** composing all phases + `0x05` extension-packet state continuity (`OP_INSPECTPACKET`/`OP_INSPECTINPUTPACKET`) + recursive covenant (`OP_INSPECTOUTPUTSCRIPTPUBKEY`) + value conservation — valid claim accepts, **7 negatives reject** (double-spend, tampered e/s, wrong claimant/pool value, broken continuity, wrong new root)

**Engine bugfix** (`5deaa1d`): `OP_CAT` was `append`-ing into aliased stack buffers, corrupting live script bytes when a CAT operand was a data push. Latent today (the existing DLEQ test never CATs a data push); a prerequisite for any data-push-CAT script. Fix allocates a fresh buffer per the documented stack contract.

## Test plan

```
cd pkg/arkade && go test ./... -count=1
```
All `pkg/arkade` and `pkg/arkade/cashupool` tests green; `gofmt`/`go vet` clean.

## Deferred: Phase 6 (live arkd+emulator integration)

The end-to-end integration test (genesis → claim → claim → negatives on a real regtest stack) is **not** in this PR. The repos integration harness is mid-migration off nigiri (#94 → `arkade-regtest#27`, both unmerged), so it cant run green in any currently-available configuration. It will be added against the new Node-driven regtest once that migration lands.

## Design docs (not committed, per repo policy)

`docs/superpowers/specs/2026-06-03-cashu-nullifier-pool-poc-design.md` and the implementation plan capture the full design, decisions, and the v1-zec relationship.
@