### PR TITLE
Push introspection values as numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The Bitcoin-level signatures that the emulator itself produces on PSBT `TaprootS
 | OP_INSPECTINPUTARKADESCRIPTHASH | 200 | 0xc8 | index | script_hash | Pushes the 32-byte Arkade script hash (`tagged_hash("ArkScriptHash", script)`) of the EmulatorEntry for the input at the given index. This is the same hash used as the tweak scalar in `ComputeArkadeScriptPublicKey`. Fails if no entry exists. |
 | OP_INSPECTINPUTVALUE | 201 | 0xc9 | index | value | Pushes the satoshi value of the previous output spent by the input at the given index, as a minimally-encoded BigNum. |
 | OP_INSPECTINPUTSCRIPTPUBKEY | 202 | 0xca | index | program version | For witness programs: pushes the witness program (2-40 bytes) and segwit version (scriptNum). For non-native segwit: pushes SHA256 hash of scriptPubKey and -1. |
-| OP_INSPECTINPUTSEQUENCE | 203 | 0xcb | index | sequence | Pushes the sequence number (4 bytes, little-endian) of the input at the given index. |
+| OP_INSPECTINPUTSEQUENCE | 203 | 0xcb | index | sequence | Pushes the sequence number of the input at the given index as a minimally-encoded BigNum. |
 | OP_PUSHCURRENTINPUTINDEX | 205 | 0xcd | Nothing | index | Pushes the current input index (scriptNum) being evaluated onto the stack. |
 | OP_INSPECTINPUTARKADEWITNESSHASH | 206 | 0xce | index | witness_hash | Pushes the 32-byte Arkade witness hash (`tagged_hash("ArkWitnessHash", witness)`) of the EmulatorEntry for the input at the given index. Pushes 32 zero bytes if witness is empty. Fails if no entry exists. |
 
@@ -263,11 +263,11 @@ The Bitcoin-level signatures that the emulator itself produces on PSBT `TaprootS
 
 | Word | Opcode | Hex | Input | Output | Description |
 |------|--------|-----|-------|--------|-------------|
-| OP_INSPECTVERSION | 210 | 0xd2 | Nothing | version | Pushes the transaction version (4 bytes, little-endian) onto the stack. |
-| OP_INSPECTLOCKTIME | 211 | 0xd3 | Nothing | locktime | Pushes the transaction locktime (4 bytes, little-endian) onto the stack. |
+| OP_INSPECTVERSION | 210 | 0xd2 | Nothing | version | Pushes the transaction version as a minimally-encoded BigNum. |
+| OP_INSPECTLOCKTIME | 211 | 0xd3 | Nothing | locktime | Pushes the transaction locktime as a minimally-encoded BigNum. |
 | OP_INSPECTNUMINPUTS | 212 | 0xd4 | Nothing | numInputs | Pushes the number of inputs in the transaction (scriptNum) onto the stack. |
 | OP_INSPECTNUMOUTPUTS | 213 | 0xd5 | Nothing | numOutputs | Pushes the number of outputs in the transaction (scriptNum) onto the stack. |
-| OP_TXWEIGHT | 214 | 0xd6 | Nothing | weight | Pushes the transaction weight (4 bytes, little-endian) onto the stack. Weight is calculated as `SerializeSizeStripped() * 4`. |
+| OP_TXWEIGHT | 214 | 0xd6 | Nothing | weight | Pushes the transaction weight as a minimally-encoded BigNum. Weight is calculated as `SerializeSizeStripped() * 4`. |
 | OP_TXID | 243 | 0xf3 | Nothing | txid | Pushes the current transaction hash (32 bytes) onto the stack. |
 | OP_SIGHASH | 246 | 0xf6 | hashType | sighash | Pops a sighash flag and pushes the 32-byte [arkade tapscript signature hash](#sighash-non-standard) of the currently executing input under that flag. The pushed digest is identical to the message `OP_CHECKSIG` verifies in the same context, but it is **not** the BIP342 digest — see the Sighash section above. The flag must be a minimally encoded scriptNum in `[0,255]` and one of `{0x00, 0x01, 0x02, 0x03, 0x81, 0x82, 0x83}`; `SIGHASH_SINGLE` additionally requires a matching output at the input's index. |
 

--- a/pkg/arkade/engine_test.go
+++ b/pkg/arkade/engine_test.go
@@ -766,7 +766,7 @@ func TestNewOpcodes(t *testing.T) {
 			script: txscript.NewScriptBuilder().
 				AddData([]byte{0x00}).
 				AddOp(OP_INSPECTINPUTSEQUENCE).
-				AddData([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0x00}). // Max sequence number
+				AddInt64(1<<32 - 1). // Max sequence number
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{
@@ -1106,7 +1106,7 @@ func TestNewOpcodes(t *testing.T) {
 			name: "OP_TXWEIGHT",
 			script: txscript.NewScriptBuilder().
 				AddOp(OP_TXWEIGHT).
-				AddData([]byte{0xCC, 0x00}). // Expected weight 204
+				AddInt64(204). // Expected weight
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{

--- a/pkg/arkade/engine_test.go
+++ b/pkg/arkade/engine_test.go
@@ -766,7 +766,7 @@ func TestNewOpcodes(t *testing.T) {
 			script: txscript.NewScriptBuilder().
 				AddData([]byte{0x00}).
 				AddOp(OP_INSPECTINPUTSEQUENCE).
-				AddData([]byte{0xFF, 0xFF, 0xFF, 0xFF}). // Max sequence number
+				AddData([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0x00}). // Max sequence number
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{
@@ -995,7 +995,7 @@ func TestNewOpcodes(t *testing.T) {
 			name: "OP_INSPECTVERSION",
 			script: txscript.NewScriptBuilder().
 				AddOp(OP_INSPECTVERSION).
-				AddData([]byte{0x01, 0x00, 0x00, 0x00}). // Version 1 in LE32
+				AddInt64(1).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{
@@ -1021,7 +1021,7 @@ func TestNewOpcodes(t *testing.T) {
 			name: "OP_INSPECTLOCKTIME",
 			script: txscript.NewScriptBuilder().
 				AddOp(OP_INSPECTLOCKTIME).
-				AddData([]byte{0x00, 0x00, 0x00, 0x00}). // LockTime 0 in LE32
+				AddInt64(0).
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{
@@ -1106,7 +1106,7 @@ func TestNewOpcodes(t *testing.T) {
 			name: "OP_TXWEIGHT",
 			script: txscript.NewScriptBuilder().
 				AddOp(OP_TXWEIGHT).
-				AddData([]byte{0xCC, 0x00, 0x00, 0x00}). // Expected weight 204 in LE32
+				AddData([]byte{0xCC, 0x00}). // Expected weight 204
 				AddOp(OP_EQUAL),
 			cases: []testCase{
 				{

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/gob"
 	"encoding/hex"
 	"errors"
@@ -2096,10 +2095,7 @@ func opcodeInspectInputSequence(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidIndex, "input index out of range")
 	}
 
-	sequence := make([]byte, 4)
-	binary.LittleEndian.PutUint32(sequence, vm.tx.TxIn[index].Sequence)
-	vm.dstack.PushByteArray(sequence)
-	return nil
+	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(vm.tx.TxIn[index].Sequence)))
 }
 
 // opcodePushCurrentInputIndex pushes the current input index onto the stack.
@@ -2148,19 +2144,13 @@ func opcodeInspectOutputScriptPubkey(op *opcode, data []byte, vm *Engine) error 
 // opcodeInspectVersion pushes the transaction version onto the stack.
 // Stack transformation: [...] -> [... version]
 func opcodeInspectVersion(op *opcode, data []byte, vm *Engine) error {
-	version := make([]byte, 4)
-	binary.LittleEndian.PutUint32(version, uint32(vm.tx.Version))
-	vm.dstack.PushByteArray(version)
-	return nil
+	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(uint32(vm.tx.Version))))
 }
 
 // opcodeInspectLocktime pushes the transaction locktime onto the stack.
 // Stack transformation: [...] -> [... locktime]
 func opcodeInspectLocktime(op *opcode, data []byte, vm *Engine) error {
-	locktime := make([]byte, 4)
-	binary.LittleEndian.PutUint32(locktime, vm.tx.LockTime)
-	vm.dstack.PushByteArray(locktime)
-	return nil
+	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(vm.tx.LockTime)))
 }
 
 // opcodeInspectNumInputs pushes the number of inputs in the transaction onto the stack.
@@ -2180,10 +2170,7 @@ func opcodeInspectNumOutputs(op *opcode, data []byte, vm *Engine) error {
 // opcodeTxWeight pushes the transaction weight onto the stack.
 // Stack transformation: [...] -> [... weight]
 func opcodeTxWeight(op *opcode, data []byte, vm *Engine) error {
-	weight := make([]byte, 4)
-	binary.LittleEndian.PutUint32(weight, uint32(vm.tx.SerializeSizeStripped()*4))
-	vm.dstack.PushByteArray(weight)
-	return nil
+	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(vm.tx.SerializeSizeStripped() * 4)))
 }
 
 // opcodeCat concatenates two byte arrays.

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -4179,7 +4179,9 @@ func txWeightSpec() *opcodeSpec {
 			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
 			require.Equal(t, c.before.condStack, c.after.condStack)
 			require.Equal(t, len(c.before.GetStack())+1, len(c.after.GetStack()))
-			require.Len(t, c.after.GetStack()[len(c.after.GetStack())-1], 4)
+			want, err := BigNumFromUint64(uint64(c.before.tx.SerializeSizeStripped() * 4)).Bytes()
+			require.NoError(t, err)
+			require.Equal(t, want, c.after.GetStack()[len(c.after.GetStack())-1])
 		},
 		validVectors: []opcodeVector{
 			{name: "push", expectedStack: [][]byte{opcodeWorldTxWeight()}},
@@ -4775,7 +4777,7 @@ func inspectInputSequenceSpec() *opcodeSpec {
 		opcode:          OP_INSPECTINPUTSEQUENCE,
 		checkProperties: inspectInputPropertyChecker(OP_INSPECTINPUTSEQUENCE),
 		validVectors: []opcodeVector{
-			{name: "seq0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{100, 0, 0, 0}}},
+			{name: "seq0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{100}}},
 		},
 		invalidVectors: []opcodeVector{
 			{
@@ -4856,7 +4858,7 @@ func inspectVersionSpec() *opcodeSpec {
 	return &opcodeSpec{
 		opcode:          OP_INSPECTVERSION,
 		checkProperties: inspectMetaPropertyChecker(OP_INSPECTVERSION),
-		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{{2, 0, 0, 0}}}},
+		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{{2}}}},
 	}
 }
 
@@ -4864,7 +4866,7 @@ func inspectLocktimeSpec() *opcodeSpec {
 	return &opcodeSpec{
 		opcode:          OP_INSPECTLOCKTIME,
 		checkProperties: inspectMetaPropertyChecker(OP_INSPECTLOCKTIME),
-		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{{144, 0, 0, 0}}}},
+		validVectors:    []opcodeVector{{name: "push", expectedStack: [][]byte{{144, 0}}}},
 	}
 }
 
@@ -5070,7 +5072,11 @@ func inspectInputPropertyChecker(op byte) opcodePropertyChecker {
 			programOrHash := c.after.GetStack()[afterDepth-2]
 			require.NotEmpty(t, programOrHash)
 		case OP_INSPECTINPUTSEQUENCE:
-			require.Len(t, top, 4)
+			index, err := BigNumFromBytes(c.before.GetStack()[beforeDepth-1])
+			require.NoError(t, err)
+			want, err := BigNumFromUint64(uint64(c.before.tx.TxIn[int(index.BigInt().Int64())].Sequence)).Bytes()
+			require.NoError(t, err)
+			require.Equal(t, want, top)
 		}
 	}
 }
@@ -5125,8 +5131,14 @@ func inspectMetaPropertyChecker(op byte) opcodePropertyChecker {
 
 		top := c.after.GetStack()[afterDepth-1]
 		switch op {
-		case OP_INSPECTVERSION, OP_INSPECTLOCKTIME:
-			require.Len(t, top, 4)
+		case OP_INSPECTVERSION:
+			want, err := BigNumFromUint64(uint64(uint32(c.before.tx.Version))).Bytes()
+			require.NoError(t, err)
+			require.Equal(t, want, top)
+		case OP_INSPECTLOCKTIME:
+			want, err := BigNumFromUint64(uint64(c.before.tx.LockTime)).Bytes()
+			require.NoError(t, err)
+			require.Equal(t, want, top)
 		case OP_PUSHCURRENTINPUTINDEX, OP_INSPECTNUMINPUTS, OP_INSPECTNUMOUTPUTS:
 			require.LessOrEqual(t, len(top), 5)
 		default:
@@ -5439,9 +5451,7 @@ func emptyByteVector() []byte {
 
 func opcodeWorldTxWeight() []byte {
 	world := buildOpcodeWorld()
-	weight := make([]byte, 4)
-	binary.LittleEndian.PutUint32(weight, uint32(world.tx.SerializeSizeStripped()*4))
-	return weight
+	return mustBigNumBytes(BigNumFromUint64(uint64(world.tx.SerializeSizeStripped() * 4)))
 }
 
 func hashBytes(h chainhash.Hash) []byte {

--- a/test/delegate_test.go
+++ b/test/delegate_test.go
@@ -44,7 +44,7 @@ const (
 // pkScript and value, and gates the spend to intent-proof txs only (v2).
 // Witness stack: [].
 //
-//	OP_INSPECTVERSION <0x02000000> OP_EQUALVERIFY  # intent proof only (v2, not v3)
+//	OP_INSPECTVERSION OP_2 OP_EQUALVERIFY          # intent proof only (v2, not v3)
 //	OP_0 OP_INSPECTOUTPUTSCRIPTPUBKEY
 //	OP_1 OP_EQUALVERIFY                            # force taproot
 //	OP_PUSHCURRENTINPUTINDEX OP_INSPECTINPUTSCRIPTPUBKEY
@@ -317,9 +317,8 @@ func enforceSelfSend(t *testing.T) []byte {
 	t.Helper()
 
 	s, err := txscript.NewScriptBuilder().
-		// OP_INSPECTVERSION pushes tx.Version as 4-byte LE, compared against raw bytes
 		AddOp(arkade.OP_INSPECTVERSION).
-		AddData([]byte{0x02, 0x00, 0x00, 0x00}).
+		AddInt64(2).
 		AddOp(arkade.OP_EQUALVERIFY).
 		// output[0] witness program == input[self] witness program
 		AddInt64(0).


### PR DESCRIPTION
## Summary

- push input sequence, transaction version, locktime, and transaction weight as minimally encoded BigNums
- update opcode properties, engine vectors, and the delegate covenant for numeric encoding
- document the numeric introspection outputs

## Root cause

These four handlers pushed unsigned numeric fields as fixed-width little-endian byte arrays. Most values therefore had trailing zero bytes and failed BigNum minimal-data validation when consumed by arithmetic or numeric comparison opcodes. Byte equality also compared against the fixed-width representation instead of the VM's canonical numeric representation.

## Impact

Scripts can consume these introspection results directly as BigNums without an `OP_BIN2NUM` normalization step, including values across the full unsigned 32-bit range.

## Validation

- `cd pkg/arkade && go test ./...`
- `go test ./... -run '^$'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction-introspection opcodes to return minimally encoded numeric values instead of fixed-length byte representations.
  * Corrected sequence, version, locktime, input/output count, and transaction weight encodings.
  * Updated covenant version checks to use numeric script values consistently.

* **Documentation**
  * Revised opcode documentation to reflect the updated numeric encoding format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->