### PR TITLE
Reject onchain outputs in emulator-approved intents

### DIFF
--- a/internal/application/intent.go
+++ b/internal/application/intent.go
@@ -100,12 +100,14 @@ func (s *service) SubmitIntent(ctx context.Context, intent Intent) (*psbt.Packet
 	return ptx, nil
 }
 
-// validateMessage checks the proof's validity window. Register and estimate-fee
-// carry ValidAt+ExpireAt; the rest only ExpireAt, read here via a type switch.
+// validateMessage checks intent admission policy and the proof's validity window.
 func validateMessage(message IntentMessage) error {
 	var validAt, expireAt int64
 	switch m := message.(type) {
 	case *intent.RegisterMessage:
+		if len(m.OnchainOutputIndexes) > 0 {
+			return fmt.Errorf("onchain outputs are not supported")
+		}
 		validAt, expireAt = m.ValidAt, m.ExpireAt
 	case *intent.EstimateIntentFeeMessage:
 		validAt, expireAt = m.ValidAt, m.ExpireAt

--- a/internal/application/intent_test.go
+++ b/internal/application/intent_test.go
@@ -115,6 +115,32 @@ func TestSubmitIntentMessageInputBinding(t *testing.T) {
 	})
 }
 
+func TestSubmitIntentRejectsOnchainOutputsBeforeSigning(t *testing.T) {
+	signerKey := newResolverPrivateKey(t)
+	arkadeScript := []byte{txscript.OP_TRUE}
+	tweaked := arkade.ComputeArkadeScriptPublicKey(
+		signerKey.PubKey(), arkade.ArkadeScriptHash(arkadeScript),
+	)
+	owned := newIntentVtxo(t, tweaked)
+	ptx := newIntentProof(
+		t, []intentVtxo{owned, owned},
+		arkade.EmulatorEntry{Vin: 1, Script: arkadeScript},
+	)
+
+	svc := &service{signer: signer{signerKey}}
+	signed, err := svc.SubmitIntent(t.Context(), Intent{
+		Proof: intent.Proof{Packet: *ptx},
+		Message: &intent.RegisterMessage{
+			OnchainOutputIndexes: []int{0},
+		},
+	})
+
+	require.ErrorContains(t, err, "onchain outputs are not supported")
+	require.Nil(t, signed)
+	require.Empty(t, ptx.Inputs[0].TaprootScriptSpendSig)
+	require.Empty(t, ptx.Inputs[1].TaprootScriptSpendSig)
+}
+
 // TestSubmitIntentEntryResolution covers how SubmitIntent treats entries that do
 // not resolve to one of its signers. Entries attributed to another emulator are
 // legitimately skipped (as in SubmitTx/SubmitOnchainTx), but a malformed entry


### PR DESCRIPTION
## What changed

Reject register intents with a non-empty `OnchainOutputIndexes` list before Arkade Script execution or signing.

The regression test verifies that the request fails and neither the real covenant input nor the synthetic message input receives an emulator signature.

## Why

Arkade Script currently validates the intent-proof transaction but cannot inspect the register message's output classification. For an ownerless recursive covenant, an untrusted proposer could preserve the output script, value, and next state while marking the continuation as on-chain. The script would pass, but arkd would place the output directly in the commitment transaction instead of a fresh VTXO-tree leaf.

That loses the leaf-carried state needed by recursive contracts and can split the outputs of a tied multi-covenant transition between on-chain and off-chain settlement.

## Delegated renewal

This is a fail-closed bridge toward delegated renewal: every ordinary output of an emulator-approved register intent is temporarily forced through arkd's off-chain receiver path, so all outputs from one intent settle together in a fresh leaf.

A later transport-classification mechanism can explicitly authorize on-chain outputs from within Arkade Script. Keeping off-chain as the default preserves existing ownerless covenants; deployed scripts that do not know about the future mechanism remain unable to opt into on-chain settlement.

This guard addresses output classification only. Managed tree participation, source classification, failure attribution, and forfeit-only finalization remain separate delegated-renewal concerns.

## Checks

- `go test ./internal/application -count=1`
- All non-integration Go packages passed during the repository-wide run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid registration messages that include on-chain output indexes are now rejected earlier.
  * Prevented invalid proofs from being signed or returned as packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->