### PR TITLE
Reject invalid introspected transaction values

### DIFF
--- a/pkg/arkade/go.mod
+++ b/pkg/arkade/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
+	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.9
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/consensys/gnark-crypto v0.19.2
@@ -18,7 +19,6 @@ require (
 require (
 	github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
-	github.com/btcsuite/btcd/btcutil v1.1.5 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect

--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -2025,7 +2026,17 @@ func opcodeInspectInputValue(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(txscript.ErrInvalidIndex, "previous output fetcher not set")
 	}
 	prevOut := vm.prevOutFetcher.FetchPrevOutput(vm.tx.TxIn[index].PreviousOutPoint)
-	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(prevOut.Value)))
+	if prevOut == nil {
+		return scriptError(txscript.ErrInvalidIndex, "previous output not found")
+	}
+	return pushSatoshiValue(prevOut.Value, vm)
+}
+
+func pushSatoshiValue(value int64, vm *Engine) error {
+	if value < 0 || value > btcutil.MaxSatoshi {
+		return scriptError(txscript.ErrInvalidIndex, "value out of range")
+	}
+	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(value)))
 }
 
 func pushScriptPubKey(scriptPubKey []byte, vm *Engine) error {
@@ -2120,7 +2131,7 @@ func opcodeInspectOutputValue(op *opcode, data []byte, vm *Engine) error {
 	if int(index) >= len(vm.tx.TxOut) {
 		return scriptError(txscript.ErrInvalidIndex, "output index out of range")
 	}
-	return vm.dstack.PushBigNum(BigNumFromUint64(uint64(vm.tx.TxOut[index].Value)))
+	return pushSatoshiValue(vm.tx.TxOut[index].Value, vm)
 }
 
 // opcodeInspectOutputScriptPubkey pushes the scriptPubKey of the output at the given index onto the stack.

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -4704,6 +4705,14 @@ func inspectInputValueSpec() *opcodeSpec {
 		checkProperties: inspectInputPropertyChecker(OP_INSPECTINPUTVALUE),
 		validVectors: []opcodeVector{
 			{name: "val0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{0x88, 0x13}}},
+			{
+				name:       "max_value",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					w.prevouts[w.tx.TxIn[0].PreviousOutPoint].Value = btcutil.MaxSatoshi
+				},
+				expectedStack: [][]byte{mustBigNumBytes(BigNumFromUint64(btcutil.MaxSatoshi))},
+			},
 		},
 		invalidVectors: []opcodeVector{
 			{
@@ -4720,6 +4729,28 @@ func inspectInputValueSpec() *opcodeSpec {
 				name:          "no_prev_fetcher",
 				inputStack:    [][]byte{nil},
 				setupWorld:    func(w *opcodeWorld) { w.prevFetcher = nil },
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:       "negative_value",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					w.prevouts[w.tx.TxIn[0].PreviousOutPoint].Value = -1
+				},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:       "above_max_value",
+				inputStack: [][]byte{nil},
+				setupWorld: func(w *opcodeWorld) {
+					w.prevouts[w.tx.TxIn[0].PreviousOutPoint].Value = btcutil.MaxSatoshi + 1
+				},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "missing_prevout",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.tx.TxIn[0].PreviousOutPoint = wire.OutPoint{} },
 				expectedError: txscript.ErrInvalidIndex,
 			},
 			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
@@ -4801,6 +4832,12 @@ func inspectOutputValueSpec() *opcodeSpec {
 		checkProperties: inspectOutputPropertyChecker(OP_INSPECTOUTPUTVALUE),
 		validVectors: []opcodeVector{
 			{name: "val0", inputStack: [][]byte{nil}, expectedStack: [][]byte{{0x58, 0x1b}}},
+			{
+				name:          "max_value",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.tx.TxOut[0].Value = btcutil.MaxSatoshi },
+				expectedStack: [][]byte{mustBigNumBytes(BigNumFromUint64(btcutil.MaxSatoshi))},
+			},
 		},
 		invalidVectors: []opcodeVector{
 			{
@@ -4811,6 +4848,18 @@ func inspectOutputValueSpec() *opcodeSpec {
 			{
 				name:          "out_of_range",
 				inputStack:    [][]byte{scriptNum(9).Bytes()},
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "negative_value",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.tx.TxOut[0].Value = -1 },
+				expectedError: txscript.ErrInvalidIndex,
+			},
+			{
+				name:          "above_max_value",
+				inputStack:    [][]byte{nil},
+				setupWorld:    func(w *opcodeWorld) { w.tx.TxOut[0].Value = btcutil.MaxSatoshi + 1 },
 				expectedError: txscript.ErrInvalidIndex,
 			},
 			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -5116,6 +5116,10 @@ func inspectInputPropertyChecker(op byte) opcodePropertyChecker {
 			want, err := BigNumFromUint64(uint64(prevOut.Value)).Bytes()
 			require.NoError(t, err)
 			require.Equal(t, want, top)
+			topBigNum, err := BigNumFromBytes(top)
+			require.NoError(t, err)
+			require.LessOrEqual(t, topBigNum.Cmp(BigNumFromUint64(btcutil.MaxSatoshi)), 0)
+			require.GreaterOrEqual(t, topBigNum.Cmp(BigNumFromUint64(0)), 0)
 		case OP_INSPECTINPUTSCRIPTPUBKEY:
 			require.LessOrEqual(t, len(top), 5)
 			programOrHash := c.after.GetStack()[afterDepth-2]
@@ -5157,6 +5161,10 @@ func inspectOutputPropertyChecker(op byte) opcodePropertyChecker {
 			want, err := BigNumFromUint64(uint64(c.before.tx.TxOut[int(index.BigInt().Int64())].Value)).Bytes()
 			require.NoError(t, err)
 			require.Equal(t, want, c.after.GetStack()[afterDepth-1])
+			topBigNum, err := BigNumFromBytes(c.after.GetStack()[afterDepth-1])
+			require.NoError(t, err)
+			require.LessOrEqual(t, topBigNum.Cmp(BigNumFromUint64(btcutil.MaxSatoshi)), 0)
+			require.GreaterOrEqual(t, topBigNum.Cmp(BigNumFromUint64(0)), 0)
 		case OP_INSPECTOUTPUTSCRIPTPUBKEY:
 			require.Equal(t, beforeDepth+1, afterDepth)
 			require.LessOrEqual(t, len(c.after.GetStack()[afterDepth-1]), 5)


### PR DESCRIPTION
Closes #124.

Rejects missing previous outputs and transaction values outside Bitcoin's monetary range before either value-introspection opcode converts them to an unsigned script number. Both `OP_INSPECTINPUTVALUE` and `OP_INSPECTOUTPUTVALUE` share the same range check.

Tests cover `-1`, exactly `MaxSatoshi`, `MaxSatoshi + 1`, and a missing previous output.

Validation:
- `make test` from a clean clone
- `go vet ./...` in `pkg/arkade`
- `make integrationtest` against a clean rebuilt regtest stack (`376.148s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of transaction input and output amounts.
  * Invalid amounts, including negative, oversized, or missing values, are now rejected.
  * Valid amounts up to the maximum supported satoshi value continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->