### PR TITLE
check psbt sanity

### DIFF
--- a/internal/interface/grpc/handlers/emulator_handler.go
+++ b/internal/interface/grpc/handlers/emulator_handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	emulatorv1 "github.com/arkade-os/emulator/api-spec/protobuf/gen/emulator/v1"
@@ -59,14 +58,14 @@ func (h *handler) SubmitTx(
 		return nil, status.Error(codes.InvalidArgument, "missing checkpoint txs")
 	}
 
-	arkPtx, err := psbt.NewFromRawBytes(strings.NewReader(arkTx), true)
+	arkPtx, err := parsePsbt(arkTx)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid ark tx")
 	}
 
 	checkpointPsbt := make([]*psbt.Packet, 0, len(checkpoints))
 	for _, checkpoint := range checkpoints {
-		checkpointPtx, err := psbt.NewFromRawBytes(strings.NewReader(checkpoint), true)
+		checkpointPtx, err := parsePsbt(checkpoint)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, "invalid checkpoint tx")
 		}
@@ -156,14 +155,14 @@ func (h *handler) SubmitFinalization(
 		return nil, status.Error(codes.InvalidArgument, "missing commitment tx")
 	}
 
-	commitmentPtx, err := psbt.NewFromRawBytes(strings.NewReader(commitmentTx), true)
+	commitmentPtx, err := parsePsbt(commitmentTx)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid commitment tx")
 	}
 
 	forfeitPsbt := make([]*psbt.Packet, 0, len(forfeitTxs))
 	for _, forfeit := range forfeitTxs {
-		forfeitPtx, err := psbt.NewFromRawBytes(strings.NewReader(forfeit), true)
+		forfeitPtx, err := parsePsbt(forfeit)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, "invalid forfeit tx")
 		}
@@ -231,7 +230,7 @@ func (h *handler) SubmitOnchainTx(
 		return nil, status.Error(codes.InvalidArgument, "missing tx")
 	}
 
-	ptx, err := psbt.NewFromRawBytes(strings.NewReader(b64), true)
+	ptx, err := parsePsbt(b64)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid tx")
 	}

--- a/internal/interface/grpc/handlers/parser.go
+++ b/internal/interface/grpc/handlers/parser.go
@@ -8,8 +8,21 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/intent"
 	emulatorv1 "github.com/arkade-os/emulator/api-spec/protobuf/gen/emulator/v1"
 	"github.com/arkade-os/emulator/internal/application"
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 )
+
+func parsePsbt(b64 string) (*psbt.Packet, error) {
+	ptx, err := psbt.NewFromRawBytes(strings.NewReader(b64), true)
+	if err != nil {
+		return nil, err
+	}
+	if err := blockchain.CheckTransactionSanity(btcutil.NewTx(ptx.UnsignedTx)); err != nil {
+		return nil, err
+	}
+	return ptx, nil
+}
 
 // parseIntent decodes the proof and intent message. The emulator takes every
 // intent type through one endpoint, so it sniffs `BaseMessage.Type` then decodes
@@ -25,7 +38,7 @@ func parseIntent(fromProto *emulatorv1.Intent) (*application.Intent, error) {
 		return nil, fmt.Errorf("missing message")
 	}
 
-	proofPsbt, err := psbt.NewFromRawBytes(strings.NewReader(proof), true)
+	proofPsbt, err := parsePsbt(proof)
 	if err != nil {
 		return nil, fmt.Errorf("invalid proof: %w", err)
 	}

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -4731,7 +4731,7 @@ func inspectInputValueSpec() *opcodeSpec {
 				setupWorld: func(w *opcodeWorld) {
 					w.prevouts[w.tx.TxIn[0].PreviousOutPoint].Value = -1
 				},
-				expectedError: txscript.ErrInvalidIndex,
+				expectedError: txscript.ErrInvalidStackOperation,
 			},
 			{
 				name:       "above_max_value",
@@ -4739,7 +4739,7 @@ func inspectInputValueSpec() *opcodeSpec {
 				setupWorld: func(w *opcodeWorld) {
 					w.prevouts[w.tx.TxIn[0].PreviousOutPoint].Value = btcutil.MaxSatoshi + 1
 				},
-				expectedError: txscript.ErrInvalidIndex,
+				expectedError: txscript.ErrInvalidStackOperation,
 			},
 			{
 				name:          "missing_prevout",
@@ -4848,13 +4848,13 @@ func inspectOutputValueSpec() *opcodeSpec {
 				name:          "negative_value",
 				inputStack:    [][]byte{nil},
 				setupWorld:    func(w *opcodeWorld) { w.tx.TxOut[0].Value = -1 },
-				expectedError: txscript.ErrInvalidIndex,
+				expectedError: txscript.ErrInvalidStackOperation,
 			},
 			{
 				name:          "above_max_value",
 				inputStack:    [][]byte{nil},
 				setupWorld:    func(w *opcodeWorld) { w.tx.TxOut[0].Value = btcutil.MaxSatoshi + 1 },
-				expectedError: txscript.ErrInvalidIndex,
+				expectedError: txscript.ErrInvalidStackOperation,
 			},
 			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
 		},


### PR DESCRIPTION

make sure every PSBTs are validated by `CheckTransactionSanity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of transaction data across Ark, checkpoint, commitment, forfeit, and on-chain operations.
  * Invalid or malformed transaction structures are now rejected earlier, preventing them from being used to create intents.
  * Existing validation behavior and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->