### PR TITLE
Restrict tapscript signatures to safe sighash types

### DIFF
--- a/internal/application/signer.go
+++ b/internal/application/signer.go
@@ -23,6 +23,12 @@ func (s signer) signInput(ptx *psbt.Packet, inputIndex int, tweak []byte, prevou
 	signingKey := arkade.ComputeArkadeScriptPrivateKey(s.secretKey, tweak)
 
 	input := ptx.Inputs[inputIndex]
+	// only sighash types committing to every input and output are safe: any other
+	// type lets the requester replace outputs or prevouts the covenant approved
+	if input.SighashType != txscript.SigHashDefault && input.SighashType != txscript.SigHashAll {
+		return fmt.Errorf("unsupported sighash type 0x%02x, cannot sign", uint32(input.SighashType))
+	}
+
 	// if not a taproot input, skip because arkd-wallet is taproot only accounts
 	if !txscript.IsPayToTaproot(input.WitnessUtxo.PkScript) {
 		return fmt.Errorf("not a taproot input, cannot sign")

--- a/internal/application/signer_test.go
+++ b/internal/application/signer_test.go
@@ -205,3 +205,73 @@ func newResolverPacketForEntries(t *testing.T, entries []resolverEntrySigner) *p
 
 	return ptx
 }
+
+func TestSignInputRejectsUnsafeSighashTypes(t *testing.T) {
+	key := newResolverPrivateKey(t)
+	closure := arkscript.MultisigClosure{PubKeys: []*btcec.PublicKey{
+		arkade.ComputeArkadeScriptPublicKey(key.PubKey(), nil),
+	}}
+	tapscript, err := closure.Script()
+	require.NoError(t, err)
+
+	leaf := txscript.NewBaseTapLeaf(tapscript)
+	tapTree := txscript.AssembleTaprootScriptTree(leaf)
+	root := tapTree.RootNode.TapHash()
+	outputKey := txscript.ComputeTaprootOutputKey(key.PubKey(), root[:])
+	pkScript, err := txscript.PayToTaprootScript(outputKey)
+	require.NoError(t, err)
+
+	prevout := &wire.TxOut{Value: 1000, PkScript: pkScript}
+	prevoutFetcher := txscript.NewCannedPrevOutputFetcher(prevout.PkScript, prevout.Value)
+
+	newPacket := func(t *testing.T, sighashType txscript.SigHashType) *psbt.Packet {
+		t.Helper()
+
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(&wire.TxIn{})
+		tx.AddTxOut(&wire.TxOut{Value: 900, PkScript: pkScript})
+		ptx, err := psbt.NewFromUnsignedTx(tx)
+		require.NoError(t, err)
+
+		ptx.Inputs[0].WitnessUtxo = prevout
+		ptx.Inputs[0].SighashType = sighashType
+		ptx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{{
+			Script:      tapscript,
+			LeafVersion: txscript.BaseLeafVersion,
+		}}
+		return ptx
+	}
+
+	tests := []struct {
+		name        string
+		sighashType txscript.SigHashType
+		accepted    bool
+	}{
+		{name: "default", sighashType: txscript.SigHashDefault, accepted: true},
+		{name: "all", sighashType: txscript.SigHashAll, accepted: true},
+		{name: "none", sighashType: txscript.SigHashNone},
+		{name: "single", sighashType: txscript.SigHashSingle},
+		{name: "anyonecanpay", sighashType: txscript.SigHashAnyOneCanPay},
+		{name: "all anyonecanpay", sighashType: txscript.SigHashAll | txscript.SigHashAnyOneCanPay},
+		{name: "none anyonecanpay", sighashType: txscript.SigHashNone | txscript.SigHashAnyOneCanPay},
+		{name: "single anyonecanpay", sighashType: txscript.SigHashSingle | txscript.SigHashAnyOneCanPay},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ptx := newPacket(t, tc.sighashType)
+
+			err := signer{key}.signInput(ptx, 0, nil, prevoutFetcher)
+
+			if tc.accepted {
+				require.NoError(t, err)
+				require.Len(t, ptx.Inputs[0].TaprootScriptSpendSig, 1)
+				require.Equal(t, tc.sighashType, ptx.Inputs[0].TaprootScriptSpendSig[0].SigHash)
+				return
+			}
+
+			require.ErrorContains(t, err, "unsupported sighash type")
+			require.Empty(t, ptx.Inputs[0].TaprootScriptSpendSig)
+		})
+	}
+}


### PR DESCRIPTION
Closes #122.

## Summary

- Reject every PSBT sighash type except `SIGHASH_DEFAULT` and `SIGHASH_ALL` centrally in `signInput`, before any signature is produced.
- Cover `SIGHASH_NONE`, `SIGHASH_SINGLE`, and all `ANYONECANPAY` combinations with a table test; `DEFAULT` and `ALL` keep signing and keep stamping their sighash into the PSBT sig field.

## Root cause

`signInput` forwarded the requester-controlled `input.SighashType` straight into `RawTxInTapscriptSignature`. Every signing endpoint reaches this helper (`tx.go`, `intent.go`, `onchain.go`, `finalization.go`), so a valid covenant execution could yield a signature that does not commit to the transaction properties the covenant approved: `SIGHASH_NONE`/`SIGHASH_SINGLE` allow outputs to be replaced after execution, `ANYONECANPAY` drops the commitment to the other input prevouts.

The guard is placed in the shared helper rather than at each call site, so all seven callers are covered by one check.

## Relationship to #129

Independent and non-overlapping (different file). #129 authenticates checkpoint prevouts, which removes the fabricated cross-input introspection data that `ANYONECANPAY` would make usable; it does not restrict sighash types. This PR closes the remaining output-replacement vector and is based on `master`, so the two can merge in either order.

## Testing

- `go test ./internal/application/ -run TestSignInput -v`: PASS; verified the new test fails without the guard.
- `go test ./internal/... ./pkg/...`: PASS.
- `go build ./...`, `go vet ./internal/application`: PASS.
- Local (uncommitted) audit PoCs `TestPocAttackerChosenSighashType` and `TestPocUncommittedPrevoutLie` are now rejected at signing (`unsupported sighash type 0x02` / `0x81`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signing now rejects unsupported or potentially unsafe sighash types.
  * Default and “all” sighash modes continue to produce signatures as expected.

* **Tests**
  * Added coverage confirming unsupported sighash combinations fail without generating a signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->