### PR TITLE
Bump Go to 1.26.6

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Check formatting
         run: |
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
 
       - name: Build binaries
         run: make build-all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Run unit tests
         run: make test
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Run Nigiri
         uses: vulpemventures/nigiri-github-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/api-spec/go.mod
+++ b/api-spec/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/emulator/api-spec
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/meshapi/grpc-api-gateway v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/emulator
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/pkg/arkade/go.mod
+++ b/pkg/arkade/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/emulator/pkg/arkade
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/emulator/pkg/client
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/arkade-os/emulator/api-spec => ../../api-spec
 


### PR DESCRIPTION
## What changed

Bump the Docker builder image, every module's Go directive, and the GitHub Actions toolchain from 1.26.5 to 1.26.6.

## Why

The Trivy image scan reports eight HIGH vulnerabilities in the Go 1.26.5 standard library embedded in the emulator binary. Trivy identifies Go 1.26.6 as the patched release. This failure is unrelated to the intent output-classification change in #137, so the toolchain fix is isolated here.

## Impact

The emulator and CI jobs now use the patched standard library. There are no application or dependency-graph changes.

## Checks

- `go test ./internal/... ./cmd/...`
- `go test ./...` in `api-spec`, `pkg/arkade`, and `pkg/client`
- Docker image build using the Go 1.26.6 builder
- GitHub Trivy Build and Scan: passed
- GitHub format, lint, and unit jobs: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go version to 1.26.6 across builds, releases, testing, formatting, and linting.
  * Updated development and build environments to use the latest Go patch version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->