### PR TITLE
Backoff retry on arkd connect

### DIFF
--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/intent"
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
@@ -93,9 +94,11 @@ func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btc
 		deprecatedPublicKeys = append(deprecatedPublicKeys, hex.EncodeToString(deprecatedKey.PubKey().SerializeCompressed()))
 	}
 
-	// arkd may still be booting when the emulator starts, retry if it fails.
 	var arkdInfo *client.Info
-	err = retryWithBackoff(ctx, arkdConnectRetryConfig,
+
+	// arkd may still be booting when the emulator starts, retry if it fails.
+	err = retryWithBackoff(
+		ctx, arkdConnectRetryConfig,
 		func() error {
 			var e error
 			arkdInfo, e = arkdClient.GetInfo(ctx)
@@ -145,4 +148,12 @@ func (s *service) GetInfo(ctx context.Context) (*Info, error) {
 		SignerPublicKey:            s.publicKey,
 		DeprecatedSignerPublicKeys: append([]string(nil), s.deprecatedPublicKeys...),
 	}, nil
+}
+
+var arkdConnectRetryConfig = retryConfig{
+	MinAttempts:  0,
+	InitialDelay: 1 * time.Second,
+	MaxDelay:     45 * time.Second,
+	Multiplier:   2.0,
+	Jitter:       0.2,
 }

--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -12,6 +12,7 @@ import (
 	grpcclient "github.com/arkade-os/go-sdk/client/grpc"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	log "github.com/sirupsen/logrus"
 )
 
 type Info struct {
@@ -92,7 +93,18 @@ func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btc
 		deprecatedPublicKeys = append(deprecatedPublicKeys, hex.EncodeToString(deprecatedKey.PubKey().SerializeCompressed()))
 	}
 
-	arkdInfo, err := arkdClient.GetInfo(ctx)
+	// arkd may still be booting when the emulator starts, retry if it fails.
+	var arkdInfo *client.Info
+	err = retryWithBackoff(ctx, arkdConnectRetryConfig,
+		func() error {
+			var e error
+			arkdInfo, e = arkdClient.GetInfo(ctx)
+			return e
+		},
+		func(attempt int, e error) {
+			log.WithField("attempt", attempt).Warnf("arkd not ready: %s", e)
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch arkd info: %w", err)
 	}

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -192,6 +192,15 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 	}, nil
 }
 
+func (s *service) retryFinalize(ctx context.Context, txid string, checkpoints []string) error {
+	return retryWithBackoff(ctx, finalizeRetryConfig,
+		func() error { return s.arkdClient.FinalizeTx(ctx, txid, checkpoints) },
+		func(attempt int, err error) {
+			log.WithField("txid", txid).WithField("attempt", attempt).Errorf("finalizing tx failed: %s", err)
+		},
+	)
+}
+
 type finalizerAccumulator struct {
 	arkdPubKeyXonly []byte
 	isLastByVin     map[uint16]bool
@@ -275,13 +284,15 @@ func verifyNonArkdCheckpointSignatures(checkpoints []*psbt.Packet, arkdPubKey *b
 	return nil
 }
 
-var finalizeRetryConfig = struct {
+type retryConfig struct {
 	MinAttempts  int
 	InitialDelay time.Duration
 	MaxDelay     time.Duration
 	Multiplier   float64
 	Jitter       float64
-}{
+}
+
+var finalizeRetryConfig = retryConfig{
 	MinAttempts:  10,
 	InitialDelay: 1 * time.Second,
 	MaxDelay:     10 * time.Second,
@@ -289,33 +300,39 @@ var finalizeRetryConfig = struct {
 	Jitter:       0.2, // + or - 20% randomness
 }
 
-func (s *service) retryFinalize(ctx context.Context, txid string, checkpoints []string) error {
-	// copy global to local for this retry run
-	retryConfig := finalizeRetryConfig
-	backoffDelay := retryConfig.InitialDelay
-	attempt := 0
+var arkdConnectRetryConfig = retryConfig{
+	MinAttempts:  0,
+	InitialDelay: 1 * time.Second,
+	MaxDelay:     45 * time.Second,
+	Multiplier:   2.0,
+	Jitter:       0.2,
+}
 
-	for {
-		attempt++
-
-		if err := s.arkdClient.FinalizeTx(ctx, txid, checkpoints); err == nil {
+func retryWithBackoff(
+	ctx context.Context, cfg retryConfig, op func() error, onErr func(attempt int, err error),
+) error {
+	backoffDelay := cfg.InitialDelay
+	for attempt := 1; ; attempt++ {
+		err := op()
+		if err == nil {
 			return nil
-		} else {
-			log.WithField("txid", txid).WithField("attempt", attempt).Errorf("finalizing tx failed: %s", err)
+		}
+		if onErr != nil {
+			onErr(attempt, err)
 		}
 
-		delay := applyJitter(backoffDelay, retryConfig.Jitter)
-		backoffDelay = min(retryConfig.MaxDelay, backoffDelay*time.Duration(retryConfig.Multiplier))
+		delay := applyJitter(backoffDelay, cfg.Jitter)
+		backoffDelay = min(cfg.MaxDelay, backoffDelay*time.Duration(cfg.Multiplier))
 
 		// try a minimum number of times before respecting ctx.Done
-		if attempt < retryConfig.MinAttempts {
+		if attempt < cfg.MinAttempts {
 			time.Sleep(delay)
 			continue
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("finalize retry cancelled after attempt %d: %w", attempt, ctx.Err())
+			return fmt.Errorf("retry cancelled after attempt %d: %w", attempt, ctx.Err())
 		case <-time.After(delay):
 		}
 	}

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -300,14 +300,6 @@ var finalizeRetryConfig = retryConfig{
 	Jitter:       0.2, // + or - 20% randomness
 }
 
-var arkdConnectRetryConfig = retryConfig{
-	MinAttempts:  0,
-	InitialDelay: 1 * time.Second,
-	MaxDelay:     45 * time.Second,
-	Multiplier:   2.0,
-	Jitter:       0.2,
-}
-
 func retryWithBackoff(
 	ctx context.Context, cfg retryConfig, op func() error, onErr func(attempt int, err error),
 ) error {


### PR DESCRIPTION
This PR extracts the logic of `retryFinalize` to `retryWithBackoff` function. Thus, we can reuse while calling arkd's GetInfo RPC on startup.

it closes #108 

@chris-ricketts please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - Improved startup reliability by automatically retrying connections when the service is not immediately ready.
  - Improved transaction finalization reliability with consistent retry and backoff behavior.
  - Added clearer warning feedback when connection or finalization attempts fail.
  - Retry timing now includes jitter and respects cancellation, helping avoid unnecessary delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->