### PR TITLE
Add missing OP_CAT result size check

### DIFF
--- a/pkg/arkade/engine_test.go
+++ b/pkg/arkade/engine_test.go
@@ -117,6 +117,38 @@ func TestNewOpcodes(t *testing.T) {
 			},
 		},
 		{
+			// OP_CAT must enforce the per-element size limit
+			// (MaxScriptElementSize == 520 bytes) on its result. Repeatedly
+			// duplicating and concatenating doubles the element size each
+			// round; without the limit this is an exponential-growth DoS.
+			// Starting from a 200-byte element: 200 -> 400 -> 800, so the
+			// second OP_CAT must fail.
+			name: "OP_CAT_growth_limit",
+			script: txscript.NewScriptBuilder().
+				AddOp(OP_DUP).AddOp(OP_CAT). // 200 -> 400
+				AddOp(OP_DUP).AddOp(OP_CAT), // 400 -> 800 (must fail)
+			cases: []testCase{
+				{
+					valid: false,
+					tx: &wire.MsgTx{
+						Version: 1,
+						TxIn: []*wire.TxIn{
+							{
+								PreviousOutPoint: wire.OutPoint{
+									Hash:  chainhash.Hash{},
+									Index: 0,
+								},
+							},
+						},
+					},
+					txIdx:       0,
+					inputAmount: 0,
+					stack:       [][]byte{bytes.Repeat([]byte{0x01}, 200)},
+					errText:     "exceeds max allowed size",
+				},
+			},
+		},
+		{
 			name:   "OP_DIV",
 			script: txscript.NewScriptBuilder().AddOp(OP_DIV).AddOp(OP_3).AddOp(OP_EQUAL),
 			cases: []testCase{

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -2154,6 +2154,12 @@ func opcodeCat(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
+	if len(x1)+len(x2) > txscript.MaxScriptElementSize {
+		str := fmt.Sprintf("concatenated size %d exceeds max allowed size %d",
+			len(x1)+len(x2), txscript.MaxScriptElementSize)
+		return scriptError(txscript.ErrElementTooBig, str)
+	}
+
 	vm.dstack.PushByteArray(append(x1, x2...))
 	return nil
 }

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -1342,12 +1342,35 @@ func catSpec() *opcodeSpec {
 				inputStack:    [][]byte{{0x01}, {0x02}},
 				expectedStack: [][]byte{{0x01, 0x02}},
 			},
+			{
+				// Concatenating to exactly MaxScriptElementSize (520) is
+				// allowed; only results strictly larger are rejected.
+				name: "result_at_max_element_size",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, 260),
+					bytes.Repeat([]byte{0x02}, 260),
+				},
+				expectedStack: [][]byte{
+					append(bytes.Repeat([]byte{0x01}, 260), bytes.Repeat([]byte{0x02}, 260)...),
+				},
+			},
 		},
 		invalidVectors: []opcodeVector{
 			{
 				name:          "underflow",
 				inputStack:    [][]byte{{0x01}},
 				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				// Two individually valid (<=520 byte) operands whose
+				// concatenation exceeds MaxScriptElementSize (520) must
+				// fail rather than produce an oversized stack element.
+				name: "result_exceeds_max_element_size",
+				inputStack: [][]byte{
+					bytes.Repeat([]byte{0x01}, 300),
+					bytes.Repeat([]byte{0x02}, 300),
+				},
+				expectedError: txscript.ErrElementTooBig,
 			},
 		},
 	}
@@ -1492,6 +1515,7 @@ func byteTransformPropertyChecker(op byte) opcodePropertyChecker {
 				txscript.ErrInvalidIndex,
 				txscript.ErrNumberTooBig,
 				txscript.ErrMinimalData,
+				txscript.ErrElementTooBig,
 			)
 			require.LessOrEqual(t, afterDepth, beforeDepth)
 			return


### PR DESCRIPTION
## Enforce stack element size limit in OP_CAT

**Problem:** `OP_CAT` concatenated two operands and pushed the result without checking it against `MaxScriptElementSize` (520 bytes). Two valid ≤520-byte elements could produce up to 1040 bytes, and repeated `OP_DUP OP_CAT` doubles the element each round — an unbounded exponential-growth DoS and a consensus-rule violation. It was the only element-producing opcode missing this check (all splice/bitwise/arithmetic/hash/introspection ops are already bounded).

**Fix:** Reject the operation with `ErrElementTooBig` when `len(x1)+len(x2) > MaxScriptElementSize`, matching the pattern already used by the packet-introspection opcodes.

**Tests:**
- Opcode-level: rejects oversized concat (300+300), allows exact boundary (260+260=520).
- Engine-level: `OP_CAT_growth_limit` proves the repeated-doubling attack now fails.