### PR TITLE
BigNum.Mul`: overflow guard false negative on `(-1) × MinInt64`

### DIFF
--- a/pkg/arkade/bignum.go
+++ b/pkg/arkade/bignum.go
@@ -181,7 +181,10 @@ func (n BigNum) Mul(m BigNum) BigNum {
 			return BigNum{small: 0}
 		}
 		r := n.small * m.small
-		if r/n.small == m.small {
+		// -1 * math.MinInt64 wraps to math.MinInt64, and Go defines
+		// math.MinInt64 / -1 as math.MinInt64, so the guard cannot see the
+		// overflow. It is the only pair for which the division itself wraps.
+		if (n.small != -1 || m.small != math.MinInt64) && r/n.small == m.small {
 			return BigNum{small: r}
 		}
 	}

--- a/pkg/arkade/bignum_test.go
+++ b/pkg/arkade/bignum_test.go
@@ -312,6 +312,16 @@ func TestBigNumMulFastPathAndOverflow(t *testing.T) {
 	require.Zero(t, got.big.Cmp(want), "got %s, want 2^64", got.big)
 }
 
+func TestBigNumMulNegOneByMinInt64Promotes(t *testing.T) {
+	t.Parallel()
+	// MinInt64 / -1 wraps back to MinInt64, so the division-based overflow
+	// guard cannot detect this product.
+	got := BigNumFromInt64(-1).Mul(BigNumFromInt64(math.MinInt64))
+	require.True(t, got.useBig, "expected promotion, got %+v", got)
+	want := new(big.Int).Neg(big.NewInt(math.MinInt64))
+	require.Zero(t, got.big.Cmp(want), "got %s, want %s", got.big, want)
+}
+
 func TestBigNumDivAndModSignSemantics(t *testing.T) {
 	t.Parallel()
 	// Truncated division: sign of remainder follows dividend.


### PR DESCRIPTION
## Summary
**Component:** `pkg/arkade/bignum.go`
**Status:** Fixed — `bignum.go:187`, regression test `bignum_test.go:315`
**Reachability:** Exported Go API: yes. Arkade scripts: no.

## The defect

`Mul` detected `int64` overflow by multiplying and dividing back:

```go
r := n.small * m.small
if r/n.small == m.small {
	return BigNum{small: r}
}
```

This fails for `(-1) × math.MinInt64` because Go defines `MinInt64 / -1` to remain `MinInt64` due to two's-complement overflow.

```text
r = (-1) * MinInt64 = MinInt64  // wraps
r / (-1) = MinInt64              // Go-defined result
```

The guard therefore succeeds and returns the wrapped value instead of promoting to
`big.Int`.

This is the only affected operand ordering. With `MinInt64 × (-1)`, the guard
correctly detects the overflow because `MinInt64 / MinInt64 == 1`, not `-1`.

## Reachability

The defect is reachable through the exported Go API. For example:

```go
x := a.Sub(b)       // can produce MinInt64
y := negOne.Mul(x)  // silently returns the wrong result
```

It is not currently reachable from Arkade scripts. Stack operands are serialized
and decoded between opcodes, and `MinInt64` requires nine bytes in the package's
sign-magnitude encoding. The `int64` fast path accepts at most eight bytes, so
`MinInt64` is promoted to `big.Int` before reaching `Mul`'s vulnerable branch.

This containment is incidental and could change if the encoding limit or arithmetic
path changes.

## Why it was missed

The sibling operations already explicitly guard the `MinInt64 / -1` case:

* `Div` — `bignum.go:200`
* `Mod` — `bignum.go:213`
* `Negate` — `bignum.go:258`
* `Abs` — `bignum.go:271`

The same edge case was therefore known, but `Mul`'s divide-back overflow check
did not account for division itself overflowing.

There was also no test covering negative operands or `MinInt64`; the existing
`Mul` overflow tests covered only positive values.

## The fix

`bignum.go:187` now excludes the problematic pair:

```go
if (n.small != -1 || m.small != math.MinInt64) && r/n.small == m.small {
	return BigNum{small: r}
}
```

The regression test is:

```text
TestBigNumMulNegOneByMinInt64Promotes
```

## Follow-ups

* Add differential fuzzing of `BigNum` arithmetic against `math/big`, including
  `MinInt64`, `MinInt64+1`, `MaxInt64`, `0`, `±1`, and powers of two.
* Document that the eight-byte encoding limit currently keeps `MinInt64` off the
  `int64` fast path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multiplication involving the minimum 64-bit integer and −1 so the operation returns the accurate positive result without overflow.
* **Tests**
  * Added coverage to verify correct handling of this boundary-case multiplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->