### PR TITLE
Standardize asset introspection with canonical asset id

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,16 +357,22 @@ These opcodes allow incremental SHA256 hashing by maintaining hash state on the 
 
 ### Asset Introspection Opcodes
 
-These opcodes provide access to the Arkade Asset V1 packet embedded in the transaction. Asset IDs are represented as two stack items: (txid32, gidx_u16).
+These opcodes provide access to the Arkade Asset V1 packet embedded in the transaction.
+
+An **Asset ID** is the canonical, position-independent identity of an asset. It is represented as two consecutive stack items, `asset_txid asset_gidx`, where `asset_txid` (32 bytes) is the asset's issuance transaction ID and `asset_gidx` is the group index at which the asset was issued (a minimally encoded ScriptNum in `0..65535`). For a fresh issuance the Asset ID is `(this transaction's ID, k)`, where `k` is the group's position in this packet.
+
+`k` is reserved throughout for a **current packet group position** — the index of a group in this transaction's packet. It is distinct from `asset_gidx`: the two coincide only for fresh issuances. Use `OP_FINDASSETGROUPBYASSETID` to convert a canonical Asset ID into the `k` consumed by the structural per-group opcodes.
+
+An intent input's source transaction ID is **not** an Asset ID; it is available through `OP_INSPECTASSETGROUP` and is never emitted or matched by the canonical opcodes.
 
 #### Packet & Groups
 
 | Word | Opcode | Hex | Input | Output | Description |
 |------|--------|-----|-------|--------|-------------|
 | OP_INSPECTNUMASSETGROUPS | 229 | 0xe5 | Nothing | K | Returns the number of asset groups in the packet. |
-| OP_INSPECTASSETGROUPASSETID | 230 | 0xe6 | k | txid32 gidx_u16 | Returns the Asset ID of group k. Fresh groups use this transaction's ID. |
-| OP_INSPECTASSETGROUPCTRL | 231 | 0xe7 | k | -1 or txid32 gidx_u16 | Returns the control Asset ID if present, else -1. |
-| OP_FINDASSETGROUPBYASSETID | 232 | 0xe8 | txid32 gidx_u16 | -1 or k | Finds group index by Asset ID, or -1 if absent. |
+| OP_INSPECTASSETGROUPASSETID | 230 | 0xe6 | k | asset_txid asset_gidx | Returns the canonical Asset ID of packet group k. Fresh groups use this transaction's ID and k. |
+| OP_INSPECTASSETGROUPCTRL | 231 | 0xe7 | k | control_asset_txid control_asset_gidx 1, or empty_bytes 0 0 | Returns the canonical Asset ID of the control asset and a success flag, or `empty_bytes 0 0` when absent. References stored by packet group index are resolved to their canonical Asset ID. |
+| OP_FINDASSETGROUPBYASSETID | 232 | 0xe8 | asset_txid asset_gidx | k 1, or 0 0 | Converts a canonical Asset ID to its current packet group position k with a success flag, or `0 0` when the Asset ID is not in the packet. |
 
 #### Metadata
 
@@ -392,13 +398,13 @@ These opcodes provide access to the Arkade Asset V1 packet embedded in the trans
 | Word | Opcode | Hex | Input | Output | Description |
 |------|--------|-----|-------|--------|-------------|
 | OP_INSPECTOUTASSETCOUNT | 237 | 0xed | o | n | Returns number of asset entries assigned to output o. |
-| OP_INSPECTOUTASSETAT | 238 | 0xee | o t | txid32 gidx_u16 amount | Returns t-th asset at output o. Amount is pushed as a BigNum. |
-| OP_INSPECTOUTASSETLOOKUP | 239 | 0xef | o txid32 gidx_u16 | amount or -1 | Returns amount of asset at output o, or -1 if not found. Amount is pushed as a BigNum. |
+| OP_INSPECTOUTASSETAT | 238 | 0xee | o t | asset_txid asset_gidx amount | Returns the canonical Asset ID and amount of the t-th asset entry at output o. `asset_gidx` is the issuance group index, directly consumable by OP_INSPECTOUTASSETLOOKUP. Amount is pushed as a BigNum. |
+| OP_INSPECTOUTASSETLOOKUP | 239 | 0xef | o asset_txid asset_gidx | amount 1, or 0 0 | Returns the amount of the asset with the given canonical Asset ID at output o and a success flag, or `0 0` when absent. Amount is pushed as a BigNum. |
 
 #### Cross-Input (Packet-Declared)
 
 | Word | Opcode | Hex | Input | Output | Description |
 |------|--------|-----|-------|--------|-------------|
 | OP_INSPECTINASSETCOUNT | 240 | 0xf0 | i | n | Returns number of assets declared for input i. |
-| OP_INSPECTINASSETAT | 241 | 0xf1 | i t | txid32 gidx_u16 amount | Returns t-th asset declared for input i. Amount is pushed as a BigNum. |
-| OP_INSPECTINASSETLOOKUP | 242 | 0xf2 | i txid32 gidx_u16 | amount or -1 | Returns declared amount for asset at input i, or -1 if not found. Amount is pushed as a BigNum. |
+| OP_INSPECTINASSETAT | 241 | 0xf1 | i t | asset_txid asset_gidx amount | Returns the canonical Asset ID and amount of the t-th asset entry declared for input i. `asset_txid` is always the issuance transaction ID, never an intent input's source txid. Amount is pushed as a BigNum. |
+| OP_INSPECTINASSETLOOKUP | 242 | 0xf2 | i asset_txid asset_gidx | amount 1, or 0 0 | Returns the declared amount for the asset with the given canonical Asset ID at input i and a success flag, or `0 0` when absent. An intent input's source txid is never accepted as the Asset ID. Amount is pushed as a BigNum. |

--- a/pkg/arkade/asset_opcodes.go
+++ b/pkg/arkade/asset_opcodes.go
@@ -18,8 +18,9 @@ func opcodeInspectNumAssetGroups(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectAssetGroupAssetId pops a group index k and pushes the asset ID (txid, index) for that group.
-// If the group has no AssetId, pushes the current transaction hash and k.
+// opcodeInspectAssetGroupAssetId pops a packet group position k and pushes the
+// canonical AssetID (asset_txid, asset_gidx) of that group. A fresh issuance
+// derives its identity from the current transaction hash and k.
 func opcodeInspectAssetGroupAssetId(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -34,17 +35,9 @@ func opcodeInspectAssetGroupAssetId(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidStackOperation, "group index out of range")
 	}
 
-	group := vm.assetPacket[int(k)]
-
-	if group.AssetId == nil {
-		txHash := vm.tx.TxHash()
-		vm.dstack.PushByteArray(txHash[:])
-		vm.dstack.PushInt(scriptNum(k))
-		return nil
-	}
-
-	vm.dstack.PushByteArray(group.AssetId.Txid[:])
-	vm.dstack.PushInt(scriptNum(group.AssetId.Index))
+	id := resolveAssetID(vm.tx.TxHash(), int(k), vm.assetPacket[int(k)])
+	vm.dstack.PushByteArray(id.Txid[:])
+	vm.dstack.PushInt(scriptNum(id.Index))
 	return nil
 }
 
@@ -83,66 +76,39 @@ func opcodeInspectAssetGroupCtrl(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if group.ControlAsset.Type == asset.AssetRefByGroup {
-		if group.ControlAsset.GroupIndex >= uint16(len(vm.assetPacket)) {
+		k := int(group.ControlAsset.GroupIndex)
+		if k >= len(vm.assetPacket) {
 			return scriptError(txscript.ErrInvalidStackOperation, "control asset group index out of range")
 		}
-		ctrlGroup := vm.assetPacket[group.ControlAsset.GroupIndex]
-		if ctrlGroup.AssetId == nil {
-			// Referenced group is a fresh issuance, use current tx hash and the group index
-			txHash := vm.tx.TxHash()
-			vm.dstack.PushByteArray(txHash[:])
-			vm.dstack.PushInt(scriptNum(group.ControlAsset.GroupIndex))
-			vm.dstack.PushInt(1)
-		} else {
-			vm.dstack.PushByteArray(ctrlGroup.AssetId.Txid[:])
-			vm.dstack.PushInt(scriptNum(ctrlGroup.AssetId.Index))
-			vm.dstack.PushInt(1)
-		}
+		id := resolveAssetID(vm.tx.TxHash(), k, vm.assetPacket[k])
+		vm.dstack.PushByteArray(id.Txid[:])
+		vm.dstack.PushInt(scriptNum(id.Index))
+		vm.dstack.PushInt(1)
 		return nil
 	}
 
 	return scriptError(txscript.ErrInvalidStackOperation, "invalid control asset type")
 }
 
-// opcodeFindAssetGroupByAssetId pops an asset ID (gidx, txid) and searches for
-// the matching group index.
-// Found:   pushes group index, 1.
+// opcodeFindAssetGroupByAssetId pops a canonical AssetID (asset_txid asset_gidx)
+// and searches for the packet group whose resolved canonical AssetID matches.
+// Found:   pushes the packet group position k, 1.
 // Missing: pushes 0, 0.
 func opcodeFindAssetGroupByAssetId(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
 	}
 
-	gidx, err := vm.dstack.PopInt()
+	searchTxid, searchGidx, err := popAssetID(vm)
 	if err != nil {
 		return err
 	}
 
-	txidBytes, err := vm.dstack.PopByteArray()
-	if err != nil {
-		return err
-	}
-
-	if len(txidBytes) != 32 {
-		return scriptError(txscript.ErrInvalidStackOperation, "invalid txid length")
-	}
-
-	var searchTxid chainhash.Hash
-	copy(searchTxid[:], txidBytes)
-
-	for i, group := range vm.assetPacket {
-		if group.AssetId == nil {
-			txHash := vm.tx.TxHash()
-			if txHash.IsEqual(&searchTxid) && scriptNum(i) == gidx {
-				vm.dstack.PushInt(scriptNum(i))
-				vm.dstack.PushInt(1)
-				return nil
-			}
-			continue
-		}
-
-		if group.AssetId.Txid.IsEqual(&searchTxid) && scriptNum(group.AssetId.Index) == gidx {
-			vm.dstack.PushInt(scriptNum(i))
+	txHash := vm.tx.TxHash()
+	for k, group := range vm.assetPacket {
+		id := resolveAssetID(txHash, k, group)
+		if assetIDEqual(id, searchTxid, searchGidx) {
+			vm.dstack.PushInt(scriptNum(k))
 			vm.dstack.PushInt(1)
 			return nil
 		}
@@ -349,7 +315,8 @@ func opcodeInspectOutAssetCount(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectOutAssetAt pops asset index t and output index o, then pushes the asset entry (txid, gidx, amount).
+// opcodeInspectOutAssetAt pops asset index t and output index o, then pushes the
+// asset entry as its canonical AssetID (asset_txid asset_gidx) and amount.
 func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -372,19 +339,13 @@ func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 	txHash := vm.tx.TxHash()
 	idx := 0
 
-	for gidx, group := range vm.assetPacket {
-		var assetTxid chainhash.Hash
-		if group.AssetId == nil {
-			assetTxid = txHash
-		} else {
-			assetTxid = group.AssetId.Txid
-		}
-
+	for k, group := range vm.assetPacket {
+		id := resolveAssetID(txHash, k, group)
 		for _, output := range group.Outputs {
 			if uint32(output.Vout) == uint32(o) {
 				if scriptNum(idx) == t {
-					vm.dstack.PushByteArray(assetTxid[:])
-					vm.dstack.PushInt(scriptNum(gidx))
+					vm.dstack.PushByteArray(id.Txid[:])
+					vm.dstack.PushInt(scriptNum(id.Index))
 					if err := vm.dstack.PushBigNum(BigNumFromUint64(output.Amount)); err != nil {
 						return err
 					}
@@ -398,7 +359,8 @@ func opcodeInspectOutAssetAt(op *opcode, data []byte, vm *Engine) error {
 	return scriptError(txscript.ErrInvalidStackOperation, "asset index out of range")
 }
 
-// opcodeInspectOutAssetLookup pops gidx, txid, and output index o, then looks up the asset amount.
+// opcodeInspectOutAssetLookup pops a canonical AssetID (asset_txid asset_gidx)
+// and an output index o, then looks up the matching asset output amount.
 // Found:     pushes the amount as a minimally-encoded BigNum, then 1 (success flag).
 // Not found: pushes 0 (BigNum), then 0 (failure flag).
 func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
@@ -406,12 +368,7 @@ func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
 	}
 
-	gidx, err := vm.dstack.PopInt()
-	if err != nil {
-		return err
-	}
-
-	txidBytes, err := vm.dstack.PopByteArray()
+	searchTxid, searchGidx, err := popAssetID(vm)
 	if err != nil {
 		return err
 	}
@@ -421,28 +378,11 @@ func opcodeInspectOutAssetLookup(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	if len(txidBytes) != 32 {
-		return scriptError(txscript.ErrInvalidStackOperation, "invalid txid length")
-	}
-
-	var searchTxid chainhash.Hash
-	copy(searchTxid[:], txidBytes)
-
 	txHash := vm.tx.TxHash()
 
-	for groupIdx, group := range vm.assetPacket {
-		if scriptNum(groupIdx) != gidx {
-			continue
-		}
-
-		var assetTxid chainhash.Hash
-		if group.AssetId == nil {
-			assetTxid = txHash
-		} else {
-			assetTxid = group.AssetId.Txid
-		}
-
-		if !assetTxid.IsEqual(&searchTxid) {
+	for k, group := range vm.assetPacket {
+		id := resolveAssetID(txHash, k, group)
+		if !assetIDEqual(id, searchTxid, searchGidx) {
 			continue
 		}
 
@@ -488,7 +428,10 @@ func opcodeInspectInAssetCount(op *opcode, data []byte, vm *Engine) error {
 	return nil
 }
 
-// opcodeInspectInAssetAt pops asset index t and input index i, then pushes the asset entry (txid, gidx, amount).
+// opcodeInspectInAssetAt pops asset index t and input index i, then pushes the
+// asset entry as its canonical AssetID (asset_txid asset_gidx) and amount. The
+// emitted asset_txid is always the asset's issuance transaction ID, never an
+// intent input's intent_txid.
 func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 	if vm.assetPacket == nil {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
@@ -511,26 +454,13 @@ func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 	txHash := vm.tx.TxHash()
 	idx := 0
 
-	for gidx, group := range vm.assetPacket {
-		var assetTxid chainhash.Hash
-		if group.AssetId == nil {
-			assetTxid = txHash
-		} else {
-			assetTxid = group.AssetId.Txid
-		}
-
+	for k, group := range vm.assetPacket {
+		id := resolveAssetID(txHash, k, group)
 		for _, input := range group.Inputs {
 			if uint32(input.Vin) == uint32(i) {
 				if scriptNum(idx) == t {
-					var inputTxid chainhash.Hash
-					if input.Type == asset.AssetInputTypeIntent {
-						inputTxid = input.Txid
-					} else {
-						inputTxid = assetTxid
-					}
-
-					vm.dstack.PushByteArray(inputTxid[:])
-					vm.dstack.PushInt(scriptNum(gidx))
+					vm.dstack.PushByteArray(id.Txid[:])
+					vm.dstack.PushInt(scriptNum(id.Index))
 					if err := vm.dstack.PushBigNum(BigNumFromUint64(input.Amount)); err != nil {
 						return err
 					}
@@ -544,7 +474,10 @@ func opcodeInspectInAssetAt(op *opcode, data []byte, vm *Engine) error {
 	return scriptError(txscript.ErrInvalidStackOperation, "asset index out of range")
 }
 
-// opcodeInspectInAssetLookup pops gidx, txid, and input index i, then looks up the asset amount.
+// opcodeInspectInAssetLookup pops a canonical AssetID (asset_txid asset_gidx)
+// and an input index i, then looks up the matching asset input amount. Matching
+// is by canonical AssetID only; an intent input's intent_txid is never accepted
+// as a substitute for the issuance asset_txid.
 // Found:     pushes the amount as a minimally-encoded BigNum, then 1 (success flag).
 // Not found: pushes 0 (BigNum), then 0 (failure flag).
 func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
@@ -552,12 +485,7 @@ func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidStackOperation, "no asset packet")
 	}
 
-	gidx, err := vm.dstack.PopInt()
-	if err != nil {
-		return err
-	}
-
-	txidBytes, err := vm.dstack.PopByteArray()
+	searchTxid, searchGidx, err := popAssetID(vm)
 	if err != nil {
 		return err
 	}
@@ -567,40 +495,16 @@ func opcodeInspectInAssetLookup(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	if len(txidBytes) != 32 {
-		return scriptError(txscript.ErrInvalidStackOperation, "invalid txid length")
-	}
-
-	var searchTxid chainhash.Hash
-	copy(searchTxid[:], txidBytes)
-
 	txHash := vm.tx.TxHash()
 
-	for groupIdx, group := range vm.assetPacket {
-		if scriptNum(groupIdx) != gidx {
+	for k, group := range vm.assetPacket {
+		id := resolveAssetID(txHash, k, group)
+		if !assetIDEqual(id, searchTxid, searchGidx) {
 			continue
 		}
 
-		var assetTxid chainhash.Hash
-		if group.AssetId == nil {
-			assetTxid = txHash
-		} else {
-			assetTxid = group.AssetId.Txid
-		}
-
 		for _, input := range group.Inputs {
-			if uint32(input.Vin) != uint32(i) {
-				continue
-			}
-
-			var inputTxid chainhash.Hash
-			if input.Type == asset.AssetInputTypeIntent {
-				inputTxid = input.Txid
-			} else {
-				inputTxid = assetTxid
-			}
-
-			if inputTxid.IsEqual(&searchTxid) {
+			if uint32(input.Vin) == uint32(i) {
 				if err := vm.dstack.PushBigNum(BigNumFromUint64(input.Amount)); err != nil {
 					return err
 				}
@@ -667,4 +571,55 @@ func safeSumOutputs(outputs []asset.AssetOutput) *big.Int {
 		sum.Add(sum, new(big.Int).SetUint64(output.Amount))
 	}
 	return sum
+}
+
+// maxAssetGroupIndex is the inclusive upper bound for a canonical asset_gidx,
+// matching the uint16 Asset V1 field.
+const maxAssetGroupIndex = 65535
+
+// resolveAssetID returns the canonical AssetID of the packet group at position k.
+// A group with an explicit AssetId is returned as stored; a fresh issuance
+// derives its identity from the current transaction hash and its packet
+// position. Callers must pass a k already validated to lie in [0, len(packet)),
+// so casting it to the uint16 asset_gidx field is always safe.
+func resolveAssetID(txHash chainhash.Hash, k int, group asset.AssetGroup) asset.AssetId {
+	if group.AssetId != nil {
+		return *group.AssetId
+	}
+	return asset.AssetId{Txid: txHash, Index: uint16(k)}
+}
+
+// popAssetID pops and validates a two-item canonical AssetID from the stack. The
+// items are, from the top, asset_gidx then asset_txid. asset_txid must be
+// exactly 32 bytes and asset_gidx must be a minimally encoded ScriptNum in the
+// range [0, 65535]. Any violation is a script error.
+func popAssetID(vm *Engine) (chainhash.Hash, uint16, error) {
+	var txid chainhash.Hash
+
+	gidx, err := vm.dstack.PopInt()
+	if err != nil {
+		return txid, 0, err
+	}
+
+	txidBytes, err := vm.dstack.PopByteArray()
+	if err != nil {
+		return txid, 0, err
+	}
+
+	if len(txidBytes) != 32 {
+		return txid, 0, scriptError(txscript.ErrInvalidStackOperation, "invalid asset_txid length")
+	}
+
+	if gidx < 0 || gidx > maxAssetGroupIndex {
+		return txid, 0, scriptError(txscript.ErrInvalidStackOperation, "asset_gidx out of range")
+	}
+
+	copy(txid[:], txidBytes)
+	return txid, uint16(gidx), nil
+}
+
+// assetIDEqual reports whether a resolved canonical AssetID equals the supplied
+// (txid, gidx) pair, comparing the complete pair.
+func assetIDEqual(id asset.AssetId, txid chainhash.Hash, gidx uint16) bool {
+	return id.Index == gidx && id.Txid.IsEqual(&txid)
 }

--- a/pkg/arkade/asset_opcodes_test.go
+++ b/pkg/arkade/asset_opcodes_test.go
@@ -88,6 +88,23 @@ func TestAssetOpcodes(t *testing.T) {
 		},
 	}
 
+	// Packet whose control asset references a fresh issuance by packet group
+	// index, so its canonical AssetID resolves to (txHash, referenced position).
+	ctrlByGroupFreshPacket := asset.Packet{
+		{
+			AssetId: nil, // fresh issuance at packet position 0
+			Outputs: []asset.AssetOutput{{Vout: 0, Amount: 100}},
+		},
+		{
+			AssetId: nil, // fresh issuance whose control references group 0
+			ControlAsset: &asset.AssetRef{
+				Type:       asset.AssetRefByGroup,
+				GroupIndex: 0,
+			},
+			Outputs: []asset.AssetOutput{{Vout: 1, Amount: 200}},
+		},
+	}
+
 	// Packet with amounts exceeding the former scriptNum 4-byte limit (2^31-1).
 	// Group 0: existing asset, 2 inputs totaling 10B, 1 output of 3B.
 	largeAmountPacket := asset.Packet{
@@ -129,6 +146,26 @@ func TestAssetOpcodes(t *testing.T) {
 		},
 	}
 
+	// Packet with two groups that share the same asset_txid but have distinct
+	// canonical asset_gidx values, at packet positions unrelated to either
+	// canonical index. Group 2 is a fresh issuance at a nonzero packet position.
+	sameTxidPacket := asset.Packet{
+		{
+			AssetId: &asset.AssetId{Txid: assetTxid, Index: 10},
+			Inputs:  []asset.AssetInput{{Type: asset.AssetInputTypeLocal, Vin: 0, Amount: 111}},
+			Outputs: []asset.AssetOutput{{Vout: 0, Amount: 111}},
+		},
+		{
+			AssetId: &asset.AssetId{Txid: assetTxid, Index: 20},
+			Inputs:  []asset.AssetInput{{Type: asset.AssetInputTypeLocal, Vin: 1, Amount: 222}},
+			Outputs: []asset.AssetOutput{{Vout: 1, Amount: 222}},
+		},
+		{
+			AssetId: nil, // fresh issuance at packet position 2
+			Outputs: []asset.AssetOutput{{Vout: 1, Amount: 333}},
+		},
+	}
+
 	// Packet with metadata.
 	md1, _ := asset.NewMetadata("name", "TestToken")
 	md2, _ := asset.NewMetadata("symbol", "TT")
@@ -140,7 +177,6 @@ func TestAssetOpcodes(t *testing.T) {
 			Metadata: []asset.Metadata{*md1, *md2},
 		},
 	}
-
 	// Compute expected metadata hash.
 	expectedMetadataHash, _ := computeMetadataMerkleRoot(metadataPacket[0].Metadata)
 
@@ -170,6 +206,7 @@ func TestAssetOpcodes(t *testing.T) {
 			{Value: 300, PkScript: nil},
 		},
 	}
+	simpleTxHash := simpleTx.TxHash()
 
 	type testCase struct {
 		valid       bool
@@ -220,18 +257,14 @@ func TestAssetOpcodes(t *testing.T) {
 		{
 			name: "OP_INSPECTASSETGROUPASSETID_fresh_issuance",
 			// For fresh issuance (nil AssetId), the opcode pushes the current tx hash and the group index.
-			// We verify the group index == 1 using EQUALVERIFY, then drop the txid with TRUE.
+			// Verify both components of the derived canonical AssetID exactly.
 			script: txscript.NewScriptBuilder().
 				AddInt64(1). // group index (fresh issuance)
 				AddOp(OP_INSPECTASSETGROUPASSETID).
 				AddInt64(1). // expected group index as gidx
 				AddOp(OP_EQUALVERIFY).
-				// txid is the tx hash - just check it's 32 bytes via SIZE
-				AddOp(OP_SIZE).
-				AddInt64(32).
-				AddOp(OP_EQUALVERIFY).
-				AddOp(OP_DROP). // drop the txid
-				AddOp(OP_TRUE),
+				AddData(simpleTxHash[:]).
+				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
 			},
@@ -583,15 +616,16 @@ func TestAssetOpcodes(t *testing.T) {
 		{
 			name: "OP_INSPECTOUTASSETAT_output0_first",
 			// Output 0, asset 0: from group 0 (existing asset).
+			// Emits the canonical asset_gidx (3), not the packet position (0).
 			script: txscript.NewScriptBuilder().
 				AddInt64(0). // output index
 				AddInt64(0). // asset index
 				AddOp(OP_INSPECTOUTASSETAT).
 				AddInt64(800). // amount
 				AddOp(OP_EQUALVERIFY).
-				AddInt64(0). // gidx (group index in packet)
+				AddInt64(3). // canonical asset_gidx (issuance index)
 				AddOp(OP_EQUALVERIFY).
-				AddData(assetTxid[:]). // txid
+				AddData(assetTxid[:]). // asset_txid
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -613,8 +647,8 @@ func TestAssetOpcodes(t *testing.T) {
 			name: "OP_INSPECTOUTASSETLOOKUP_found",
 			script: txscript.NewScriptBuilder().
 				AddInt64(0).           // output index
-				AddData(assetTxid[:]). // txid
-				AddInt64(0).           // gidx (group index in packet)
+				AddData(assetTxid[:]). // asset_txid
+				AddInt64(3).           // canonical asset_gidx
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
 				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUALVERIFY).
@@ -626,10 +660,12 @@ func TestAssetOpcodes(t *testing.T) {
 		},
 		{
 			name: "OP_INSPECTOUTASSETLOOKUP_not_found",
+			// Canonical AssetID (assetTxid, 3) exists but its only output is at
+			// vout 0, so a lookup at output 1 returns absent.
 			script: txscript.NewScriptBuilder().
 				AddInt64(1).           // output 1
-				AddData(assetTxid[:]). // txid
-				AddInt64(0).           // gidx 0
+				AddData(assetTxid[:]). // asset_txid
+				AddInt64(3).           // canonical asset_gidx
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
 				AddOp(OP_NOT). // flag=0 → NOT → true
 				AddOp(OP_VERIFY).
@@ -681,16 +717,16 @@ func TestAssetOpcodes(t *testing.T) {
 		{
 			name: "OP_INSPECTINASSETAT_local",
 			// Input 0, asset 0: local input from group 0.
-			// For local inputs, txid = group's asset txid.
+			// Emits the canonical AssetID (asset_txid, asset_gidx=3).
 			script: txscript.NewScriptBuilder().
 				AddInt64(0). // input index
 				AddInt64(0). // asset index
 				AddOp(OP_INSPECTINASSETAT).
 				AddInt64(500). // amount
 				AddOp(OP_EQUALVERIFY).
-				AddInt64(0). // gidx (group index)
+				AddInt64(3). // canonical asset_gidx
 				AddOp(OP_EQUALVERIFY).
-				AddData(assetTxid[:]). // txid (group's asset txid for local)
+				AddData(assetTxid[:]). // asset_txid
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -699,16 +735,16 @@ func TestAssetOpcodes(t *testing.T) {
 		{
 			name: "OP_INSPECTINASSETAT_intent",
 			// Input 1, asset 0: intent input from group 0.
-			// For intent inputs, txid = intent txid.
+			// Emits the canonical issuance AssetID, never the intent_txid.
 			script: txscript.NewScriptBuilder().
 				AddInt64(1). // input index
 				AddInt64(0). // asset index
 				AddOp(OP_INSPECTINASSETAT).
 				AddInt64(300). // amount
 				AddOp(OP_EQUALVERIFY).
-				AddInt64(0). // gidx (group index)
+				AddInt64(3). // canonical asset_gidx
 				AddOp(OP_EQUALVERIFY).
-				AddData(intentTxid[:]). // txid (intent txid)
+				AddData(assetTxid[:]). // canonical asset_txid (not intent_txid)
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: twoGroupPacket},
@@ -728,11 +764,11 @@ func TestAssetOpcodes(t *testing.T) {
 		// ========== OP_INSPECTINASSETLOOKUP ==========
 		{
 			name: "OP_INSPECTINASSETLOOKUP_local_found",
-			// Lookup local input: input 0, group 0 asset txid => 500.
+			// Lookup local input: input 0, canonical AssetID => 500.
 			script: txscript.NewScriptBuilder().
 				AddInt64(0).           // input index
-				AddData(assetTxid[:]). // txid (group's asset txid for local)
-				AddInt64(0).           // gidx
+				AddData(assetTxid[:]). // asset_txid
+				AddInt64(3).           // canonical asset_gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
 				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUALVERIFY).
@@ -744,11 +780,11 @@ func TestAssetOpcodes(t *testing.T) {
 		},
 		{
 			name: "OP_INSPECTINASSETLOOKUP_intent_found",
-			// Lookup intent input: input 1, intent txid => 300.
+			// Lookup intent input by its canonical AssetID => 300.
 			script: txscript.NewScriptBuilder().
-				AddInt64(1).            // input index
-				AddData(intentTxid[:]). // txid (intent txid)
-				AddInt64(0).            // gidx
+				AddInt64(1).           // input index
+				AddData(assetTxid[:]). // canonical asset_txid (not intent_txid)
+				AddInt64(3).           // canonical asset_gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
 				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUALVERIFY).
@@ -759,11 +795,28 @@ func TestAssetOpcodes(t *testing.T) {
 			},
 		},
 		{
+			name: "OP_INSPECTINASSETLOOKUP_intent_txid_rejected",
+			// Supplying the intent_txid instead of the canonical asset_txid
+			// must not match: returns absent.
+			script: txscript.NewScriptBuilder().
+				AddInt64(1).            // input index
+				AddData(intentTxid[:]). // intent_txid, not a valid AssetID
+				AddInt64(3).            // correct canonical asset_gidx
+				AddOp(OP_INSPECTINASSETLOOKUP).
+				AddOp(OP_NOT). // flag=0 → NOT → true
+				AddOp(OP_VERIFY).
+				AddInt64(0). // expected dummy 0
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: twoGroupPacket},
+			},
+		},
+		{
 			name: "OP_INSPECTINASSETLOOKUP_not_found",
 			script: txscript.NewScriptBuilder().
 				AddInt64(0).           // input index
-				AddData(assetTxid[:]). // txid
-				AddInt64(5).           // wrong gidx
+				AddData(assetTxid[:]). // asset_txid
+				AddInt64(5).           // wrong canonical asset_gidx
 				AddOp(OP_INSPECTINASSETLOOKUP).
 				AddOp(OP_NOT). // flag=0 → NOT → true
 				AddOp(OP_VERIFY).
@@ -864,9 +917,9 @@ func TestAssetOpcodes(t *testing.T) {
 				AddInt64(2_000_000_000).      // threshold
 				AddOp(OP_GREATERTHANOREQUAL). // 3B >= 2B → true
 				AddOp(OP_VERIFY).
-				AddInt64(0). // gidx
+				AddInt64(3). // canonical asset_gidx
 				AddOp(OP_EQUALVERIFY).
-				AddData(assetTxid[:]). // txid
+				AddData(assetTxid[:]). // asset_txid
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: largeAmountPacket},
@@ -877,8 +930,8 @@ func TestAssetOpcodes(t *testing.T) {
 			// Lookup with large amount returns amount.
 			script: txscript.NewScriptBuilder().
 				AddInt64(0).           // output index
-				AddData(assetTxid[:]). // txid
-				AddInt64(0).           // gidx
+				AddData(assetTxid[:]). // asset_txid
+				AddInt64(3).           // canonical asset_gidx
 				AddOp(OP_INSPECTOUTASSETLOOKUP).
 				AddOp(OP_1). // verify success flag
 				AddOp(OP_EQUALVERIFY).
@@ -886,6 +939,264 @@ func TestAssetOpcodes(t *testing.T) {
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{valid: true, assetPacket: largeAmountPacket},
+			},
+		},
+
+		// ========== Canonical AssetID: same txid, distinct canonical gidx ==========
+		{
+			name: "canonical_find_first_of_shared_txid",
+			// (assetTxid, 10) resolves to packet position 0.
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddInt64(10).
+				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(0). // packet position k
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_find_second_of_shared_txid",
+			// (assetTxid, 20) resolves to packet position 1.
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddInt64(20).
+				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(1). // packet position k
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_out_at_emits_canonical_gidx",
+			// Output 1's first entry belongs to packet group 1 with canonical gidx 20.
+			script: txscript.NewScriptBuilder().
+				AddInt64(1). // output index
+				AddInt64(0). // asset index
+				AddOp(OP_INSPECTOUTASSETAT).
+				AddInt64(222). // amount
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(20). // canonical asset_gidx (not packet position 1)
+				AddOp(OP_EQUALVERIFY).
+				AddData(assetTxid[:]).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_out_lookup_wrong_gidx_absent",
+			// Output 0 carries (assetTxid, 10), not (assetTxid, 20).
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // output index
+				AddData(assetTxid[:]).
+				AddInt64(20). // canonical asset_gidx of the other group
+				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddOp(OP_NOT).
+				AddOp(OP_VERIFY).
+				AddInt64(0).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_out_lookup_wrong_txid_absent",
+			// Right canonical gidx, wrong issuance txid.
+			script: txscript.NewScriptBuilder().
+				AddInt64(0). // output index
+				AddData(ctrlTxid[:]).
+				AddInt64(10).
+				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddOp(OP_NOT).
+				AddOp(OP_VERIFY).
+				AddInt64(0).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_out_lookup_wrong_output_absent",
+			// Valid AssetID (assetTxid, 10) but requested at output 99.
+			script: txscript.NewScriptBuilder().
+				AddInt64(99). // output index
+				AddData(assetTxid[:]).
+				AddInt64(10).
+				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddOp(OP_NOT).
+				AddOp(OP_VERIFY).
+				AddInt64(0).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+
+		// ========== Fresh issuance at nonzero packet position ==========
+		{
+			name: "canonical_fresh_issuance_group_resolution_round_trip",
+			// k OP_INSPECTASSETGROUPASSETID => txHash k ; feeding it back into
+			// OP_FINDASSETGROUPBYASSETID recovers the same packet position.
+			script: txscript.NewScriptBuilder().
+				AddInt64(2). // packet position of the fresh issuance
+				AddOp(OP_INSPECTASSETGROUPASSETID).
+				// stack: asset_txid asset_gidx
+				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(2). // recovered packet position k
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_fresh_issuance_output_round_trip",
+			// OUTASSETAT emits the fresh issuance's canonical ID; that ID is
+			// directly consumable by OUTASSETLOOKUP at the same output.
+			script: txscript.NewScriptBuilder().
+				AddInt64(1). // output index
+				AddInt64(1). // second asset entry is the fresh issuance
+				AddOp(OP_INSPECTOUTASSETAT).
+				// stack: asset_txid asset_gidx amount
+				AddInt64(333).
+				AddOp(OP_EQUALVERIFY).
+				// stack: asset_txid asset_gidx ; build "o asset_txid asset_gidx".
+				AddInt64(1).
+				AddOp(OP_ROT).
+				AddOp(OP_ROT).
+				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(333).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+
+		// ========== Canonical AssetID operand validation ==========
+		{
+			name: "canonical_find_negative_gidx_error",
+			// OP_2DROP OP_TRUE makes the non-error path succeed, so failure can
+			// only come from operand validation rejecting the negative gidx.
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddInt64(-1).
+				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_2DROP).
+				AddOp(OP_TRUE),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_find_gidx_too_large_error",
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddInt64(65536). // exceeds uint16 ceiling
+				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_2DROP).
+				AddOp(OP_TRUE),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_find_gidx_max_ok",
+			// 65535 is in range; a well-formed but absent AssetID returns 0 0.
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddInt64(65535).
+				AddOp(OP_FINDASSETGROUPBYASSETID).
+				AddOp(OP_NOT).
+				AddOp(OP_VERIFY).
+				AddInt64(0).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_find_gidx_oversized_error",
+			// A 5-byte ScriptNum exceeds the 4-byte numeric limit.
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddData([]byte{0x01, 0x00, 0x00, 0x00, 0x00}).
+				AddOp(OP_FINDASSETGROUPBYASSETID),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_find_gidx_non_minimal_error",
+			// 10 with a redundant trailing zero byte is non-minimal.
+			script: txscript.NewScriptBuilder().
+				AddData(assetTxid[:]).
+				AddData([]byte{0x0a, 0x00}).
+				AddOp(OP_FINDASSETGROUPBYASSETID),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_find_txid_wrong_length_error",
+			script: txscript.NewScriptBuilder().
+				AddData(make([]byte, 31)). // not 32 bytes
+				AddInt64(10).
+				AddOp(OP_FINDASSETGROUPBYASSETID),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_out_lookup_gidx_too_large_error",
+			script: txscript.NewScriptBuilder().
+				AddInt64(5). // output index
+				AddData(assetTxid[:]).
+				AddInt64(65536).
+				AddOp(OP_INSPECTOUTASSETLOOKUP).
+				AddOp(OP_2DROP).
+				AddOp(OP_TRUE),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+		{
+			name: "canonical_in_lookup_txid_wrong_length_error",
+			script: txscript.NewScriptBuilder().
+				AddInt64(5).               // input index
+				AddData(make([]byte, 33)). // not 32 bytes
+				AddInt64(10).
+				AddOp(OP_INSPECTINASSETLOOKUP),
+			cases: []testCase{
+				{valid: false, assetPacket: sameTxidPacket},
+			},
+		},
+
+		// ========== Control asset canonical resolution ==========
+		{
+			name: "canonical_ctrl_by_group_fresh_issuance",
+			// Group 1's control references group 0 by packet index; group 0 is a
+			// fresh issuance, so the control AssetID resolves to (txHash, 0).
+			script: txscript.NewScriptBuilder().
+				AddInt64(1).
+				AddOp(OP_INSPECTASSETGROUPCTRL).
+				AddOp(OP_1).
+				AddOp(OP_EQUALVERIFY).
+				AddInt64(0). // canonical asset_gidx of the referenced fresh issuance
+				AddOp(OP_EQUALVERIFY).
+				AddData(simpleTxHash[:]).
+				AddOp(OP_EQUAL),
+			cases: []testCase{
+				{valid: true, assetPacket: ctrlByGroupFreshPacket},
 			},
 		},
 	}

--- a/pkg/arkade/opcode_fuzz_test.go
+++ b/pkg/arkade/opcode_fuzz_test.go
@@ -335,18 +335,22 @@ func (b assetLookupCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcod
 	}
 
 	var txid []byte
-	groupIdx := int64(0)
+	// Generate a canonical AssetID (asset_txid, asset_gidx) for the selected
+	// group rather than its current packet position.
+	assetGidx := int64(0)
 	if world.world.assetPacket != nil && len(world.world.assetPacket) > 0 {
-		group := world.world.assetPacket[int(data[1])%len(world.world.assetPacket)]
-		groupIdx = int64(int(data[1]) % len(world.world.assetPacket))
+		k := int(data[1]) % len(world.world.assetPacket)
+		group := world.world.assetPacket[k]
 		if group.AssetId == nil {
 			assetTxid := world.world.tx.TxHash()
 			txid = cloneBytes(assetTxid[:])
+			assetGidx = int64(k)
 		} else {
 			txid = cloneBytes(group.AssetId.Txid[:])
+			assetGidx = int64(group.AssetId.Index)
 		}
 		if data[2]&1 == 1 {
-			groupIdx = int64(len(world.world.assetPacket) + int(data[1]%4))
+			assetGidx += int64(len(world.world.assetPacket))
 		}
 	}
 	if len(txid) == 0 {
@@ -355,7 +359,7 @@ func (b assetLookupCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcod
 	if data[3]&1 == 1 {
 		txid[0] ^= 0xff
 	}
-	c.stackPushes = [][]byte{scriptNum(index).Bytes(), txid, scriptNum(groupIdx).Bytes()}
+	c.stackPushes = [][]byte{scriptNum(index).Bytes(), txid, scriptNum(assetGidx).Bytes()}
 	return c
 }
 

--- a/test/asset_account_covenant_test.go
+++ b/test/asset_account_covenant_test.go
@@ -65,8 +65,9 @@ const (
 //
 // Educational simplifications: the covenants do not pin the asset_id (and
 // drop the NUMASSETGROUPS == 1 gate). Asset substitution is therefore
-// possible and should be mitigated in production by pinning (txid, gidx)
-// on every OP_INSPECTOUTASSETAT call. Bob's account is also assumed empty
+// possible and should be mitigated in production by pinning the canonical
+// AssetID (asset_txid, asset_gidx) on every OP_INSPECTOUTASSETAT call. Bob's
+// account is also assumed empty
 // (0 USDT) before the claim, which lets bobClaim pin output[1] USDT to 50.
 func TestAssetAccountCovenant(t *testing.T) {
 	ctx := t.Context()
@@ -261,9 +262,9 @@ func TestAssetAccountCovenant(t *testing.T) {
 //	output[1] = alice account  (330 sats + 45 USDT, full pkScript match)
 //	output[2] = solver fee     (330 sats + 5 USDT, *any* pkScript)
 //
-// OP_INSPECTOUTASSETAT pushes (txid, gidx, amount). We drop txid+gidx with
-// OP_NIP OP_NIP and keep only the amount — see the test doc on the
-// asset-substitution caveat.
+// OP_INSPECTOUTASSETAT pushes (asset_txid, asset_gidx, amount). We drop the
+// canonical AssetID with OP_NIP OP_NIP and keep only the amount — see the test
+// doc on the asset-substitution caveat.
 func enforceSolverRouting(t *testing.T, bobClaimPk, aliceAccountPk []byte) []byte {
 	t.Helper()
 	s, err := txscript.NewScriptBuilder().

--- a/test/contract_id_test.go
+++ b/test/contract_id_test.go
@@ -388,8 +388,8 @@ func readerContractArkadeScript(t *testing.T, mainAssetTxid chainhash.Hash) []by
 	arkadeScript, err := txscript.NewScriptBuilder().
 		// Verify main contract asset at input 0.
 		AddInt64(0).               // input index
-		AddData(mainAssetTxid[:]). // asset txid (genesis tx hash)
-		AddInt64(0).               // group index in current packet
+		AddData(mainAssetTxid[:]). // canonical asset_txid (genesis tx hash)
+		AddInt64(0).               // canonical asset_gidx (issuance index)
 		AddOp(arkade.OP_INSPECTINASSETLOOKUP).
 		AddOp(arkade.OP_1).
 		AddOp(arkade.OP_EQUALVERIFY). // found flag == 1


### PR DESCRIPTION
## Summary

This PR standardizes asset introspection around canonical AssetIDs represented as `(asset_txid, asset_gidx)`.

It separates an asset’s issuance group index from its current packet position, ensures intent inputs use the issuance transaction ID rather than the intent source transaction ID, and adds strict AssetID operand validation.

## Opcode Changes

| Opcode | Input | Output | Change |
|---|---|---|---|
| `OP_INSPECTASSETGROUPASSETID` | `k` | `asset_txid asset_gidx` | Returns the canonical AssetID. Fresh issuances resolve to `(current_txid, k)`. |
| `OP_INSPECTASSETGROUPCTRL` | `k` | `asset_txid asset_gidx 1` or `empty 0 0` | Resolves group-based control references to canonical AssetIDs. |
| `OP_FINDASSETGROUPBYASSETID` | `asset_txid asset_gidx` | `k 1` or `0 0` | Finds the current packet position using the complete canonical AssetID. |
| `OP_INSPECTOUTASSETAT` | `output_index asset_index` | `asset_txid asset_gidx amount` | Emits canonical `asset_gidx` instead of the current packet position. |
| `OP_INSPECTOUTASSETLOOKUP` | `output_index asset_txid asset_gidx` | `amount 1` or `0 0` | Matches outputs by the complete canonical AssetID. |
| `OP_INSPECTINASSETAT` | `input_index asset_index` | `asset_txid asset_gidx amount` | Always emits the issuance AssetID, including for intent inputs. |
| `OP_INSPECTINASSETLOOKUP` | `input_index asset_txid asset_gidx` | `amount 1` or `0 0` | Matches canonical AssetIDs and no longer accepts intent source txids. |

## Validation

Malformed AssetIDs now produce script errors for:

- Asset transaction IDs that are not exactly 32 bytes
- Negative `asset_gidx` values
- `asset_gidx` values greater than `65535`
- Oversized ScriptNums
- Non-minimally encoded ScriptNums

## Additional Changes

- Added shared helpers for resolving, parsing, validating, and comparing canonical AssetIDs.
- Updated README opcode documentation and terminology.
- Updated fuzz generators to produce canonical AssetIDs.
- Updated covenant and contract identity examples.
- Expanded coverage for shared issuance txids, distinct issuance indices, fresh issuances, intent inputs, invalid operands, wrong IDs, and control-asset resolution.

## Testing

- `go test ./... -count=1` in `pkg/arkade`
- `TestContractIdWithAssetIdentity`
- `git diff --check`

`TestAssetAccountCovenant` reaches the local emulator but currently fails during setup with `VTXO_NOT_FOUND`, unrelated to these opcode changes.