### PR TITLE
Bind SubmitFinalization signatures to authorized spends

### DIFF
--- a/internal/application/finalization.go
+++ b/internal/application/finalization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	"github.com/arkade-os/emulator/pkg/arkade"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
@@ -77,6 +78,9 @@ func (s *service) SubmitFinalization(ctx context.Context, finalization BatchFina
 			if !ok {
 				continue
 			}
+			if err := association.validateFinalizationInput(forfeit, inputIndex, s.arkdPubKey); err != nil {
+				return nil, err
+			}
 
 			// validate connector is part of the connector tree
 			connectorIndex := inputIndex ^ 1 // if inputIndex is 0, connectorIndex is 1, and vice versa
@@ -85,12 +89,11 @@ func (s *service) SubmitFinalization(ctx context.Context, finalization BatchFina
 			if connectorOutput == nil {
 				return nil, fmt.Errorf("connector %s is not part of the tree", connector)
 			}
-
 			// the input side alone says nothing about where the forfeit sends the
 			// vtxo: without this the requester can reuse a vtxo input we signed in
 			// the past and redirect its value anywhere
 			if err := validateForfeitOutputs(
-				forfeit, inputIndex, association.prevout, connectorOutput,
+				forfeit, inputIndex, &association.prevout, connectorOutput,
 			); err != nil {
 				return nil, fmt.Errorf(
 					"malformed forfeit %s: %w", forfeit.UnsignedTx.TxID(), err,
@@ -133,6 +136,11 @@ func (s *service) SubmitFinalization(ctx context.Context, finalization BatchFina
 		if !ok {
 			continue
 		}
+		if err := association.validateFinalizationInput(
+			finalization.CommitmentTx, inputIndex, s.arkdPubKey,
+		); err != nil {
+			return nil, err
+		}
 
 		if err := association.signer.signInput(
 			finalization.CommitmentTx, inputIndex, association.script.Hash(), prevoutFetcher,
@@ -150,12 +158,37 @@ func (s *service) SubmitFinalization(ctx context.Context, finalization BatchFina
 }
 
 type signedInputAssociation struct {
-	script *arkade.ArkadeScript
-	signer signer
-	// prevout is the vtxo output the intent proof spends. The tapscript
-	// signature verified below commits to it, so it is the trusted description
-	// of the vtxo a forfeit is allowed to spend.
-	prevout *wire.TxOut
+	script  *arkade.ArkadeScript
+	signer  signer
+	prevout wire.TxOut
+}
+
+func (a signedInputAssociation) validateFinalizationInput(
+	ptx *psbt.Packet, inputIndex int, arkdPubKey *btcec.PublicKey,
+) error {
+	if !containsPubKey(a.script.ClosurePubKeys(), arkdPubKey) {
+		return fmt.Errorf("input %d: finalization leaf does not require the arkd signer", inputIndex)
+	}
+	if len(ptx.Inputs) <= inputIndex {
+		return fmt.Errorf("input %d: PSBT input index out of range", inputIndex)
+	}
+
+	input := ptx.Inputs[inputIndex]
+	if input.WitnessUtxo == nil || input.WitnessUtxo.Value != a.prevout.Value ||
+		!bytes.Equal(input.WitnessUtxo.PkScript, a.prevout.PkScript) {
+		return fmt.Errorf("input %d: witness UTXO does not match intent proof", inputIndex)
+	}
+	if len(input.TaprootLeafScript) == 0 || input.TaprootLeafScript[0] == nil {
+		return fmt.Errorf("input %d: missing taproot leaf script", inputIndex)
+	}
+
+	tapLeaf := input.TaprootLeafScript[0]
+	if txscript.NewTapLeaf(tapLeaf.LeafVersion, tapLeaf.Script).TapHash() !=
+		a.script.TapLeaf().TapHash() {
+		return fmt.Errorf("input %d: taproot leaf script does not match intent proof", inputIndex)
+	}
+
+	return nil
 }
 
 // getSignedInputAssociations iterates over tapscript sigs to find arkade script inputs with valid signature.
@@ -239,9 +272,12 @@ func getSignedInputAssociations(
 				}
 
 				signedInputs[ptx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint] = signedInputAssociation{
-					script:  script,
-					signer:  candidate,
-					prevout: input.WitnessUtxo,
+					script: script,
+					signer: candidate,
+					prevout: wire.TxOut{
+						Value:    input.WitnessUtxo.Value,
+						PkScript: append([]byte(nil), input.WitnessUtxo.PkScript...),
+					},
 				}
 				break
 			}
@@ -344,7 +380,6 @@ func leafOutput(tree *tree.TxTree, outpoint wire.OutPoint) *wire.TxOut {
 
 	output := node.Root.UnsignedTx.TxOut[outpoint.Index]
 
-	// nil if the output is anchor
 	if bytes.Equal(output.PkScript, txutils.ANCHOR_PKSCRIPT) {
 		return nil
 	}

--- a/internal/application/finalization_test.go
+++ b/internal/application/finalization_test.go
@@ -237,6 +237,50 @@ func TestValidateForfeitOutputs(t *testing.T) {
 			},
 			wantErr: "output 0 pays",
 		},
+
+		{name: "valid"},
+		{
+			name: "connector mismatch",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.Inputs[1].WitnessUtxo = &wire.TxOut{Value: connector.Value - 1, PkScript: connector.PkScript}
+			},
+			wantErr: "does not match the connector tree",
+		},
+		{
+			name: "missing connector witness utxo",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.Inputs[1].WitnessUtxo = nil
+			},
+			wantErr: "does not match the connector tree",
+		},
+		{
+			name: "extra output",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{txscript.OP_TRUE}})
+			},
+			wantErr: "expected 2 outputs",
+		},
+		{
+			name: "missing anchor",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.TxOut[1].PkScript = []byte{txscript.OP_TRUE}
+			},
+			wantErr: "is not the anchor output",
+		},
+		{
+			name: "wrong anchor value",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.TxOut[1].Value = txutils.ANCHOR_VALUE + 1
+			},
+			wantErr: "is not the anchor output",
+		},
+		{
+			name: "wrong value",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.TxOut[0].Value--
+			},
+			wantErr: "output 0 pays",
+		},
 	}
 
 	for _, tc := range tests {
@@ -347,6 +391,13 @@ func TestSubmitFinalizationValidatesAuthorizedInput(t *testing.T) {
 			wantErr:        "witness UTXO does not match intent proof",
 		},
 		{
+			name:           "different prevout script",
+			proofLeaf:      authorizedLeaf,
+			commitmentLeaf: authorizedLeaf,
+			commitment:     &wire.TxOut{Value: prevout.Value, PkScript: []byte{txscript.OP_TRUE}},
+			wantErr:        "witness UTXO does not match intent proof",
+		},
+		{
 			name:           "leaf without arkd signer",
 			proofLeaf:      foreignLeaf,
 			commitmentLeaf: foreignLeaf,
@@ -380,6 +431,109 @@ func TestSubmitFinalizationValidatesAuthorizedInput(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, signed.CommitmentTx)
 			require.NotEmpty(t, signed.CommitmentTx.Inputs[0].TaprootScriptSpendSig)
+		})
+	}
+}
+
+func TestSubmitFinalizationValidatesForfeit(t *testing.T) {
+	emulatorKey := newResolverPrivateKey(t)
+	arkdKey := newResolverPrivateKey(t)
+	arkadeScript := []byte{txscript.OP_TRUE}
+	tweakedKey := arkade.ComputeArkadeScriptPublicKey(
+		emulatorKey.PubKey(), arkade.ArkadeScriptHash(arkadeScript),
+	)
+
+	authorizedClosure := &arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{tweakedKey, arkdKey.PubKey()}}
+	foreignClosure := &arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{tweakedKey}}
+	vtxoScript := arkscript.TapscriptsVtxoScript{
+		Closures: []arkscript.Closure{authorizedClosure, foreignClosure},
+	}
+	tapKey, tapTree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+	pkScript, err := arkscript.P2TRScript(tapKey)
+	require.NoError(t, err)
+	authorizedLeaf := finalizationTapLeaf(t, authorizedClosure, tapTree)
+	foreignLeaf := finalizationTapLeaf(t, foreignClosure, tapTree)
+	prevout := &wire.TxOut{Value: 100_000, PkScript: pkScript}
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+
+	connector := &wire.TxOut{Value: 450, PkScript: []byte{txscript.OP_TRUE}}
+	connectorTree, connectorOutpoint := finalizationConnectorTree(t, connector)
+
+	tests := []struct {
+		name           string
+		proofLeaf      *psbt.TaprootTapLeafScript
+		forfeitLeaf    *psbt.TaprootTapLeafScript
+		forfeitPrevout *wire.TxOut
+		connector      wire.OutPoint
+		wantErr        string
+	}{
+		{
+			name:           "valid forfeit",
+			proofLeaf:      authorizedLeaf,
+			forfeitLeaf:    authorizedLeaf,
+			forfeitPrevout: prevout,
+			connector:      connectorOutpoint,
+		},
+		{
+			name:           "foreign leaf",
+			proofLeaf:      authorizedLeaf,
+			forfeitLeaf:    foreignLeaf,
+			forfeitPrevout: prevout,
+			connector:      connectorOutpoint,
+			wantErr:        "taproot leaf script does not match intent proof",
+		},
+		{
+			name:           "prevout mismatch",
+			proofLeaf:      authorizedLeaf,
+			forfeitLeaf:    authorizedLeaf,
+			forfeitPrevout: &wire.TxOut{Value: prevout.Value - 1, PkScript: pkScript},
+			connector:      connectorOutpoint,
+			wantErr:        "witness UTXO does not match intent proof",
+		},
+		{
+			name:           "leaf without arkd signer",
+			proofLeaf:      foreignLeaf,
+			forfeitLeaf:    foreignLeaf,
+			forfeitPrevout: prevout,
+			connector:      connectorOutpoint,
+			wantErr:        "finalization leaf does not require the arkd signer",
+		},
+		{
+			name:           "connector outside the tree",
+			proofLeaf:      authorizedLeaf,
+			forfeitLeaf:    authorizedLeaf,
+			forfeitPrevout: prevout,
+			connector:      wire.OutPoint{Hash: chainhash.Hash{9}, Index: 0},
+			wantErr:        "is not part of the tree",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			intent := signedFinalizationIntent(
+				t, emulatorKey, arkadeScript, tc.proofLeaf, prevout, outpoint,
+			)
+			forfeit := finalizationForfeit(
+				t, tc.forfeitLeaf, tc.forfeitPrevout, outpoint, connector, tc.connector,
+				prevout.Value+connector.Value-txutils.ANCHOR_VALUE,
+			)
+			svc := &service{signer: signer{emulatorKey}, arkdPubKey: arkdKey.PubKey()}
+
+			signed, err := svc.SubmitFinalization(context.Background(), BatchFinalization{
+				Intent:        intent,
+				Forfeits:      []*psbt.Packet{forfeit},
+				ConnectorTree: connectorTree,
+			})
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, signed.Forfeits, 1)
+			require.NotEmpty(t, signed.Forfeits[0].Inputs[0].TaprootScriptSpendSig)
 		})
 	}
 }
@@ -652,6 +806,46 @@ func signedFinalizationIntent(
 	))
 
 	return Intent{Proof: arkintent.Proof{Packet: *ptx}}
+}
+
+// finalizationConnectorTree returns a single-leaf connector tree paying connector on output 0,
+// along with the outpoint spending it.
+func finalizationConnectorTree(t *testing.T, connector *wire.TxOut) (*tree.TxTree, wire.OutPoint) {
+	t.Helper()
+
+	tx := wire.NewMsgTx(3)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{3}}})
+	tx.AddTxOut(connector)
+	ptx, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	hash, err := chainhash.NewHashFromStr(ptx.UnsignedTx.TxID())
+	require.NoError(t, err)
+	return &tree.TxTree{Root: ptx}, wire.OutPoint{Hash: *hash, Index: 0}
+}
+
+func finalizationForfeit(
+	t *testing.T,
+	tapLeaf *psbt.TaprootTapLeafScript,
+	prevout *wire.TxOut,
+	outpoint wire.OutPoint,
+	connector *wire.TxOut,
+	connectorOutpoint wire.OutPoint,
+	payout int64,
+) *psbt.Packet {
+	t.Helper()
+
+	tx := wire.NewMsgTx(3)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: connectorOutpoint})
+	tx.AddTxOut(&wire.TxOut{Value: payout, PkScript: []byte{txscript.OP_TRUE}})
+	tx.AddTxOut(txutils.AnchorOutput())
+	ptx, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	ptx.Inputs[0].WitnessUtxo = prevout
+	ptx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapLeaf}
+	ptx.Inputs[1].WitnessUtxo = connector
+	return ptx
 }
 
 func finalizationCommitment(

--- a/internal/application/finalization_test.go
+++ b/internal/application/finalization_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
 	arkintent "github.com/arkade-os/arkd/pkg/ark-lib/intent"
 	arkscript "github.com/arkade-os/arkd/pkg/ark-lib/script"
@@ -87,6 +88,8 @@ func TestSubmitFinalizationValidatesForfeitOutputs(t *testing.T) {
 		require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
 	})
 
+	// the witness utxo is checked against the intent proof before the output
+	// side is validated, so an inflated prevout fails the binding check
 	t.Run("vtxo prevout inflated against the intent proof", func(t *testing.T) {
 		inflated := &wire.TxOut{
 			Value:    fix.vtxoPrevout.Value * 10,
@@ -95,7 +98,7 @@ func TestSubmitFinalizationValidatesForfeitOutputs(t *testing.T) {
 		forfeit := fix.buildForfeit(t, inflated, fix.connectorOutput)
 
 		_, err := fix.submit(t, forfeit)
-		require.ErrorContains(t, err, "malformed forfeit")
+		require.ErrorContains(t, err, "witness UTXO does not match intent proof")
 		require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
 	})
 
@@ -144,51 +147,113 @@ func TestSubmitFinalizationRejectsUnknownCommitmentTx(t *testing.T) {
 	require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
 }
 
-func TestValidateForfeitOutputsInternals(t *testing.T) {
-	vtxoPrevout := &wire.TxOut{Value: 100_000, PkScript: []byte{0x51}}
-	connectorOutput := &wire.TxOut{Value: 450, PkScript: []byte{0x52}}
+func TestValidateForfeitOutputs(t *testing.T) {
+	vtxo := &wire.TxOut{Value: 100_000, PkScript: []byte{txscript.OP_TRUE}}
+	connector := &wire.TxOut{Value: 450, PkScript: []byte{txscript.OP_TRUE}}
 
-	newForfeit := func() *psbt.Packet {
-		tx := wire.NewMsgTx(2)
+	newForfeit := func(t *testing.T) *psbt.Packet {
+		t.Helper()
+
+		tx := wire.NewMsgTx(3)
 		tx.AddTxIn(&wire.TxIn{})
 		tx.AddTxIn(&wire.TxIn{})
 		tx.AddTxOut(&wire.TxOut{
-			Value:    vtxoPrevout.Value + connectorOutput.Value - txutils.ANCHOR_VALUE,
-			PkScript: []byte{0x53},
+			Value:    vtxo.Value + connector.Value - txutils.ANCHOR_VALUE,
+			PkScript: []byte{txscript.OP_TRUE},
 		})
 		tx.AddTxOut(txutils.AnchorOutput())
-
-		forfeit, err := psbt.NewFromUnsignedTx(tx)
+		ptx, err := psbt.NewFromUnsignedTx(tx)
 		require.NoError(t, err)
-		forfeit.Inputs[0].WitnessUtxo = vtxoPrevout
-		forfeit.Inputs[1].WitnessUtxo = connectorOutput
-		return forfeit
+		ptx.Inputs[0].WitnessUtxo = vtxo
+		ptx.Inputs[1].WitnessUtxo = connector
+		return ptx
 	}
 
-	t.Run("canonical forfeit is accepted", func(t *testing.T) {
-		require.NoError(t, validateForfeitOutputs(newForfeit(), 0, vtxoPrevout, connectorOutput))
-	})
-
+	// not a packet mutation: the vtxo prevout argument itself is missing
 	t.Run("nil vtxo prevout is rejected", func(t *testing.T) {
-		err := validateForfeitOutputs(newForfeit(), 0, nil, connectorOutput)
+		err := validateForfeitOutputs(newForfeit(t), 0, nil, connector)
 		require.ErrorContains(t, err, "missing vtxo prevout for input 0")
 	})
 
-	t.Run("missing vtxo witness utxo is rejected", func(t *testing.T) {
-		forfeit := newForfeit()
-		forfeit.Inputs[0].WitnessUtxo = nil
+	tests := []struct {
+		name    string
+		mutate  func(*psbt.Packet)
+		wantErr string
+	}{
+		{name: "valid"},
+		{
+			name: "missing vtxo witness utxo",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.Inputs[0].WitnessUtxo = nil
+			},
+			wantErr: "missing witness utxo for input 0",
+		},
+		{
+			name: "missing connector witness utxo",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.Inputs[1].WitnessUtxo = nil
+			},
+			wantErr: "missing witness utxo for input 1",
+		},
+		{
+			name: "vtxo witness utxo mismatch",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.Inputs[0].WitnessUtxo = &wire.TxOut{Value: vtxo.Value - 1, PkScript: vtxo.PkScript}
+			},
+			wantErr: "does not spend the vtxo committed by the intent proof",
+		},
+		{
+			name: "connector witness utxo mismatch",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.Inputs[1].WitnessUtxo = &wire.TxOut{Value: connector.Value - 1, PkScript: connector.PkScript}
+			},
+			wantErr: "does not spend the connector output of the tree",
+		},
+		{
+			name: "extra output",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{txscript.OP_TRUE}})
+			},
+			wantErr: "expected 2 outputs",
+		},
+		{
+			name: "anchor script replaced",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.TxOut[1].PkScript = []byte{txscript.OP_TRUE}
+			},
+			wantErr: "is not the anchor output",
+		},
+		{
+			name: "wrong anchor value",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.TxOut[1].Value = txutils.ANCHOR_VALUE + 1
+			},
+			wantErr: "is not the anchor output",
+		},
+		{
+			name: "wrong value",
+			mutate: func(ptx *psbt.Packet) {
+				ptx.UnsignedTx.TxOut[0].Value--
+			},
+			wantErr: "output 0 pays",
+		},
+	}
 
-		err := validateForfeitOutputs(forfeit, 0, vtxoPrevout, connectorOutput)
-		require.ErrorContains(t, err, "missing witness utxo for input 0")
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			forfeit := newForfeit(t)
+			if tc.mutate != nil {
+				tc.mutate(forfeit)
+			}
 
-	t.Run("missing connector witness utxo is rejected", func(t *testing.T) {
-		forfeit := newForfeit()
-		forfeit.Inputs[1].WitnessUtxo = nil
-
-		err := validateForfeitOutputs(forfeit, 0, vtxoPrevout, connectorOutput)
-		require.ErrorContains(t, err, "missing witness utxo for input 1")
-	})
+			err := validateForfeitOutputs(forfeit, 0, vtxo, connector)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
 }
 
 func TestLeafOutput(t *testing.T) {
@@ -232,10 +297,98 @@ func TestLeafOutput(t *testing.T) {
 	})
 }
 
+func TestSubmitFinalizationValidatesAuthorizedInput(t *testing.T) {
+	emulatorKey := newResolverPrivateKey(t)
+	arkdKey := newResolverPrivateKey(t)
+	arkadeScript := []byte{txscript.OP_TRUE}
+	tweakedKey := arkade.ComputeArkadeScriptPublicKey(
+		emulatorKey.PubKey(), arkade.ArkadeScriptHash(arkadeScript),
+	)
+
+	authorizedClosure := &arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{tweakedKey, arkdKey.PubKey()}}
+	foreignClosure := &arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{tweakedKey}}
+	vtxoScript := arkscript.TapscriptsVtxoScript{
+		Closures: []arkscript.Closure{authorizedClosure, foreignClosure},
+	}
+	tapKey, tapTree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+	pkScript, err := arkscript.P2TRScript(tapKey)
+	require.NoError(t, err)
+	authorizedLeaf := finalizationTapLeaf(t, authorizedClosure, tapTree)
+	foreignLeaf := finalizationTapLeaf(t, foreignClosure, tapTree)
+	prevout := &wire.TxOut{Value: 100_000, PkScript: pkScript}
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+
+	tests := []struct {
+		name           string
+		proofLeaf      *psbt.TaprootTapLeafScript
+		commitmentLeaf *psbt.TaprootTapLeafScript
+		commitment     *wire.TxOut
+		wantErr        string
+	}{
+		{
+			name:           "matching authorized input",
+			proofLeaf:      authorizedLeaf,
+			commitmentLeaf: authorizedLeaf,
+			commitment:     prevout,
+		},
+		{
+			name:           "foreign leaf",
+			proofLeaf:      authorizedLeaf,
+			commitmentLeaf: foreignLeaf,
+			commitment:     prevout,
+			wantErr:        "taproot leaf script does not match intent proof",
+		},
+		{
+			name:           "different prevout",
+			proofLeaf:      authorizedLeaf,
+			commitmentLeaf: authorizedLeaf,
+			commitment:     &wire.TxOut{Value: prevout.Value - 1, PkScript: prevout.PkScript},
+			wantErr:        "witness UTXO does not match intent proof",
+		},
+		{
+			name:           "leaf without arkd signer",
+			proofLeaf:      foreignLeaf,
+			commitmentLeaf: foreignLeaf,
+			commitment:     prevout,
+			wantErr:        "finalization leaf does not require the arkd signer",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			intent := signedFinalizationIntent(
+				t, emulatorKey, arkadeScript, tc.proofLeaf, prevout, outpoint,
+			)
+			commitment := finalizationCommitment(t, tc.commitmentLeaf, tc.commitment, outpoint)
+			svc := &service{
+				signer:        signer{emulatorKey},
+				arkdPubKey:    arkdKey.PubKey(),
+				indexerClient: &mockIndexerClient{},
+			}
+
+			signed, err := svc.SubmitFinalization(context.Background(), BatchFinalization{
+				Intent:       intent,
+				CommitmentTx: commitment,
+			})
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				require.Empty(t, commitment.Inputs[0].TaprootScriptSpendSig)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, signed.CommitmentTx)
+			require.NotEmpty(t, signed.CommitmentTx.Inputs[0].TaprootScriptSpendSig)
+		})
+	}
+}
+
 // forfeitFixture holds a signer that already approved an intent proof for a
 // single vtxo, plus the connector tree that vtxo's forfeit must use.
 type forfeitFixture struct {
 	signerKey         *btcec.PrivateKey
+	arkdKey           *btcec.PrivateKey
 	intent            Intent
 	commitmentTx      *psbt.Packet
 	connectorTree     *tree.TxTree
@@ -253,11 +406,16 @@ func newForfeitFixture(t *testing.T) *forfeitFixture {
 	signerKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
+	arkdKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
 	arkadeScript := []byte{txscript.OP_TRUE}
 	scriptHash := arkade.ArkadeScriptHash(arkadeScript)
 
+	// the finalization leaf must require the arkd signer, see validateFinalizationInput
 	closure := arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{
 		arkade.ComputeArkadeScriptPublicKey(signerKey.PubKey(), scriptHash),
+		arkdKey.PubKey(),
 	}}
 	vtxoScript := arkscript.TapscriptsVtxoScript{
 		Closures: []arkscript.Closure{&closure},
@@ -278,6 +436,7 @@ func newForfeitFixture(t *testing.T) *forfeitFixture {
 
 	fix := &forfeitFixture{
 		signerKey: signerKey,
+		arkdKey:   arkdKey,
 		leafScript: &psbt.TaprootTapLeafScript{
 			ControlBlock: merkleProof.ControlBlock,
 			Script:       merkleProof.Script,
@@ -404,7 +563,11 @@ func (f *forfeitFixture) submit(
 ) (*SignedBatchFinalization, error) {
 	t.Helper()
 
-	svc := &service{signer: signer{f.signerKey}, indexerClient: &mockIndexerClient{}}
+	svc := &service{
+		signer:        signer{f.signerKey},
+		arkdPubKey:    f.arkdKey.PubKey(),
+		indexerClient: &mockIndexerClient{},
+	}
 	return svc.SubmitFinalization(t.Context(), BatchFinalization{
 		Intent:        f.intent,
 		Forfeits:      forfeits,
@@ -437,4 +600,70 @@ func (m *mockIndexerClient) GetCommitmentTx(
 		return nil, m.err
 	}
 	return &indexer.CommitmentTx{}, nil
+}
+
+func finalizationTapLeaf(
+	t *testing.T, closure arkscript.Closure, tapTree arklib.TaprootTree,
+) *psbt.TaprootTapLeafScript {
+	t.Helper()
+
+	script, err := closure.Script()
+	require.NoError(t, err)
+	proof, err := tapTree.GetTaprootMerkleProof(txscript.NewBaseTapLeaf(script).TapHash())
+	require.NoError(t, err)
+	return &psbt.TaprootTapLeafScript{
+		ControlBlock: proof.ControlBlock,
+		Script:       proof.Script,
+		LeafVersion:  txscript.BaseLeafVersion,
+	}
+}
+
+func signedFinalizationIntent(
+	t *testing.T,
+	emulatorKey *btcec.PrivateKey,
+	arkadeScript []byte,
+	tapLeaf *psbt.TaprootTapLeafScript,
+	prevout *wire.TxOut,
+	outpoint wire.OutPoint,
+) Intent {
+	t.Helper()
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{2}}})
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	ptx, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	for i := range ptx.Inputs {
+		ptx.Inputs[i].WitnessUtxo = prevout
+	}
+	ptx.Inputs[1].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapLeaf}
+
+	packet, err := arkade.NewPacket(arkade.EmulatorEntry{Vin: 1, Script: arkadeScript})
+	require.NoError(t, err)
+	packetOutput, err := (extension.Extension{packet}).TxOut()
+	require.NoError(t, err)
+	ptx.UnsignedTx.AddTxOut(packetOutput)
+	ptx.Outputs = append(ptx.Outputs, psbt.POutput{})
+
+	prevoutFetcher, err := computePrevoutFetcher(ptx)
+	require.NoError(t, err)
+	require.NoError(t, (signer{emulatorKey}).signInput(
+		ptx, 1, arkade.ArkadeScriptHash(arkadeScript), prevoutFetcher,
+	))
+
+	return Intent{Proof: arkintent.Proof{Packet: *ptx}}
+}
+
+func finalizationCommitment(
+	t *testing.T, tapLeaf *psbt.TaprootTapLeafScript, prevout *wire.TxOut, outpoint wire.OutPoint,
+) *psbt.Packet {
+	t.Helper()
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	ptx, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	ptx.Inputs[0].WitnessUtxo = prevout
+	ptx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapLeaf}
+	return ptx
 }

--- a/internal/application/finalization_test.go
+++ b/internal/application/finalization_test.go
@@ -113,6 +113,23 @@ func TestSubmitFinalizationValidatesForfeitOutputs(t *testing.T) {
 		require.ErrorContains(t, err, "malformed forfeit")
 		require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
 	})
+
+	t.Run("connector outside the tree", func(t *testing.T) {
+		bogusConnector := wire.OutPoint{Hash: chainhash.Hash{0x99}, Index: 0}
+		forfeit, err := tree.BuildForfeitTx(
+			[]*wire.OutPoint{&fix.vtxoOutpoint, &bogusConnector},
+			[]uint32{wire.MaxTxInSequenceNum, wire.MaxTxInSequenceNum},
+			[]*wire.TxOut{fix.vtxoPrevout, fix.connectorOutput},
+			fix.forfeitScript,
+			0,
+		)
+		require.NoError(t, err)
+		forfeit.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{fix.leafScript}
+
+		_, err = fix.submit(t, forfeit)
+		require.ErrorContains(t, err, "is not part of the tree")
+		require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
+	})
 }
 
 // TestSubmitFinalizationRejectsUnknownCommitmentTx proves SubmitFinalization
@@ -218,50 +235,6 @@ func TestValidateForfeitOutputs(t *testing.T) {
 		},
 		{
 			name: "anchor script replaced",
-			mutate: func(ptx *psbt.Packet) {
-				ptx.UnsignedTx.TxOut[1].PkScript = []byte{txscript.OP_TRUE}
-			},
-			wantErr: "is not the anchor output",
-		},
-		{
-			name: "wrong anchor value",
-			mutate: func(ptx *psbt.Packet) {
-				ptx.UnsignedTx.TxOut[1].Value = txutils.ANCHOR_VALUE + 1
-			},
-			wantErr: "is not the anchor output",
-		},
-		{
-			name: "wrong value",
-			mutate: func(ptx *psbt.Packet) {
-				ptx.UnsignedTx.TxOut[0].Value--
-			},
-			wantErr: "output 0 pays",
-		},
-
-		{name: "valid"},
-		{
-			name: "connector mismatch",
-			mutate: func(ptx *psbt.Packet) {
-				ptx.Inputs[1].WitnessUtxo = &wire.TxOut{Value: connector.Value - 1, PkScript: connector.PkScript}
-			},
-			wantErr: "does not match the connector tree",
-		},
-		{
-			name: "missing connector witness utxo",
-			mutate: func(ptx *psbt.Packet) {
-				ptx.Inputs[1].WitnessUtxo = nil
-			},
-			wantErr: "does not match the connector tree",
-		},
-		{
-			name: "extra output",
-			mutate: func(ptx *psbt.Packet) {
-				ptx.UnsignedTx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{txscript.OP_TRUE}})
-			},
-			wantErr: "expected 2 outputs",
-		},
-		{
-			name: "missing anchor",
 			mutate: func(ptx *psbt.Packet) {
 				ptx.UnsignedTx.TxOut[1].PkScript = []byte{txscript.OP_TRUE}
 			},
@@ -431,109 +404,6 @@ func TestSubmitFinalizationValidatesAuthorizedInput(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, signed.CommitmentTx)
 			require.NotEmpty(t, signed.CommitmentTx.Inputs[0].TaprootScriptSpendSig)
-		})
-	}
-}
-
-func TestSubmitFinalizationValidatesForfeit(t *testing.T) {
-	emulatorKey := newResolverPrivateKey(t)
-	arkdKey := newResolverPrivateKey(t)
-	arkadeScript := []byte{txscript.OP_TRUE}
-	tweakedKey := arkade.ComputeArkadeScriptPublicKey(
-		emulatorKey.PubKey(), arkade.ArkadeScriptHash(arkadeScript),
-	)
-
-	authorizedClosure := &arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{tweakedKey, arkdKey.PubKey()}}
-	foreignClosure := &arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{tweakedKey}}
-	vtxoScript := arkscript.TapscriptsVtxoScript{
-		Closures: []arkscript.Closure{authorizedClosure, foreignClosure},
-	}
-	tapKey, tapTree, err := vtxoScript.TapTree()
-	require.NoError(t, err)
-	pkScript, err := arkscript.P2TRScript(tapKey)
-	require.NoError(t, err)
-	authorizedLeaf := finalizationTapLeaf(t, authorizedClosure, tapTree)
-	foreignLeaf := finalizationTapLeaf(t, foreignClosure, tapTree)
-	prevout := &wire.TxOut{Value: 100_000, PkScript: pkScript}
-	outpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
-
-	connector := &wire.TxOut{Value: 450, PkScript: []byte{txscript.OP_TRUE}}
-	connectorTree, connectorOutpoint := finalizationConnectorTree(t, connector)
-
-	tests := []struct {
-		name           string
-		proofLeaf      *psbt.TaprootTapLeafScript
-		forfeitLeaf    *psbt.TaprootTapLeafScript
-		forfeitPrevout *wire.TxOut
-		connector      wire.OutPoint
-		wantErr        string
-	}{
-		{
-			name:           "valid forfeit",
-			proofLeaf:      authorizedLeaf,
-			forfeitLeaf:    authorizedLeaf,
-			forfeitPrevout: prevout,
-			connector:      connectorOutpoint,
-		},
-		{
-			name:           "foreign leaf",
-			proofLeaf:      authorizedLeaf,
-			forfeitLeaf:    foreignLeaf,
-			forfeitPrevout: prevout,
-			connector:      connectorOutpoint,
-			wantErr:        "taproot leaf script does not match intent proof",
-		},
-		{
-			name:           "prevout mismatch",
-			proofLeaf:      authorizedLeaf,
-			forfeitLeaf:    authorizedLeaf,
-			forfeitPrevout: &wire.TxOut{Value: prevout.Value - 1, PkScript: pkScript},
-			connector:      connectorOutpoint,
-			wantErr:        "witness UTXO does not match intent proof",
-		},
-		{
-			name:           "leaf without arkd signer",
-			proofLeaf:      foreignLeaf,
-			forfeitLeaf:    foreignLeaf,
-			forfeitPrevout: prevout,
-			connector:      connectorOutpoint,
-			wantErr:        "finalization leaf does not require the arkd signer",
-		},
-		{
-			name:           "connector outside the tree",
-			proofLeaf:      authorizedLeaf,
-			forfeitLeaf:    authorizedLeaf,
-			forfeitPrevout: prevout,
-			connector:      wire.OutPoint{Hash: chainhash.Hash{9}, Index: 0},
-			wantErr:        "is not part of the tree",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			intent := signedFinalizationIntent(
-				t, emulatorKey, arkadeScript, tc.proofLeaf, prevout, outpoint,
-			)
-			forfeit := finalizationForfeit(
-				t, tc.forfeitLeaf, tc.forfeitPrevout, outpoint, connector, tc.connector,
-				prevout.Value+connector.Value-txutils.ANCHOR_VALUE,
-			)
-			svc := &service{signer: signer{emulatorKey}, arkdPubKey: arkdKey.PubKey()}
-
-			signed, err := svc.SubmitFinalization(context.Background(), BatchFinalization{
-				Intent:        intent,
-				Forfeits:      []*psbt.Packet{forfeit},
-				ConnectorTree: connectorTree,
-			})
-			if tc.wantErr != "" {
-				require.ErrorContains(t, err, tc.wantErr)
-				require.Empty(t, forfeit.Inputs[0].TaprootScriptSpendSig)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Len(t, signed.Forfeits, 1)
-			require.NotEmpty(t, signed.Forfeits[0].Inputs[0].TaprootScriptSpendSig)
 		})
 	}
 }
@@ -806,46 +676,6 @@ func signedFinalizationIntent(
 	))
 
 	return Intent{Proof: arkintent.Proof{Packet: *ptx}}
-}
-
-// finalizationConnectorTree returns a single-leaf connector tree paying connector on output 0,
-// along with the outpoint spending it.
-func finalizationConnectorTree(t *testing.T, connector *wire.TxOut) (*tree.TxTree, wire.OutPoint) {
-	t.Helper()
-
-	tx := wire.NewMsgTx(3)
-	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{3}}})
-	tx.AddTxOut(connector)
-	ptx, err := psbt.NewFromUnsignedTx(tx)
-	require.NoError(t, err)
-
-	hash, err := chainhash.NewHashFromStr(ptx.UnsignedTx.TxID())
-	require.NoError(t, err)
-	return &tree.TxTree{Root: ptx}, wire.OutPoint{Hash: *hash, Index: 0}
-}
-
-func finalizationForfeit(
-	t *testing.T,
-	tapLeaf *psbt.TaprootTapLeafScript,
-	prevout *wire.TxOut,
-	outpoint wire.OutPoint,
-	connector *wire.TxOut,
-	connectorOutpoint wire.OutPoint,
-	payout int64,
-) *psbt.Packet {
-	t.Helper()
-
-	tx := wire.NewMsgTx(3)
-	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
-	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: connectorOutpoint})
-	tx.AddTxOut(&wire.TxOut{Value: payout, PkScript: []byte{txscript.OP_TRUE}})
-	tx.AddTxOut(txutils.AnchorOutput())
-	ptx, err := psbt.NewFromUnsignedTx(tx)
-	require.NoError(t, err)
-	ptx.Inputs[0].WitnessUtxo = prevout
-	ptx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapLeaf}
-	ptx.Inputs[1].WitnessUtxo = connector
-	return ptx
 }
 
 func finalizationCommitment(

--- a/internal/application/signer.go
+++ b/internal/application/signer.go
@@ -34,11 +34,13 @@ func (s signer) signInput(ptx *psbt.Packet, inputIndex int, tweak []byte, prevou
 		return fmt.Errorf("not a taproot input, cannot sign")
 	}
 
-	// only the first leaf is ever signed, the others are ignored on purpose:
-	// arkd builds one leaf per input and the emulator has no way to pick between
-	// several of them
-	if len(input.TaprootLeafScript) == 0 || input.TaprootLeafScript[0] == nil {
-		return fmt.Errorf("no taproot leaf script, cannot sign")
+	// the whole codebase reads and signs the leaf at index 0, reject ambiguous inputs
+	// instead of silently picking one of several declared leaves
+	if len(input.TaprootLeafScript) != 1 || input.TaprootLeafScript[0] == nil {
+		return fmt.Errorf(
+			"expected exactly 1 taproot leaf script, got %d, cannot sign",
+			len(input.TaprootLeafScript),
+		)
 	}
 
 	// the leaf script is the requester's assertion until it is checked against

--- a/internal/application/signer_test.go
+++ b/internal/application/signer_test.go
@@ -367,6 +367,16 @@ func TestSignInputRejectsUnsafeSighashTypes(t *testing.T) {
 	pkScript, err := txscript.PayToTaprootScript(outputKey)
 	require.NoError(t, err)
 
+	// single-leaf tree: the control block carries only the internal key, no
+	// inclusion proof
+	controlBlock := txscript.ControlBlock{
+		InternalKey:     key.PubKey(),
+		OutputKeyYIsOdd: outputKey.SerializeCompressed()[0] == 0x03,
+		LeafVersion:     txscript.BaseLeafVersion,
+	}
+	controlBlockBytes, err := controlBlock.ToBytes()
+	require.NoError(t, err)
+
 	prevout := &wire.TxOut{Value: 1000, PkScript: pkScript}
 	prevoutFetcher := txscript.NewCannedPrevOutputFetcher(prevout.PkScript, prevout.Value)
 
@@ -382,8 +392,9 @@ func TestSignInputRejectsUnsafeSighashTypes(t *testing.T) {
 		ptx.Inputs[0].WitnessUtxo = prevout
 		ptx.Inputs[0].SighashType = sighashType
 		ptx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{{
-			Script:      tapscript,
-			LeafVersion: txscript.BaseLeafVersion,
+			ControlBlock: controlBlockBytes,
+			Script:       tapscript,
+			LeafVersion:  txscript.BaseLeafVersion,
 		}}
 		return ptx
 	}


### PR DESCRIPTION
## Summary

- carry the proof-authorized prevout into each finalization association
- require finalization targets to use the same tapleaf and prevout as the signed intent proof
- require the authorized finalization leaf to include the configured arkd signer
- authenticate the connector input, anchor output, and forfeit value before signing
- add regressions using two different leaves committed by the same taproot tree

## Root cause

SubmitFinalization treated a valid emulator signature in an intent proof as authorization for any later transaction matching the same outpoint. signer.signInput then selected the tapleaf and transaction data from that later requester-controlled PSBT.

## Impact

A requester could substitute another committed leaf containing the same tweaked emulator key and obtain a signature over a transaction that no Arkade script execution approved. The fix binds the reusable proof association to its exact leaf and prevout and ensures every finalization path retains an honest arkd cosigner.

## Validation

- go vet ./internal/application
- go test ./internal/application with all committed application tests
- go test ./cmd ./internal/... -run '^$' -count=1
- focused valid, foreign-leaf, prevout-mismatch, arkd-signer, connector, anchor, and forfeit-value regressions

Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened finalization checks to reject expired or invalid intent messages.
  * Ensured signed inputs match the intended transaction and authorized Taproot details.
  * Added validation for connector outputs, anchors, output counts, and payout values during forfeits.
  * Signing now rejects requests with missing or multiple Taproot leaf scripts.

* **Tests**
  * Added coverage for valid finalizations and rejection of unauthorized or mismatched inputs and forfeits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->