### PR TITLE
Validate checkpoints before SubmitTx signs them

### DIFF
--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -11,6 +11,8 @@ import (
 	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/arkade-os/go-sdk/client"
 	grpcclient "github.com/arkade-os/go-sdk/client/grpc"
+	"github.com/arkade-os/go-sdk/indexer"
+	grpcindexer "github.com/arkade-os/go-sdk/indexer/grpc"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	log "github.com/sirupsen/logrus"
@@ -69,6 +71,7 @@ type service struct {
 	publicKey            string
 	deprecatedPublicKeys []string
 	arkdClient           client.TransportClient
+	arkdIndexer          indexer.Indexer
 	arkdPubKey           *btcec.PublicKey
 	computeLimits        arkade.ComputeLimits
 }
@@ -127,6 +130,11 @@ func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btc
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse arkd signer pubkey: %w", err)
 	}
+	arkdIndexer, err := grpcindexer.NewClient(arkdURL)
+	if err != nil {
+		arkdClient.Close()
+		return nil, fmt.Errorf("failed to create arkd indexer client: %w", err)
+	}
 
 	return &service{
 		signer:               signer{secretKey},
@@ -134,13 +142,19 @@ func New(ctx context.Context, secretKey *btcec.PrivateKey, deprecatedKeys []*btc
 		publicKey:            publicKey,
 		deprecatedPublicKeys: deprecatedPublicKeys,
 		arkdClient:           arkdClient,
+		arkdIndexer:          arkdIndexer,
 		arkdPubKey:           arkdPubKey,
 		computeLimits:        computeLimits,
 	}, nil
 }
 
 func (s *service) Close() {
-	s.arkdClient.Close()
+	if s.arkdClient != nil {
+		s.arkdClient.Close()
+	}
+	if s.arkdIndexer != nil {
+		s.arkdIndexer.Close()
+	}
 }
 
 func (s *service) GetInfo(ctx context.Context) (*Info, error) {

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -35,6 +35,10 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prevout fetcher: %w", err)
 	}
+	checkpointPrevouts, err := s.fetchCheckpointPrevouts(ctx, tx.Checkpoints)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch checkpoint prevouts: %w", err)
+	}
 
 	// Parse EmulatorPacket from the transaction's OP_RETURN output
 	packet, err := arkade.FindEmulatorPacket(arkPtx.UnsignedTx)
@@ -62,7 +66,7 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 
 		inputTxid := arkPtx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint.Hash.String()
 		checkpointPtx := indexedCheckpoints[inputTxid]
-		if err := validateCheckpoint(arkPtx, inputIndex, checkpointPtx, script.TapLeaf(), prevOutFetcher); err != nil {
+		if err := validateCheckpoint(arkPtx, inputIndex, checkpointPtx, checkpointPrevouts[inputTxid], script.TapLeaf()); err != nil {
 			return nil, fmt.Errorf("invalid checkpoint for input %d: %w", inputIndex, err)
 		}
 
@@ -185,6 +189,53 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 	}, nil
 }
 
+func (s *service) fetchCheckpointPrevouts(
+	ctx context.Context, checkpoints []*psbt.Packet,
+) (map[string]*wire.TxOut, error) {
+	if s.arkdIndexer == nil {
+		return nil, fmt.Errorf("arkd indexer is unavailable")
+	}
+
+	txids := make([]string, 0, len(checkpoints))
+	for i, checkpoint := range checkpoints {
+		if checkpoint == nil || checkpoint.UnsignedTx == nil || len(checkpoint.UnsignedTx.TxIn) != 1 {
+			return nil, fmt.Errorf("checkpoint %d must have exactly one input", i)
+		}
+		txids = append(txids, checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint.Hash.String())
+	}
+
+	response, err := s.arkdIndexer.GetVirtualTxs(ctx, txids)
+	if err != nil {
+		return nil, err
+	}
+	if response == nil {
+		return nil, fmt.Errorf("arkd indexer returned no response")
+	}
+	prevTxs := make(map[string]*wire.MsgTx, len(response.Txs))
+	for i, encoded := range response.Txs {
+		ptx, err := psbt.NewFromRawBytes(strings.NewReader(encoded), true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode previous ark transaction %d: %w", i, err)
+		}
+		prevTxs[ptx.UnsignedTx.TxID()] = ptx.UnsignedTx
+	}
+
+	prevouts := make(map[string]*wire.TxOut, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		outpoint := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
+		prevTx, ok := prevTxs[outpoint.Hash.String()]
+		if !ok {
+			return nil, fmt.Errorf("previous ark transaction %s not found", outpoint.Hash)
+		}
+		if outpoint.Index >= uint32(len(prevTx.TxOut)) {
+			return nil, fmt.Errorf("previous ark transaction output index %d out of range", outpoint.Index)
+		}
+		prevouts[checkpoint.UnsignedTx.TxID()] = prevTx.TxOut[outpoint.Index]
+	}
+
+	return prevouts, nil
+}
+
 func indexCheckpoints(arkPtx *psbt.Packet, checkpoints []*psbt.Packet) (map[string]*psbt.Packet, error) {
 	if arkPtx == nil || arkPtx.UnsignedTx == nil {
 		return nil, fmt.Errorf("missing ark transaction")
@@ -222,7 +273,7 @@ func indexCheckpoints(arkPtx *psbt.Packet, checkpoints []*psbt.Packet) (map[stri
 
 func validateCheckpoint(
 	arkPtx *psbt.Packet, inputIndex int, checkpoint *psbt.Packet,
-	expectedLeaf txscript.TapLeaf, prevOutFetcher arkade.ArkPrevOutFetcher,
+	previousOutput *wire.TxOut, expectedLeaf txscript.TapLeaf,
 ) error {
 	if inputIndex < 0 || inputIndex >= len(arkPtx.Inputs) || inputIndex >= len(arkPtx.UnsignedTx.TxIn) {
 		return fmt.Errorf("ark input index out of range")
@@ -248,21 +299,13 @@ func validateCheckpoint(
 		return fmt.Errorf("checkpoint anchor output is invalid")
 	}
 
-	prevArkTx := prevOutFetcher.FetchPrevOutArkTx(arkOutpoint)
-	if prevArkTx == nil {
-		return fmt.Errorf("missing authenticated previous ark transaction")
+	if previousOutput == nil {
+		return fmt.Errorf("missing authenticated previous ark output")
 	}
-	checkpointOutpoint := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
-	if checkpointOutpoint.Hash != prevArkTx.TxHash() {
-		return fmt.Errorf("checkpoint input does not spend the previous ark transaction")
-	}
-	if checkpointOutpoint.Index >= uint32(len(prevArkTx.TxOut)) {
-		return fmt.Errorf("previous ark transaction output index %d out of range", checkpointOutpoint.Index)
-	}
-	if !equalTxOut(checkpoint.Inputs[0].WitnessUtxo, prevArkTx.TxOut[checkpointOutpoint.Index]) {
+	if !equalTxOut(checkpoint.Inputs[0].WitnessUtxo, previousOutput) {
 		return fmt.Errorf("checkpoint input witness utxo does not match previous ark transaction")
 	}
-	if checkpoint.UnsignedTx.TxOut[0].Value != checkpoint.Inputs[0].WitnessUtxo.Value {
+	if checkpoint.UnsignedTx.TxOut[0].Value != previousOutput.Value {
 		return fmt.Errorf("checkpoint vtxo output value does not match its input")
 	}
 

--- a/internal/application/tx.go
+++ b/internal/application/tx.go
@@ -11,10 +11,13 @@ import (
 	"time"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -23,15 +26,9 @@ import (
 func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, error) {
 	arkPtx := tx.ArkTx
 
-	// index checkpoints by txid for easy lookup while signing ark transaction
-	indexedCheckpoints := make(map[string]*psbt.Packet) // txid => checkpoint psbt
-	for _, checkpoint := range tx.Checkpoints {
-		indexedCheckpoints[checkpoint.UnsignedTx.TxID()] = checkpoint
-	}
-	// preserve original checkpoint order for deterministic response
-	orderedCheckpointTxids := make([]string, 0, len(tx.Checkpoints))
-	for _, checkpoint := range tx.Checkpoints {
-		orderedCheckpointTxids = append(orderedCheckpointTxids, checkpoint.UnsignedTx.TxID())
+	indexedCheckpoints, err := indexCheckpoints(arkPtx, tx.Checkpoints)
+	if err != nil {
+		return nil, err
 	}
 
 	prevOutFetcher, err := prevOutFetcherForArkTx(arkPtx, tx.Checkpoints)
@@ -63,6 +60,12 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 			return nil, fmt.Errorf("failed to read arkade script: %w vin=%d", err, inputIndex)
 		}
 
+		inputTxid := arkPtx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint.Hash.String()
+		checkpointPtx := indexedCheckpoints[inputTxid]
+		if err := validateCheckpoint(arkPtx, inputIndex, checkpointPtx, script.TapLeaf(), prevOutFetcher); err != nil {
+			return nil, fmt.Errorf("invalid checkpoint for input %d: %w", inputIndex, err)
+		}
+
 		log.Debugf("executing arkade script: %x", script.Script())
 		if err := script.Execute(
 			arkPtx.UnsignedTx,
@@ -76,13 +79,6 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 
 		if err := matchedSigner.signInput(arkPtx, inputIndex, script.Hash(), prevOutFetcher); err != nil {
 			return nil, fmt.Errorf("failed to sign input %d: %w", inputIndex, err)
-		}
-
-		// search for checkpoint
-		inputTxid := arkPtx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint.Hash.String()
-		checkpointPtx, ok := indexedCheckpoints[inputTxid]
-		if !ok {
-			return nil, fmt.Errorf("checkpoint not found for input %d", inputIndex)
 		}
 
 		checkpointPrevoutFetcher, err := computePrevoutFetcher(checkpointPtx)
@@ -105,10 +101,7 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 		return nil, fmt.Errorf("failed to find any valid input/entry pairs")
 	}
 
-	signedCheckpointTxs := make([]*psbt.Packet, 0, len(orderedCheckpointTxids))
-	for _, txid := range orderedCheckpointTxids {
-		signedCheckpointTxs = append(signedCheckpointTxs, indexedCheckpoints[txid])
-	}
+	signedCheckpointTxs := tx.Checkpoints
 
 	isFinalizer, err := finalizerAcc.isFinalizer()
 	if err != nil {
@@ -190,6 +183,127 @@ func (s *service) SubmitTx(ctx context.Context, tx OffchainTx) (*OffchainTx, err
 		ArkTx:       finalArkPtx,
 		Checkpoints: signedCheckpointTxs,
 	}, nil
+}
+
+func indexCheckpoints(arkPtx *psbt.Packet, checkpoints []*psbt.Packet) (map[string]*psbt.Packet, error) {
+	if arkPtx == nil || arkPtx.UnsignedTx == nil {
+		return nil, fmt.Errorf("missing ark transaction")
+	}
+	if len(checkpoints) != len(arkPtx.UnsignedTx.TxIn) {
+		return nil, fmt.Errorf("expected %d checkpoints, got %d", len(arkPtx.UnsignedTx.TxIn), len(checkpoints))
+	}
+
+	indexed := make(map[string]*psbt.Packet, len(checkpoints))
+	for i, checkpoint := range checkpoints {
+		if checkpoint == nil || checkpoint.UnsignedTx == nil {
+			return nil, fmt.Errorf("checkpoint %d is missing its transaction", i)
+		}
+		txid := checkpoint.UnsignedTx.TxID()
+		if _, exists := indexed[txid]; exists {
+			return nil, fmt.Errorf("duplicate checkpoint %s", txid)
+		}
+		indexed[txid] = checkpoint
+	}
+
+	used := make(map[string]struct{}, len(arkPtx.UnsignedTx.TxIn))
+	for inputIndex, input := range arkPtx.UnsignedTx.TxIn {
+		txid := input.PreviousOutPoint.Hash.String()
+		if _, ok := indexed[txid]; !ok {
+			return nil, fmt.Errorf("checkpoint not found for input %d", inputIndex)
+		}
+		if _, exists := used[txid]; exists {
+			return nil, fmt.Errorf("checkpoint %s is associated with multiple ark inputs", txid)
+		}
+		used[txid] = struct{}{}
+	}
+
+	return indexed, nil
+}
+
+func validateCheckpoint(
+	arkPtx *psbt.Packet, inputIndex int, checkpoint *psbt.Packet,
+	expectedLeaf txscript.TapLeaf, prevOutFetcher arkade.ArkPrevOutFetcher,
+) error {
+	if inputIndex < 0 || inputIndex >= len(arkPtx.Inputs) || inputIndex >= len(arkPtx.UnsignedTx.TxIn) {
+		return fmt.Errorf("ark input index out of range")
+	}
+	if checkpoint == nil || checkpoint.UnsignedTx == nil || len(checkpoint.Inputs) != 1 || len(checkpoint.UnsignedTx.TxIn) != 1 {
+		return fmt.Errorf("checkpoint must have exactly one input")
+	}
+	if len(checkpoint.UnsignedTx.TxOut) != 2 {
+		return fmt.Errorf("checkpoint must have one vtxo output and one anchor output")
+	}
+
+	arkOutpoint := arkPtx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint
+	if arkOutpoint.Hash != checkpoint.UnsignedTx.TxHash() {
+		return fmt.Errorf("ark input does not spend checkpoint")
+	}
+	if arkOutpoint.Index != 0 {
+		return fmt.Errorf("ark input must spend checkpoint output 0")
+	}
+	if !equalTxOut(arkPtx.Inputs[inputIndex].WitnessUtxo, checkpoint.UnsignedTx.TxOut[arkOutpoint.Index]) {
+		return fmt.Errorf("checkpoint output does not match ark input witness utxo")
+	}
+	if !equalTxOut(checkpoint.UnsignedTx.TxOut[1], txutils.AnchorOutput()) {
+		return fmt.Errorf("checkpoint anchor output is invalid")
+	}
+
+	prevArkTx := prevOutFetcher.FetchPrevOutArkTx(arkOutpoint)
+	if prevArkTx == nil {
+		return fmt.Errorf("missing authenticated previous ark transaction")
+	}
+	checkpointOutpoint := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
+	if checkpointOutpoint.Hash != prevArkTx.TxHash() {
+		return fmt.Errorf("checkpoint input does not spend the previous ark transaction")
+	}
+	if checkpointOutpoint.Index >= uint32(len(prevArkTx.TxOut)) {
+		return fmt.Errorf("previous ark transaction output index %d out of range", checkpointOutpoint.Index)
+	}
+	if !equalTxOut(checkpoint.Inputs[0].WitnessUtxo, prevArkTx.TxOut[checkpointOutpoint.Index]) {
+		return fmt.Errorf("checkpoint input witness utxo does not match previous ark transaction")
+	}
+	if checkpoint.UnsignedTx.TxOut[0].Value != checkpoint.Inputs[0].WitnessUtxo.Value {
+		return fmt.Errorf("checkpoint vtxo output value does not match its input")
+	}
+
+	if err := validateTaprootLeaf(arkPtx.Inputs[inputIndex], expectedLeaf); err != nil {
+		return fmt.Errorf("ark input tapleaf: %w", err)
+	}
+	if err := validateTaprootLeaf(checkpoint.Inputs[0], expectedLeaf); err != nil {
+		return fmt.Errorf("checkpoint tapleaf: %w", err)
+	}
+
+	return nil
+}
+
+func equalTxOut(a, b *wire.TxOut) bool {
+	return a != nil && b != nil && a.Value == b.Value && bytes.Equal(a.PkScript, b.PkScript)
+}
+
+func validateTaprootLeaf(input psbt.PInput, expectedLeaf txscript.TapLeaf) error {
+	if input.WitnessUtxo == nil || !txscript.IsPayToTaproot(input.WitnessUtxo.PkScript) {
+		return fmt.Errorf("witness utxo is not taproot")
+	}
+	if len(input.TaprootLeafScript) == 0 || input.TaprootLeafScript[0] == nil {
+		return fmt.Errorf("missing taproot leaf script")
+	}
+
+	leaf := input.TaprootLeafScript[0]
+	controlBlock, err := txscript.ParseControlBlock(leaf.ControlBlock)
+	if err != nil {
+		return fmt.Errorf("invalid control block: %w", err)
+	}
+	if controlBlock.LeafVersion != leaf.LeafVersion {
+		return fmt.Errorf("control block leaf version does not match taproot leaf script")
+	}
+	if txscript.NewTapLeaf(leaf.LeafVersion, leaf.Script).TapHash() != expectedLeaf.TapHash() {
+		return fmt.Errorf("tapleaf does not match ark input")
+	}
+	if err := txscript.VerifyTaprootLeafCommitment(controlBlock, input.WitnessUtxo.PkScript[2:], leaf.Script); err != nil {
+		return fmt.Errorf("tapleaf is not committed by witness utxo: %w", err)
+	}
+
+	return nil
 }
 
 func (s *service) retryFinalize(ctx context.Context, txid string, checkpoints []string) error {

--- a/internal/application/tx_test.go
+++ b/internal/application/tx_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
 	arkscript "github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	"github.com/arkade-os/emulator/pkg/arkade"
 	sdkclient "github.com/arkade-os/go-sdk/client"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -20,6 +21,189 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIndexCheckpoints(t *testing.T) {
+	newCheckpoint := func(t *testing.T, id byte) *psbt.Packet {
+		t.Helper()
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{id}}})
+		tx.AddTxOut(&wire.TxOut{Value: 1})
+		ptx, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+		return ptx
+	}
+	newArkTx := func(t *testing.T, checkpoints ...*psbt.Packet) *psbt.Packet {
+		t.Helper()
+		tx := wire.NewMsgTx(2)
+		for _, checkpoint := range checkpoints {
+			tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: checkpoint.UnsignedTx.TxHash()}})
+		}
+		ptx, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+		return ptx
+	}
+
+	first := newCheckpoint(t, 1)
+	second := newCheckpoint(t, 2)
+	arkPtx := newArkTx(t, first, second)
+
+	indexed, err := indexCheckpoints(arkPtx, []*psbt.Packet{second, first})
+	require.NoError(t, err)
+	require.Same(t, first, indexed[first.UnsignedTx.TxID()])
+	require.Same(t, second, indexed[second.UnsignedTx.TxID()])
+
+	_, err = indexCheckpoints(arkPtx, []*psbt.Packet{first})
+	require.ErrorContains(t, err, "expected 2 checkpoints")
+
+	_, err = indexCheckpoints(arkPtx, []*psbt.Packet{first, first})
+	require.ErrorContains(t, err, "duplicate checkpoint")
+
+	arkPtx.UnsignedTx.TxIn[1].PreviousOutPoint.Hash = first.UnsignedTx.TxHash()
+	_, err = indexCheckpoints(arkPtx, []*psbt.Packet{first, second})
+	require.ErrorContains(t, err, "associated with multiple ark inputs")
+}
+
+func TestValidateCheckpoint(t *testing.T) {
+	type setup struct {
+		arkPtx       *psbt.Packet
+		checkpoint   *psbt.Packet
+		expectedLeaf txscript.TapLeaf
+		foreignLeaf  *psbt.TaprootTapLeafScript
+		fetcher      *mapArkPrevOutFetcher
+	}
+
+	newSetup := func(t *testing.T, unrelatedOutput bool) setup {
+		t.Helper()
+
+		firstKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		secondKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		closures := []*arkscript.MultisigClosure{
+			{PubKeys: []*btcec.PublicKey{firstKey.PubKey()}},
+			{PubKeys: []*btcec.PublicKey{secondKey.PubKey()}},
+		}
+		vtxoScript := arkscript.TapscriptsVtxoScript{
+			Closures: []arkscript.Closure{closures[0], closures[1]},
+		}
+		tapKey, tapTree, err := vtxoScript.TapTree()
+		require.NoError(t, err)
+		vtxoPkScript, err := arkscript.P2TRScript(tapKey)
+		require.NoError(t, err)
+
+		leafField := func(t *testing.T, closure arkscript.Closure) (*psbt.TaprootTapLeafScript, txscript.TapLeaf) {
+			t.Helper()
+			script, err := closure.Script()
+			require.NoError(t, err)
+			leaf := txscript.NewBaseTapLeaf(script)
+			proof, err := tapTree.GetTaprootMerkleProof(leaf.TapHash())
+			require.NoError(t, err)
+			return &psbt.TaprootTapLeafScript{
+				ControlBlock: proof.ControlBlock,
+				Script:       proof.Script,
+				LeafVersion:  txscript.BaseLeafVersion,
+			}, leaf
+		}
+		authorizedField, authorizedLeaf := leafField(t, closures[0])
+		foreignField, _ := leafField(t, closures[1])
+
+		const amount = int64(100_000)
+		previousOutput := &wire.TxOut{Value: amount, PkScript: vtxoPkScript}
+		previousTx := wire.NewMsgTx(2)
+		previousTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{9}}})
+		previousTx.AddTxOut(previousOutput)
+
+		checkpointOutputScript := vtxoPkScript
+		if unrelatedOutput {
+			attackerKey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			checkpointOutputScript, err = txscript.PayToTaprootScript(attackerKey.PubKey())
+			require.NoError(t, err)
+		}
+		checkpointOutput := &wire.TxOut{Value: amount, PkScript: checkpointOutputScript}
+		checkpointTx := wire.NewMsgTx(2)
+		checkpointTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: previousTx.TxHash()}})
+		checkpointTx.AddTxOut(checkpointOutput)
+		checkpointTx.AddTxOut(txutils.AnchorOutput())
+		checkpoint, err := psbt.NewFromUnsignedTx(checkpointTx)
+		require.NoError(t, err)
+		checkpoint.Inputs[0].WitnessUtxo = &wire.TxOut{Value: amount, PkScript: append([]byte(nil), vtxoPkScript...)}
+		checkpoint.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{authorizedField}
+
+		arkTx := wire.NewMsgTx(2)
+		arkOutpoint := wire.OutPoint{Hash: checkpointTx.TxHash()}
+		arkTx.AddTxIn(&wire.TxIn{PreviousOutPoint: arkOutpoint})
+		arkPtx, err := psbt.NewFromUnsignedTx(arkTx)
+		require.NoError(t, err)
+		arkPtx.Inputs[0].WitnessUtxo = &wire.TxOut{Value: amount, PkScript: append([]byte(nil), checkpointOutputScript...)}
+		arkPtx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{authorizedField}
+
+		return setup{
+			arkPtx:       arkPtx,
+			checkpoint:   checkpoint,
+			expectedLeaf: authorizedLeaf,
+			foreignLeaf:  foreignField,
+			fetcher: &mapArkPrevOutFetcher{
+				arkTxs: map[wire.OutPoint]*wire.MsgTx{arkOutpoint: previousTx},
+			},
+		}
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		setup := newSetup(t, false)
+		require.NoError(t, validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher))
+	})
+
+	t.Run("multiple checkpoint inputs", func(t *testing.T) {
+		setup := newSetup(t, false)
+		setup.checkpoint.UnsignedTx.AddTxIn(&wire.TxIn{})
+		setup.checkpoint.Inputs = append(setup.checkpoint.Inputs, psbt.PInput{})
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "exactly one input")
+	})
+
+	t.Run("extra checkpoint output", func(t *testing.T) {
+		setup := newSetup(t, false)
+		setup.checkpoint.UnsignedTx.AddTxOut(&wire.TxOut{})
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "one vtxo output and one anchor output")
+	})
+
+	t.Run("checkpoint output mismatch", func(t *testing.T) {
+		setup := newSetup(t, false)
+		setup.arkPtx.Inputs[0].WitnessUtxo.Value--
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "checkpoint output does not match")
+	})
+
+	t.Run("unauthenticated checkpoint input", func(t *testing.T) {
+		setup := newSetup(t, false)
+		setup.checkpoint.Inputs[0].WitnessUtxo.Value--
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "does not match previous ark transaction")
+	})
+
+	t.Run("missing previous ark transaction", func(t *testing.T) {
+		setup := newSetup(t, false)
+		setup.fetcher.arkTxs = nil
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "missing authenticated previous ark transaction")
+	})
+
+	t.Run("substituted checkpoint leaf", func(t *testing.T) {
+		setup := newSetup(t, false)
+		setup.checkpoint.Inputs[0].TaprootLeafScript[0] = setup.foreignLeaf
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "tapleaf does not match ark input")
+	})
+
+	t.Run("unrelated checkpoint destination", func(t *testing.T) {
+		setup := newSetup(t, true)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		require.ErrorContains(t, err, "ark input tapleaf")
+		require.ErrorContains(t, err, "not committed by witness utxo")
+	})
+}
 
 func TestFinalizerAccumulatorFlow(t *testing.T) {
 	thisSigner, err := btcec.NewPrivateKey()

--- a/internal/application/tx_test.go
+++ b/internal/application/tx_test.go
@@ -65,11 +65,11 @@ func TestIndexCheckpoints(t *testing.T) {
 
 func TestValidateCheckpoint(t *testing.T) {
 	type setup struct {
-		arkPtx       *psbt.Packet
-		checkpoint   *psbt.Packet
-		expectedLeaf txscript.TapLeaf
-		foreignLeaf  *psbt.TaprootTapLeafScript
-		fetcher      *mapArkPrevOutFetcher
+		arkPtx         *psbt.Packet
+		checkpoint     *psbt.Packet
+		previousOutput *wire.TxOut
+		expectedLeaf   txscript.TapLeaf
+		foreignLeaf    *psbt.TaprootTapLeafScript
 	}
 
 	newSetup := func(t *testing.T, unrelatedOutput bool) setup {
@@ -139,67 +139,64 @@ func TestValidateCheckpoint(t *testing.T) {
 		arkPtx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{authorizedField}
 
 		return setup{
-			arkPtx:       arkPtx,
-			checkpoint:   checkpoint,
-			expectedLeaf: authorizedLeaf,
-			foreignLeaf:  foreignField,
-			fetcher: &mapArkPrevOutFetcher{
-				arkTxs: map[wire.OutPoint]*wire.MsgTx{arkOutpoint: previousTx},
-			},
+			arkPtx:         arkPtx,
+			checkpoint:     checkpoint,
+			previousOutput: previousOutput,
+			expectedLeaf:   authorizedLeaf,
+			foreignLeaf:    foreignField,
 		}
 	}
 
 	t.Run("valid", func(t *testing.T) {
 		setup := newSetup(t, false)
-		require.NoError(t, validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher))
+		require.NoError(t, validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf))
 	})
 
 	t.Run("multiple checkpoint inputs", func(t *testing.T) {
 		setup := newSetup(t, false)
 		setup.checkpoint.UnsignedTx.AddTxIn(&wire.TxIn{})
 		setup.checkpoint.Inputs = append(setup.checkpoint.Inputs, psbt.PInput{})
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf)
 		require.ErrorContains(t, err, "exactly one input")
 	})
 
 	t.Run("extra checkpoint output", func(t *testing.T) {
 		setup := newSetup(t, false)
 		setup.checkpoint.UnsignedTx.AddTxOut(&wire.TxOut{})
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf)
 		require.ErrorContains(t, err, "one vtxo output and one anchor output")
 	})
 
 	t.Run("checkpoint output mismatch", func(t *testing.T) {
 		setup := newSetup(t, false)
 		setup.arkPtx.Inputs[0].WitnessUtxo.Value--
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf)
 		require.ErrorContains(t, err, "checkpoint output does not match")
 	})
 
 	t.Run("unauthenticated checkpoint input", func(t *testing.T) {
 		setup := newSetup(t, false)
 		setup.checkpoint.Inputs[0].WitnessUtxo.Value--
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf)
 		require.ErrorContains(t, err, "does not match previous ark transaction")
 	})
 
 	t.Run("missing previous ark transaction", func(t *testing.T) {
 		setup := newSetup(t, false)
-		setup.fetcher.arkTxs = nil
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
-		require.ErrorContains(t, err, "missing authenticated previous ark transaction")
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, nil, setup.expectedLeaf)
+		require.ErrorContains(t, err, "missing authenticated previous ark output")
 	})
 
 	t.Run("substituted checkpoint leaf", func(t *testing.T) {
 		setup := newSetup(t, false)
 		setup.checkpoint.Inputs[0].TaprootLeafScript[0] = setup.foreignLeaf
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf)
 		require.ErrorContains(t, err, "tapleaf does not match ark input")
 	})
 
 	t.Run("unrelated checkpoint destination", func(t *testing.T) {
 		setup := newSetup(t, true)
-		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.expectedLeaf, setup.fetcher)
+		err := validateCheckpoint(setup.arkPtx, 0, setup.checkpoint, setup.previousOutput, setup.expectedLeaf)
 		require.ErrorContains(t, err, "ark input tapleaf")
 		require.ErrorContains(t, err, "not committed by witness utxo")
 	})


### PR DESCRIPTION
Closes #121.

## Summary

- require a unique checkpoint for every Ark input
- fetch each checkpoint's previous VTXO from arkd's indexer and reconcile the request's WitnessUtxo with the authenticated output
- reconcile the selected checkpoint output with the Ark input WitnessUtxo
- bind both spends to the exact committed tapleaf used for Arkade execution
- enforce the native one-input, VTXO-plus-anchor checkpoint shape

## Root cause

SubmitTx executed the Arkade covenant against the Ark transaction, then signed a request-supplied checkpoint after matching only its txid. The checkpoint input, selected output, WitnessUtxo, and spending leaf were not bound to authenticated protocol data.

## Testing

- `make test` in a clean checkout
- `make integrationtest` against a clean, rebuilt Compose regtest environment (all integration tests passed in 369.351s)
- `go vet ./internal/application`
- confirmed the audit PoC is rejected before signing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction submission validation for checkpoint structure, ordering, previous outputs, and Taproot data.
  * Prevented invalid or unauthorized transaction outputs from being accepted.
  * Ensured related service clients are closed safely when initialization or shutdown occurs.

* **Tests**
  * Added comprehensive coverage for checkpoint indexing, validation, output mismatches, missing data, and unauthorized Taproot information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->